### PR TITLE
Ask Gemini to fix missing URL-decoding of basic auth credentials.

### DIFF
--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1118,9 +1118,9 @@ class OAuthProviderImpl {
     if (authHeader && authHeader.startsWith('Basic ')) {
       // Basic auth
       const credentials = atob(authHeader.substring(6));
-      const [id, secret] = credentials.split(':');
-      clientId = id;
-      clientSecret = secret || '';
+      const [id, secret] = credentials.split(':', 2);
+      clientId = decodeURIComponent(id);
+      clientSecret = decodeURIComponent(secret || '');
     } else {
       // Form parameters
       clientId = body.client_id;


### PR DESCRIPTION
Fixes #41

Prompt: We received a bug report: "As per https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1 and https://www.rfc-editor.org/rfc/rfc6749.html#appendix-B, OAuth uses a modified form of Basic auth in which the client id and secret are url-encoded first before being combined and then base64-encoded." Apparently, we aren't performing this URL encoding. Can you fix it?

Gemini actually fixed the second part of the issue, too: that the secret can technically contain colons. I didn't actually prompt it to fix that, it just did it. Neat.

(Note that valid client IDs and secrets are always generated by this library itself, and it does not include colons nor characters needing URL encoding, so this issue is never a problem in practice, but we should be implementing what the spec says.)

This was a test using Gemini 2.5-Pro under Windsurf. (I am trying out various models and environments...)