### PR TITLE
remove explicit imports from `@cloudflare/workers-types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
     "prepublishOnly": "npm run build",
     "prettier": "prettier -w ."
   },
-  "dependencies": {
-    "@cloudflare/workers-types": "^4.20250311.0"
-  },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250311.0",
     "prettier": "^3.5.3",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1,4 +1,3 @@
-import { ExportedHandler, ExecutionContext } from '@cloudflare/workers-types';
 import { WorkerEntrypoint } from 'cloudflare:workers';
 
 // Types


### PR DESCRIPTION
We expect people to be using cloudflare/workers-types anyway, and we want to match whatever version they're using (to avoid problems like https://github.com/cloudflare/ai/pull/161