### PR TITLE
Fix for the Missing Validation for ClientId

### DIFF
--- a/.changeset/sharp-apes-punch.md
+++ b/.changeset/sharp-apes-punch.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-oauth-provider": patch
+---
+
+Fix for the Missing Validation for ClientId

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -511,6 +511,41 @@ describe('OAuthProvider', () => {
       expect(grants.keys.length).toBe(0);
     });
 
+    it('should reject authorization request with invalid client id', async () => {
+      // Create an authorization request with an invalid redirect URI
+      const invalidClientId = 'attackerClientId'
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${invalidClientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+
+      // Expect the request to be rejected
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+
+      // Verify no grant was created
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grants.keys.length).toBe(0);
+    });
+
+    it('should reject authorization request with invalid client id and redirect uri', async () => {
+      // Create an authorization request with an invalid redirect URI
+      const invalidRedirectUri = 'https://attacker.example.com/callback';
+      const invalidClientId = 'attackerClientId'
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${invalidClientId}` +
+          `&redirect_uri=${encodeURIComponent(invalidRedirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+
+      // Expect the request to be rejected
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+
+      // Verify no grant was created
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grants.keys.length).toBe(0);
+    });
+
     // Add more tests for auth code flow...
   });
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2202,6 +2202,11 @@ class OAuthHelpersImpl implements OAuthHelpers {
     if (clientId) {
       const clientInfo = await this.lookupClient(clientId);
 
+      if (!clientInfo) {
+        throw new Error(
+            `Invalid client. The clientId provided does not match to this client.`
+          );
+      }
       // If client exists, validate the redirect URI against registered URIs
       if (clientInfo && redirectUri) {
         if (!clientInfo.redirectUris.includes(redirectUri)) {


### PR DESCRIPTION
~https://github.com/cloudflare/workers-oauth-provider/security/advisories/GHSA-4pc9-x2fx-p7vj~

__(edited by @threepointone to strike out the advisory link since it's not relevant)__

**Original Request:** 
http://localhost:8787/authorize?response_type=code&client_id=k331WCMdRWmBxKxt&code_challenge=Jco6hZ5K7VFomiStpBRMo2VvUUNSBZQ9EnDZl0dBz3c&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A9882%2Foauth%2Fcallback&state=ce9ff539-17bf-40bf-900b-03c22960d47b

**Modified Request**:  Changed client_id and redirect_uri
http://localhost:8787/authorize?response_type=code&client_id=attackerId&code_challenge=Jco6hZ5K7VFomiStpBRMo2VvUUNSBZQ9EnDZl0dBz3c&code_challenge_method=S256&redirect_uri=http://www.google.com&state=ce9ff539-17bf-40bf-900b-03c22960d47b

After Successful authentication, token is redirected to www.google.com
<img width="1099" height="322" alt="image" src="https://github.com/user-attachments/assets/ee60fcb3-63df-44c1-96e6-829868fdf545" />



**After Fix** : Catches the error: Error: Invalid client.

<img width="920" height="74" alt="image" src="https://github.com/user-attachments/assets/c47ba68a-4faf-499c-9c71-c95c2f818664" />
