### PR TITLE
explicitly block javascript: (and other suspicious protocols) in redi…

### DIFF
--- a/.changeset/moody-adults-know.md
+++ b/.changeset/moody-adults-know.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+explicitly block javascript: (and other suspicious protocols) in redirect uris
+
+In https://github.com/cloudflare/workers-oauth-provider/pull/80, we blocked redirects that didn't start with http:// or https:// to prevent xss attacks with javascript: URIs. However this blocked redirects to custom apps like cursor:// et al. This patch now explicitly blocks javascript: (and other suspicious protocols) in redirect uris.

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2479,7 +2479,14 @@ class OAuthHelpersImpl implements OAuthHelpers {
     const codeChallengeMethod = url.searchParams.get('code_challenge_method') || 'plain';
 
     // prevent javascript: URIs / XSS attacks
-    if (!redirectUri.startsWith('http://') && !redirectUri.startsWith('https://')) {
+    if (
+      redirectUri.startsWith('javascript:') ||
+      redirectUri.startsWith('data:') ||
+      redirectUri.startsWith('vbscript:') ||
+      redirectUri.startsWith('file:') ||
+      redirectUri.startsWith('mailto:') ||
+      redirectUri.startsWith('blob:')
+    ) {
       throw new Error('Invalid redirect URI');
     }
 


### PR DESCRIPTION
…rect uris

In https://github.com/cloudflare/workers-oauth-provider/pull/80, we blocked redirects that didn't start with http:// or https:// to prevent xss attacks with javascript: URIs. However this blocked redirects to custom apps like cursor:// et al. This patch now explicitly blocks javascript: (and other suspicious protocols) in redirect uris.