### PR TITLE
Fix token revocation returning HTTP 500 instead of 200

### DIFF
--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1700,7 +1700,7 @@ class OAuthProviderImpl {
     } else if (isRefreshToken) {
       await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
     }
-    return new Response('', { status: 500 });
+    return new Response('', { status: 200 });
   }
 
   /**


### PR DESCRIPTION
Token revocation endpoint was incorrectly returning HTTP 500 on successful revocation. Per RFC 7009, the revocation endpoint must return 200 OK regardless of whether the token was found/revoked.

Related to PR #62 (token revocation support).