### PR TITLE
feat: add Client ID Metadata Document (CIMD) support

### DIFF
--- a/.changeset/wise-parrots-boil.md
+++ b/.changeset/wise-parrots-boil.md
@@ -1,0 +1,19 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+feat: add Client ID Metadata Document (CIMD) support 
+
+(by @mattzcarey in https://github.com/cloudflare/workers-oauth-provider/issues/112)
+
+CIMD support allows clients to use HTTPS URLs as client_id values that
+point to metadata documents.
+
+When a client_id is an HTTPS URL with a non-root path, the provider
+fetches and validates the metadata document instead of looking up in KV
+storage. Added validation to ensure client_id in the document matches
+the URL and redirect_uris are present.
+
+matches the new authorization spec for MCP
+
+https://modelcontextprotocol.io/specification/draft/basic/authorization

--- a/package-lock.json
+++ b/package-lock.json
@@ -1106,6 +1106,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2190,6 +2191,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3092,6 +3094,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3171,6 +3174,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3959,6 +3963,7 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -3999,6 +4004,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4070,6 +4076,7 @@
       "integrity": "sha512-3jdAy3NhBJYsa/lCFcnRfbK4kNkO/bhijFCnv5ByUQk/eekYagoV2yQSISUrhpV+5JiY5hmwOh7jNnQ68dFMuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",


### PR DESCRIPTION
(by @mattzcarey in https://github.com/cloudflare/workers-oauth-provider/issues/112)

CIMD support allows clients to use HTTPS URLs as client_id values that point to metadata documents.

When a client_id is an HTTPS URL with a non-root path, the provider fetches and validates the metadata document instead of looking up in KV storage. Added validation to ensure client_id in the document matches the URL and redirect_uris are present.

matches the new authorization spec for MCP

https://modelcontextprotocol.io/specification/draft/basic/authorization