### PR TITLE
Replace prettier with oxfmt/oxlint and improve types

### DIFF
--- a/.changeset/add-oxlint-oxfmt.md
+++ b/.changeset/add-oxlint-oxfmt.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-oauth-provider": patch
+---
+
+Replace prettier with oxfmt/oxlint for formatting and linting

--- a/.changeset/add-protected-resource-metadata.md
+++ b/.changeset/add-protected-resource-metadata.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': patch
+"@cloudflare/workers-oauth-provider": patch
 ---
 
 Add `/.well-known/oauth-protected-resource` endpoint (RFC 9728) for OAuth 2.0 Protected Resource Metadata discovery, as required by the MCP authorization specification. The endpoint is always served with sensible defaults (request origin as resource and authorization server), and can be customized via the new `resourceMetadata` option.

--- a/.changeset/allow-plain-pkce-option.md
+++ b/.changeset/allow-plain-pkce-option.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': patch
+"@cloudflare/workers-oauth-provider": patch
 ---
 
 Add `allowPlainPKCE` option to enforce S256-only PKCE as recommended by OAuth 2.1. When set to false, the plain PKCE method is rejected and only S256 is accepted. Defaults to true for backward compatibility.

--- a/.changeset/fix-root-api-handler.md
+++ b/.changeset/fix-root-api-handler.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': patch
+"@cloudflare/workers-oauth-provider": patch
 ---
 
 Fix apiHandler route matching when set to '/' to use exact match instead of prefix match, preventing it from matching all routes and breaking OAuth endpoints

--- a/.changeset/fix-typescript-env-generics.md
+++ b/.changeset/fix-typescript-env-generics.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': patch
+"@cloudflare/workers-oauth-provider": patch
 ---
 
 Fix TypeScript types by making OAuthProviderOptions generic over Env, eliminating the need for @ts-expect-error workarounds when using typed environments

--- a/.changeset/rfc8252-loopback-ports.md
+++ b/.changeset/rfc8252-loopback-ports.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': patch
+"@cloudflare/workers-oauth-provider": patch
 ---
 
 Add RFC 8252 Section 7.3 compliance: allow any port for loopback redirect URIs (127.x.x.x, ::1) to support native apps that use ephemeral ports

--- a/.changeset/www-authenticate-resource-metadata.md
+++ b/.changeset/www-authenticate-resource-metadata.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': patch
+"@cloudflare/workers-oauth-provider": patch
 ---
 
 Include `resource_metadata` URL in `WWW-Authenticate` headers on 401 responses per RFC 9728 §5.1, enabling clients to discover the protected resource metadata endpoint directly from authentication challenges.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -44,10 +44,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Check formatting
-        run: npx prettier --check .
+        run: npm run format:check

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   workflow_run:
-    workflows: ['CI']
+    workflows: ["CI"]
     branches: [main]
     types: [completed]
 
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
 
       - run: npm ci
       - run: npm run build

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "trailingComma": "es5",
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": true,
-  "printWidth": 120
-}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This is a TypeScript library that implements the provider side of the OAuth 2.1 
 A Worker that uses the library might look like this:
 
 ```ts
-import { OAuthProvider } from '@cloudflare/workers-oauth-provider';
-import { WorkerEntrypoint } from 'cloudflare:workers';
+import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
+import { WorkerEntrypoint } from "cloudflare:workers";
 
 // We export the OAuthProvider instance as the entrypoint to our Worker. This means it
 // implements the `fetch()` handler, receiving all HTTP requests.
@@ -29,8 +29,8 @@ export default new OAuthProvider({
   // - A single route (string) or multiple routes (array)
   // - Full URLs (which will match the hostname) or just paths (which will match any hostname)
   apiRoute: [
-    '/api/', // Path only - will match any hostname
-    'https://api.example.com/', // Full URL - will check hostname
+    "/api/", // Path only - will match any hostname
+    "https://api.example.com/", // Full URL - will check hostname
   ],
 
   // When the OAuth system receives an API request with a valid access token, it passes the request
@@ -58,23 +58,23 @@ export default new OAuthProvider({
   // this URL is given to the OAuthProvider is so that it can implement the RFC-8414 metadata
   // discovery endpoint, i.e. `.well-known/oauth-authorization-server`.
   // Can also be specified as just a path (e.g., "/authorize").
-  authorizeEndpoint: 'https://example.com/authorize',
+  authorizeEndpoint: "https://example.com/authorize",
 
   // This specifies the OAuth 2 token exchange endpoint. The OAuthProvider will implement this
   // endpoint (by directly responding to requests with a matching URL).
   // Can also be specified as just a path (e.g., "/oauth/token").
-  tokenEndpoint: 'https://example.com/oauth/token',
+  tokenEndpoint: "https://example.com/oauth/token",
 
   // This specifies the RFC-7591 dynamic client registration endpoint. This setting is optional,
   // but if provided, the OAuthProvider will implement this endpoint to allow dynamic client
   // registration.
   // Can also be specified as just a path (e.g., "/oauth/register").
-  clientRegistrationEndpoint: 'https://example.com/oauth/register',
+  clientRegistrationEndpoint: "https://example.com/oauth/register",
 
   // Optional list of scopes supported by this OAuth provider.
   // If provided, this will be included in the RFC 8414 metadata as 'scopes_supported'.
   // If not provided, the 'scopes_supported' field will be omitted from the metadata.
-  scopesSupported: ['document.read', 'document.write', 'profile'],
+  scopesSupported: ["document.read", "document.write", "profile"],
 
   // Optional: Controls whether the OAuth implicit flow is allowed.
   // The implicit flow is discouraged in OAuth 2.1 but may be needed for some clients.
@@ -116,7 +116,7 @@ const defaultHandler = {
   async fetch(request: Request, env, ctx) {
     let url = new URL(request.url);
 
-    if (url.pathname == '/authorize') {
+    if (url.pathname == "/authorize") {
       // This is a request for our OAuth authorization flow UI. It is up to the application to
       // implement this. However, the OAuthProvider library provides some helpers to assist.
 
@@ -143,23 +143,23 @@ const defaultHandler = {
         // The application must specify the user's ID, which is some sort of string. This is needed
         // so that the application can later query the OAuthProvider to enumerate all grants
         // belonging to a particular user, e.g. to implement an audit and revocation UI.
-        userId: '1234',
+        userId: "1234",
 
         // The application can specify some arbitary metadata which describes this grant. The
         // metadata can contain any JSON-serializable content. This metadata is not used by the
         // OAuthProvider, but the application can read back the metadata attached to specific
         // grants when enumerating them later, again e.g. to implement an udit and revocation UI.
-        metadata: { label: 'foo' },
+        metadata: { label: "foo" },
 
         // The application specifies the list of OAuth scope identifiers that were granted. This
         // may or may not be the same as was requested in `oauthReqInfo.scope`.
-        scope: ['document.read', 'document.write'],
+        scope: ["document.read", "document.write"],
 
         // `props` is an arbitrary JSON-serializable object which will be passed back to the API
         // handler for every request authorized by this grant.
         props: {
           userId: 1234,
-          username: 'Bob',
+          username: "Bob",
         },
       });
 
@@ -172,7 +172,7 @@ const defaultHandler = {
 
     // ... the application can implement other non-API HTTP endpoints here ...
 
-    return new Response('Not found', { status: 404 });
+    return new Response("Not found", { status: 404 });
   },
 };
 
@@ -192,13 +192,13 @@ class ApiHandler extends WorkerEntrypoint {
     // endpoint, `/api/whoami`, which returns the user's authenticated identity.
 
     let url = new URL(request.url);
-    if (url.pathname == '/api/whoami') {
+    if (url.pathname == "/api/whoami") {
       // Since the username is embedded in `ctx.props`, which came from the access token that the
       // OAuthProivder already verified, we don't need to do any other authentication steps.
       return new Response(`You are authenticated as: ${this.ctx.props.username}`);
     }
 
-    return new Response('Not found', { status: 404 });
+    return new Response("Not found", { status: 404 });
   }
 }
 ```
@@ -229,7 +229,7 @@ new OAuthProvider({
     // options.props contains the current props
     // options.clientId, options.userId, and options.scope are also available
 
-    if (options.grantType === 'authorization_code') {
+    if (options.grantType === "authorization_code") {
       // For authorization code exchange, might want to obtain upstream tokens
       const upstreamTokens = await exchangeUpstreamToken(options.props.someCode);
 
@@ -247,7 +247,7 @@ new OAuthProvider({
       };
     }
 
-    if (options.grantType === 'refresh_token') {
+    if (options.grantType === "refresh_token") {
       // For refresh token exchanges, might want to refresh upstream tokens too
       const upstreamTokens = await refreshUpstreamToken(options.props.upstreamRefreshToken);
 
@@ -300,8 +300,8 @@ By returning a `Response` you can also override what the OAuthProvider returns t
 new OAuthProvider({
   // ... other options ...
   onError({ code, description, status, headers }) {
-    if (code === 'unsupported_grant_type') {
-      return new Response('...', { status, headers });
+    if (code === "unsupported_grant_type") {
+      return new Response("...", { status, headers });
     }
     // returning undefined (i.e. void) uses the default Response generation
   },

--- a/__tests__/mocks/cloudflare-workers.ts
+++ b/__tests__/mocks/cloudflare-workers.ts
@@ -13,6 +13,6 @@ export class WorkerEntrypoint<Env = any> {
   }
 
   fetch(request: Request): Response | Promise<Response> {
-    throw new Error('Method not implemented. This should be overridden by subclasses.');
+    throw new Error("Method not implemented. This should be overridden by subclasses.");
   }
 }

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { OAuthProvider, type OAuthHelpers } from '../src/oauth-provider';
-import type { ExecutionContext } from '@cloudflare/workers-types';
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { OAuthProvider, type OAuthHelpers } from "../src/oauth-provider";
+import type { ExecutionContext } from "@cloudflare/workers-types";
 // We're importing WorkerEntrypoint from our mock implementation
 // The actual import is mocked in setup.ts
-import { WorkerEntrypoint } from 'cloudflare:workers';
+import { WorkerEntrypoint } from "cloudflare:workers";
 
 /**
  * Mock KV namespace implementation that stores data in memory
@@ -11,7 +11,11 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 class MockKV {
   private storage: Map<string, { value: any; expiration?: number }> = new Map();
 
-  async put(key: string, value: string | ArrayBuffer, options?: { expirationTtl?: number }): Promise<void> {
+  async put(
+    key: string,
+    value: string | ArrayBuffer,
+    options?: { expirationTtl?: number },
+  ): Promise<void> {
     let expirationTime: number | undefined = undefined;
 
     if (options?.expirationTtl) {
@@ -21,7 +25,10 @@ class MockKV {
     this.storage.set(key, { value, expiration: expirationTime });
   }
 
-  async get(key: string, options?: { type: 'text' | 'json' | 'arrayBuffer' | 'stream' }): Promise<any> {
+  async get(
+    key: string,
+    options?: { type: "text" | "json" | "arrayBuffer" | "stream" },
+  ): Promise<any> {
     const item = this.storage.get(key);
 
     if (!item) {
@@ -33,7 +40,7 @@ class MockKV {
       return null;
     }
 
-    if (options?.type === 'json' && typeof item.value === 'string') {
+    if (options?.type === "json" && typeof item.value === "string") {
       return JSON.parse(item.value);
     }
 
@@ -102,7 +109,7 @@ class TestApiHandler extends WorkerEntrypoint<TestEnv> {
   fetch(request: Request) {
     const url = new URL(request.url);
 
-    if (url.pathname.startsWith('/api/')) {
+    if (url.pathname.startsWith("/api/")) {
       // Return authenticated user info from ctx.props
       return new Response(
         JSON.stringify({
@@ -110,12 +117,12 @@ class TestApiHandler extends WorkerEntrypoint<TestEnv> {
           user: this.ctx.props,
         }),
         {
-          headers: { 'Content-Type': 'application/json' },
-        }
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
-    return new Response('Not found', { status: 404 });
+    return new Response("Not found", { status: 404 });
   }
 }
 
@@ -124,7 +131,7 @@ const testDefaultHandler = {
   async fetch(request: Request, env: TestEnv, ctx: ExecutionContext) {
     const url = new URL(request.url);
 
-    if (url.pathname === '/authorize') {
+    if (url.pathname === "/authorize") {
       // Mock authorize endpoint
       const oauthReqInfo = await env.OAUTH_PROVIDER!.parseAuthRequest(request);
       const clientInfo = await env.OAUTH_PROVIDER!.lookupClient(oauthReqInfo.clientId);
@@ -132,25 +139,25 @@ const testDefaultHandler = {
       // Mock user consent flow - automatically grant consent
       const { redirectTo } = await env.OAUTH_PROVIDER!.completeAuthorization({
         request: oauthReqInfo,
-        userId: 'test-user-123',
+        userId: "test-user-123",
         metadata: { testConsent: true },
         scope: oauthReqInfo.scope,
-        props: { userId: 'test-user-123', username: 'TestUser' },
+        props: { userId: "test-user-123", username: "TestUser" },
       });
 
       return Response.redirect(redirectTo, 302);
     }
 
-    return new Response('Default handler', { status: 200 });
+    return new Response("Default handler", { status: 200 });
   },
 };
 
 // Helper function to create mock requests
 function createMockRequest(
   url: string,
-  method: string = 'GET',
+  method: string = "GET",
   headers: Record<string, string> = {},
-  body?: string | FormData
+  body?: string | FormData,
 ): Request {
   const requestInit: RequestInit = {
     method,
@@ -172,7 +179,7 @@ function createMockEnv(): TestEnv {
   };
 }
 
-describe('OAuthProvider', () => {
+describe("OAuthProvider", () => {
   let oauthProvider: OAuthProvider<TestEnv>;
   let mockEnv: TestEnv;
   let mockCtx: MockExecutionContext;
@@ -187,13 +194,13 @@ describe('OAuthProvider', () => {
 
     // Create OAuth provider with test configuration
     oauthProvider = new OAuthProvider({
-      apiRoute: ['/api/', 'https://api.example.com/'],
+      apiRoute: ["/api/", "https://api.example.com/"],
       apiHandler: TestApiHandler,
       defaultHandler: testDefaultHandler,
-      authorizeEndpoint: '/authorize',
-      tokenEndpoint: '/oauth/token',
-      clientRegistrationEndpoint: '/oauth/register',
-      scopesSupported: ['read', 'write', 'profile'],
+      authorizeEndpoint: "/authorize",
+      tokenEndpoint: "/oauth/token",
+      clientRegistrationEndpoint: "/oauth/register",
+      scopesSupported: ["read", "write", "profile"],
       accessTokenTTL: 3600,
       allowImplicitFlow: true, // Enable implicit flow for tests
       allowTokenExchangeGrant: true, // Enable token exchange for tests
@@ -205,78 +212,82 @@ describe('OAuthProvider', () => {
     mockEnv.OAUTH_KV.clear();
   });
 
-  describe('API Route Configuration', () => {
-    it('should support multi-handler configuration with apiHandlers', async () => {
+  describe("API Route Configuration", () => {
+    it("should support multi-handler configuration with apiHandlers", async () => {
       // Create handler classes for different API routes
       class UsersApiHandler extends WorkerEntrypoint<TestEnv> {
         fetch(request: Request) {
-          return new Response('Users API response', { status: 200 });
+          return new Response("Users API response", { status: 200 });
         }
       }
 
       class DocumentsApiHandler extends WorkerEntrypoint<TestEnv> {
         fetch(request: Request) {
-          return new Response('Documents API response', { status: 200 });
+          return new Response("Documents API response", { status: 200 });
         }
       }
 
       // Create provider with multi-handler configuration
       const providerWithMultiHandler = new OAuthProvider({
         apiHandlers: {
-          '/api/users/': UsersApiHandler,
-          '/api/documents/': DocumentsApiHandler,
+          "/api/users/": UsersApiHandler,
+          "/api/documents/": DocumentsApiHandler,
         },
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register', // Important for registering clients in the test
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register", // Important for registering clients in the test
+        scopesSupported: ["read", "write"],
       });
 
       // Create a client and get an access token
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
-      const registerResponse = await providerWithMultiHandler.fetch(registerRequest, mockEnv, mockCtx);
+      const registerResponse = await providerWithMultiHandler.fetch(
+        registerRequest,
+        mockEnv,
+        mockCtx,
+      );
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithMultiHandler.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await providerWithMultiHandler.fetch(tokenRequest, mockEnv, mockCtx);
@@ -284,264 +295,288 @@ describe('OAuthProvider', () => {
       const accessToken = tokens.access_token;
 
       // Make requests to different API routes
-      const usersApiRequest = createMockRequest('https://example.com/api/users/profile', 'GET', {
+      const usersApiRequest = createMockRequest("https://example.com/api/users/profile", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
-      const documentsApiRequest = createMockRequest('https://example.com/api/documents/list', 'GET', {
-        Authorization: `Bearer ${accessToken}`,
-      });
+      const documentsApiRequest = createMockRequest(
+        "https://example.com/api/documents/list",
+        "GET",
+        {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      );
 
       // Request to Users API should be handled by UsersApiHandler
       const usersResponse = await providerWithMultiHandler.fetch(usersApiRequest, mockEnv, mockCtx);
       expect(usersResponse.status).toBe(200);
-      expect(await usersResponse.text()).toBe('Users API response');
+      expect(await usersResponse.text()).toBe("Users API response");
 
       // Request to Documents API should be handled by DocumentsApiHandler
-      const documentsResponse = await providerWithMultiHandler.fetch(documentsApiRequest, mockEnv, mockCtx);
+      const documentsResponse = await providerWithMultiHandler.fetch(
+        documentsApiRequest,
+        mockEnv,
+        mockCtx,
+      );
       expect(documentsResponse.status).toBe(200);
-      expect(await documentsResponse.text()).toBe('Documents API response');
+      expect(await documentsResponse.text()).toBe("Documents API response");
     });
 
-    it('should throw an error when both single-handler and multi-handler configs are provided', () => {
+    it("should throw an error when both single-handler and multi-handler configs are provided", () => {
       expect(() => {
         new OAuthProvider({
-          apiRoute: '/api/',
+          apiRoute: "/api/",
           apiHandler: {
             fetch: () => Promise.resolve(new Response()),
           },
           apiHandlers: {
-            '/api/users/': {
+            "/api/users/": {
               fetch: () => Promise.resolve(new Response()),
             },
           },
           defaultHandler: testDefaultHandler,
-          authorizeEndpoint: '/authorize',
-          tokenEndpoint: '/oauth/token',
+          authorizeEndpoint: "/authorize",
+          tokenEndpoint: "/oauth/token",
         });
-      }).toThrow('Cannot use both apiRoute/apiHandler and apiHandlers');
+      }).toThrow("Cannot use both apiRoute/apiHandler and apiHandlers");
     });
 
-    it('should throw an error when neither single-handler nor multi-handler config is provided', () => {
+    it("should throw an error when neither single-handler nor multi-handler config is provided", () => {
       expect(() => {
         new OAuthProvider({
           // Intentionally omitting apiRoute and apiHandler and apiHandlers
           defaultHandler: testDefaultHandler,
-          authorizeEndpoint: '/authorize',
-          tokenEndpoint: '/oauth/token',
+          authorizeEndpoint: "/authorize",
+          tokenEndpoint: "/oauth/token",
         });
-      }).toThrow('Must provide either apiRoute + apiHandler OR apiHandlers');
+      }).toThrow("Must provide either apiRoute + apiHandler OR apiHandlers");
     });
   });
 
-  describe('OAuth Metadata Discovery', () => {
-    it('should return correct metadata at .well-known/oauth-authorization-server', async () => {
-      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+  describe("OAuth Metadata Discovery", () => {
+    it("should return correct metadata at .well-known/oauth-authorization-server", async () => {
+      const request = createMockRequest(
+        "https://example.com/.well-known/oauth-authorization-server",
+      );
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
 
       const metadata = await response.json<any>();
-      expect(metadata.issuer).toBe('https://example.com');
-      expect(metadata.authorization_endpoint).toBe('https://example.com/authorize');
-      expect(metadata.token_endpoint).toBe('https://example.com/oauth/token');
-      expect(metadata.registration_endpoint).toBe('https://example.com/oauth/register');
-      expect(metadata.scopes_supported).toEqual(['read', 'write', 'profile']);
-      expect(metadata.response_types_supported).toContain('code');
-      expect(metadata.response_types_supported).toContain('token'); // Implicit flow enabled
-      expect(metadata.grant_types_supported).toContain('authorization_code');
-      expect(metadata.code_challenge_methods_supported).toContain('S256');
+      expect(metadata.issuer).toBe("https://example.com");
+      expect(metadata.authorization_endpoint).toBe("https://example.com/authorize");
+      expect(metadata.token_endpoint).toBe("https://example.com/oauth/token");
+      expect(metadata.registration_endpoint).toBe("https://example.com/oauth/register");
+      expect(metadata.scopes_supported).toEqual(["read", "write", "profile"]);
+      expect(metadata.response_types_supported).toContain("code");
+      expect(metadata.response_types_supported).toContain("token"); // Implicit flow enabled
+      expect(metadata.grant_types_supported).toContain("authorization_code");
+      expect(metadata.code_challenge_methods_supported).toContain("S256");
     });
 
-    it('should not include token response type when implicit flow is disabled', async () => {
+    it("should not include token response type when implicit flow is disabled", async () => {
       // Create a provider with implicit flow disabled
       const providerWithoutImplicit = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         allowImplicitFlow: false, // Explicitly disable
       });
 
-      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const request = createMockRequest(
+        "https://example.com/.well-known/oauth-authorization-server",
+      );
       const response = await providerWithoutImplicit.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
 
       const metadata = await response.json<any>();
-      expect(metadata.response_types_supported).toContain('code');
-      expect(metadata.response_types_supported).not.toContain('token');
+      expect(metadata.response_types_supported).toContain("code");
+      expect(metadata.response_types_supported).not.toContain("token");
     });
 
-    it('should only include S256 PKCE method when allowPlainPKCE is false', async () => {
+    it("should only include S256 PKCE method when allowPlainPKCE is false", async () => {
       // Create a provider with plain PKCE disabled
       const providerWithoutPlainPKCE = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         allowPlainPKCE: false, // Enforce S256 only
       });
 
-      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const request = createMockRequest(
+        "https://example.com/.well-known/oauth-authorization-server",
+      );
       const response = await providerWithoutPlainPKCE.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
 
       const metadata = await response.json<any>();
-      expect(metadata.code_challenge_methods_supported).toEqual(['S256']);
-      expect(metadata.code_challenge_methods_supported).not.toContain('plain');
+      expect(metadata.code_challenge_methods_supported).toEqual(["S256"]);
+      expect(metadata.code_challenge_methods_supported).not.toContain("plain");
     });
 
-    it('should include both plain and S256 PKCE methods by default', async () => {
-      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+    it("should include both plain and S256 PKCE methods by default", async () => {
+      const request = createMockRequest(
+        "https://example.com/.well-known/oauth-authorization-server",
+      );
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
 
       const metadata = await response.json<any>();
-      expect(metadata.code_challenge_methods_supported).toContain('plain');
-      expect(metadata.code_challenge_methods_supported).toContain('S256');
+      expect(metadata.code_challenge_methods_supported).toContain("plain");
+      expect(metadata.code_challenge_methods_supported).toContain("S256");
     });
   });
 
-  describe('Protected Resource Metadata (RFC 9728)', () => {
-    it('should return default metadata at .well-known/oauth-protected-resource', async () => {
-      const request = createMockRequest('https://example.com/.well-known/oauth-protected-resource');
+  describe("Protected Resource Metadata (RFC 9728)", () => {
+    it("should return default metadata at .well-known/oauth-protected-resource", async () => {
+      const request = createMockRequest("https://example.com/.well-known/oauth-protected-resource");
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
 
       const metadata = await response.json<any>();
-      expect(metadata.resource).toBe('https://example.com');
-      expect(metadata.authorization_servers).toEqual(['https://example.com']);
-      expect(metadata.scopes_supported).toEqual(['read', 'write', 'profile']);
-      expect(metadata.bearer_methods_supported).toEqual(['header']);
+      expect(metadata.resource).toBe("https://example.com");
+      expect(metadata.authorization_servers).toEqual(["https://example.com"]);
+      expect(metadata.scopes_supported).toEqual(["read", "write", "profile"]);
+      expect(metadata.bearer_methods_supported).toEqual(["header"]);
       expect(metadata.resource_name).toBeUndefined();
     });
 
-    it('should use custom resourceMetadata when provided', async () => {
+    it("should use custom resourceMetadata when provided", async () => {
       const customProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         resourceMetadata: {
-          resource: 'https://api.example.com',
-          authorization_servers: ['https://auth.example.com'],
-          scopes_supported: ['custom:read', 'custom:write'],
-          bearer_methods_supported: ['header', 'body'],
-          resource_name: 'Example API',
+          resource: "https://api.example.com",
+          authorization_servers: ["https://auth.example.com"],
+          scopes_supported: ["custom:read", "custom:write"],
+          bearer_methods_supported: ["header", "body"],
+          resource_name: "Example API",
         },
       });
 
-      const request = createMockRequest('https://example.com/.well-known/oauth-protected-resource');
+      const request = createMockRequest("https://example.com/.well-known/oauth-protected-resource");
       const response = await customProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
 
       const metadata = await response.json<any>();
-      expect(metadata.resource).toBe('https://api.example.com');
-      expect(metadata.authorization_servers).toEqual(['https://auth.example.com']);
-      expect(metadata.scopes_supported).toEqual(['custom:read', 'custom:write']);
-      expect(metadata.bearer_methods_supported).toEqual(['header', 'body']);
-      expect(metadata.resource_name).toBe('Example API');
+      expect(metadata.resource).toBe("https://api.example.com");
+      expect(metadata.authorization_servers).toEqual(["https://auth.example.com"]);
+      expect(metadata.scopes_supported).toEqual(["custom:read", "custom:write"]);
+      expect(metadata.bearer_methods_supported).toEqual(["header", "body"]);
+      expect(metadata.resource_name).toBe("Example API");
     });
 
-    it('should fall back to top-level scopesSupported when resourceMetadata.scopes_supported is not set', async () => {
+    it("should fall back to top-level scopesSupported when resourceMetadata.scopes_supported is not set", async () => {
       const providerWithPartialMetadata = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         resourceMetadata: {
-          resource: 'https://api.example.com',
+          resource: "https://api.example.com",
         },
       });
 
-      const request = createMockRequest('https://example.com/.well-known/oauth-protected-resource');
+      const request = createMockRequest("https://example.com/.well-known/oauth-protected-resource");
       const response = await providerWithPartialMetadata.fetch(request, mockEnv, mockCtx);
 
       const metadata = await response.json<any>();
-      expect(metadata.resource).toBe('https://api.example.com');
-      expect(metadata.authorization_servers).toEqual(['https://example.com']);
-      expect(metadata.scopes_supported).toEqual(['read', 'write']);
+      expect(metadata.resource).toBe("https://api.example.com");
+      expect(metadata.authorization_servers).toEqual(["https://example.com"]);
+      expect(metadata.scopes_supported).toEqual(["read", "write"]);
     });
 
-    it('should add CORS headers to protected resource metadata endpoint', async () => {
-      const request = createMockRequest('https://example.com/.well-known/oauth-protected-resource', 'GET', {
-        Origin: 'https://client.example.com',
-      });
+    it("should add CORS headers to protected resource metadata endpoint", async () => {
+      const request = createMockRequest(
+        "https://example.com/.well-known/oauth-protected-resource",
+        "GET",
+        {
+          Origin: "https://client.example.com",
+        },
+      );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://client.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
-      expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://client.example.com",
+      );
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
+      expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
     });
 
-    it('should derive authorization_servers from tokenEndpoint origin for cross-origin auth', async () => {
+    it("should derive authorization_servers from tokenEndpoint origin for cross-origin auth", async () => {
       const crossOriginProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: 'https://auth.example.com/authorize',
-        tokenEndpoint: 'https://auth.example.com/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "https://auth.example.com/authorize",
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+        scopesSupported: ["read", "write"],
       });
 
-      const request = createMockRequest('https://resource.example.com/.well-known/oauth-protected-resource');
+      const request = createMockRequest(
+        "https://resource.example.com/.well-known/oauth-protected-resource",
+      );
       const response = await crossOriginProvider.fetch(request, mockEnv, mockCtx);
 
       const metadata = await response.json<any>();
-      expect(metadata.resource).toBe('https://resource.example.com');
-      expect(metadata.authorization_servers).toEqual(['https://auth.example.com']);
+      expect(metadata.resource).toBe("https://resource.example.com");
+      expect(metadata.authorization_servers).toEqual(["https://auth.example.com"]);
     });
 
-    it('should handle OPTIONS preflight for protected resource metadata endpoint', async () => {
+    it("should handle OPTIONS preflight for protected resource metadata endpoint", async () => {
       const preflightRequest = createMockRequest(
-        'https://example.com/.well-known/oauth-protected-resource',
-        'OPTIONS',
+        "https://example.com/.well-known/oauth-protected-resource",
+        "OPTIONS",
         {
-          Origin: 'https://spa.example.com',
-          'Access-Control-Request-Method': 'GET',
-        }
+          Origin: "https://spa.example.com",
+          "Access-Control-Request-Method": "GET",
+        },
       );
 
       const response = await oauthProvider.fetch(preflightRequest, mockEnv, mockCtx);
 
       expect(response.status).toBe(204);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://spa.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
-      expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
-      expect(response.headers.get('Content-Length')).toBe('0');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://spa.example.com");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
+      expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
+      expect(response.headers.get("Content-Length")).toBe("0");
     });
   });
 
-  describe('Client Registration', () => {
-    it('should register a new client', async () => {
+  describe("Client Registration", () => {
+    it("should register a new client", async () => {
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
@@ -551,29 +586,31 @@ describe('OAuthProvider', () => {
       const registeredClient = await response.json<any>();
       expect(registeredClient.client_id).toBeDefined();
       expect(registeredClient.client_secret).toBeDefined();
-      expect(registeredClient.redirect_uris).toEqual(['https://client.example.com/callback']);
-      expect(registeredClient.client_name).toBe('Test Client');
+      expect(registeredClient.redirect_uris).toEqual(["https://client.example.com/callback"]);
+      expect(registeredClient.client_name).toBe("Test Client");
 
       // Verify the client was saved to KV
-      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, {
+        type: "json",
+      });
       expect(savedClient).not.toBeNull();
       expect(savedClient.clientId).toBe(registeredClient.client_id);
       // Secret should be stored as a hash
       expect(savedClient.clientSecret).not.toBe(registeredClient.client_secret);
     });
 
-    it('should register a public client', async () => {
+    it("should register a public client", async () => {
       const clientData = {
-        redirect_uris: ['https://spa.example.com/callback'],
-        client_name: 'SPA Client',
-        token_endpoint_auth_method: 'none',
+        redirect_uris: ["https://spa.example.com/callback"],
+        client_name: "SPA Client",
+        token_endpoint_auth_method: "none",
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
@@ -583,16 +620,18 @@ describe('OAuthProvider', () => {
       const registeredClient = await response.json<any>();
       expect(registeredClient.client_id).toBeDefined();
       expect(registeredClient.client_secret).toBeUndefined(); // Public client should not have a secret
-      expect(registeredClient.token_endpoint_auth_method).toBe('none');
+      expect(registeredClient.token_endpoint_auth_method).toBe("none");
 
       // Verify the client was saved to KV
-      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, {
+        type: "json",
+      });
       expect(savedClient).not.toBeNull();
       expect(savedClient.clientSecret).toBeUndefined(); // No secret stored
     });
   });
 
-  describe('Authorization Code Flow', () => {
+  describe("Authorization Code Flow", () => {
     let clientId: string;
     let clientSecret: string;
     let redirectUri: string;
@@ -600,16 +639,16 @@ describe('OAuthProvider', () => {
     // Helper to create a test client before authorization tests
     async function createTestClient() {
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
@@ -617,19 +656,19 @@ describe('OAuthProvider', () => {
 
       clientId = client.client_id;
       clientSecret = client.client_secret;
-      redirectUri = 'https://client.example.com/callback';
+      redirectUri = "https://client.example.com/callback";
     }
 
     beforeEach(async () => {
       await createTestClient();
     });
 
-    it('should handle the authorization request and redirect', async () => {
+    it("should handle the authorization request and redirect", async () => {
       // Create an authorization request
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // The default handler will process this request and generate a redirect
@@ -638,158 +677,166 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(302);
 
       // Check that we're redirected to the client's redirect_uri with a code
-      const location = response.headers.get('Location');
+      const location = response.headers.get("Location");
       expect(location).toBeDefined();
       expect(location).toContain(redirectUri);
-      expect(location).toContain('code=');
-      expect(location).toContain('state=xyz123');
+      expect(location).toContain("code=");
+      expect(location).toContain("state=xyz123");
 
       // Extract the authorization code from the redirect URL
       const url = new URL(location!);
-      const code = url.searchParams.get('code');
+      const code = url.searchParams.get("code");
       expect(code).toBeDefined();
 
       // Verify a grant was created in KV
-      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       expect(grants.keys.length).toBe(1);
     });
 
-    it('should reject authorization request with invalid redirect URI', async () => {
+    it("should reject authorization request with invalid redirect URI", async () => {
       // Create an authorization request with an invalid redirect URI
-      const invalidRedirectUri = 'https://attacker.example.com/callback';
+      const invalidRedirectUri = "https://attacker.example.com/callback";
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(invalidRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // Expect the request to be rejected
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+        "Invalid redirect URI",
+      );
 
       // Verify no grant was created
-      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       expect(grants.keys.length).toBe(0);
     });
 
-    it('should reject authorization request with invalid client id', async () => {
+    it("should reject authorization request with invalid client id", async () => {
       // Create an authorization request with an invalid redirect URI
-      const invalidClientId = 'attackerClientId';
+      const invalidClientId = "attackerClientId";
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${invalidClientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // Expect the request to be rejected
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+        "Invalid client",
+      );
 
       // Verify no grant was created
-      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       expect(grants.keys.length).toBe(0);
     });
 
-    it('should reject authorization request with invalid client id and redirect uri', async () => {
+    it("should reject authorization request with invalid client id and redirect uri", async () => {
       // Create an authorization request with an invalid redirect URI
-      const invalidRedirectUri = 'https://attacker.example.com/callback';
-      const invalidClientId = 'attackerClientId';
+      const invalidRedirectUri = "https://attacker.example.com/callback";
+      const invalidClientId = "attackerClientId";
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${invalidClientId}` +
           `&redirect_uri=${encodeURIComponent(invalidRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // Expect the request to be rejected
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+        "Invalid client",
+      );
 
       // Verify no grant was created
-      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       expect(grants.keys.length).toBe(0);
     });
 
-    it('should reject authorization request with javascript: redirect URI', async () => {
+    it("should reject authorization request with javascript: redirect URI", async () => {
       // Create an authorization request with a javascript: redirect URI
       const javascriptRedirectUri = 'javascript:alert("xss")';
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(javascriptRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // Expect the request to be rejected
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+        "Invalid redirect URI",
+      );
 
       // Verify no grant was created
-      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       expect(grants.keys.length).toBe(0);
     });
 
-    it('should reject completeAuthorization if redirect_uri is invalid', async () => {
+    it("should reject completeAuthorization if redirect_uri is invalid", async () => {
       // This test ensures that completeAuthorization re-validates the redirect_uri.
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read&state=xyz123`
+          `&scope=read&state=xyz123`,
       );
 
       // Manually trigger the fetch to populate env.OAUTH_PROVIDER
-      await oauthProvider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+      await oauthProvider.fetch(createMockRequest("https://example.com/"), mockEnv, mockCtx);
       const helpers = mockEnv.OAUTH_PROVIDER!;
 
       // Parse the request to get a valid AuthRequest object
       const oauthReqInfo = await helpers.parseAuthRequest(authRequest);
 
       // Manually tamper with the redirect_uri after parsing
-      const tamperedRequest = { ...oauthReqInfo, redirectUri: 'https://attacker.com' };
+      const tamperedRequest = { ...oauthReqInfo, redirectUri: "https://attacker.com" };
 
       // Expect completeAuthorization to throw because the redirect_uri is not registered
       await expect(
         helpers.completeAuthorization({
           request: tamperedRequest,
-          userId: 'test-user-123',
+          userId: "test-user-123",
           metadata: {},
           scope: tamperedRequest.scope,
           props: {},
-        })
-      ).rejects.toThrow('Invalid redirect URI');
+        }),
+      ).rejects.toThrow("Invalid redirect URI");
     });
   });
 
-  describe('Implicit Flow', () => {
+  describe("Implicit Flow", () => {
     let clientId: string;
     let redirectUri: string;
 
     // Helper to create a test client before authorization tests
     async function createPublicClient() {
       const clientData = {
-        redirect_uris: ['https://spa-client.example.com/callback'],
-        client_name: 'SPA Test Client',
-        token_endpoint_auth_method: 'none', // Public client
+        redirect_uris: ["https://spa-client.example.com/callback"],
+        client_name: "SPA Test Client",
+        token_endpoint_auth_method: "none", // Public client
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
       const client = await response.json<any>();
 
       clientId = client.client_id;
-      redirectUri = 'https://spa-client.example.com/callback';
+      redirectUri = "https://spa-client.example.com/callback";
     }
 
     beforeEach(async () => {
       await createPublicClient();
     });
 
-    it('should handle implicit flow request and redirect with token in fragment', async () => {
+    it("should handle implicit flow request and redirect with token in fragment", async () => {
       // Create an implicit flow authorization request
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=token&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // The default handler will process this request and generate a redirect
@@ -798,14 +845,14 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(302);
 
       // Check that we're redirected to the client's redirect_uri with token in fragment
-      const location = response.headers.get('Location');
+      const location = response.headers.get("Location");
       expect(location).toBeDefined();
       expect(location).toContain(redirectUri);
 
       const url = new URL(location!);
 
       // Check that there's no code parameter in the query string
-      expect(url.searchParams.has('code')).toBe(false);
+      expect(url.searchParams.has("code")).toBe(false);
 
       // Check that we have a hash/fragment with token parameters
       expect(url.hash).toBeTruthy();
@@ -814,30 +861,30 @@ describe('OAuthProvider', () => {
       const fragment = new URLSearchParams(url.hash.substring(1)); // Remove the # character
 
       // Verify token parameters
-      expect(fragment.get('access_token')).toBeTruthy();
-      expect(fragment.get('token_type')).toBe('bearer');
-      expect(fragment.get('expires_in')).toBe('3600');
-      expect(fragment.get('scope')).toBe('read write');
-      expect(fragment.get('state')).toBe('xyz123');
+      expect(fragment.get("access_token")).toBeTruthy();
+      expect(fragment.get("token_type")).toBe("bearer");
+      expect(fragment.get("expires_in")).toBe("3600");
+      expect(fragment.get("scope")).toBe("read write");
+      expect(fragment.get("state")).toBe("xyz123");
 
       // Verify a grant was created in KV
-      const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       expect(grants.keys.length).toBe(1);
 
       // Verify access token was stored in KV
-      const tokenEntries = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      const tokenEntries = await mockEnv.OAUTH_KV.list({ prefix: "token:" });
       expect(tokenEntries.keys.length).toBe(1);
     });
 
-    it('should reject implicit flow when allowImplicitFlow is disabled', async () => {
+    it("should reject implicit flow when allowImplicitFlow is disabled", async () => {
       // Create a provider with implicit flow disabled
       const providerWithoutImplicit = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         allowImplicitFlow: false, // Explicitly disable
       });
 
@@ -845,29 +892,29 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=token&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // Mock parseAuthRequest to test error handling
-      vi.spyOn(authRequest, 'formData').mockImplementation(() => {
-        throw new Error('The implicit grant flow is not enabled for this provider');
+      vi.spyOn(authRequest, "formData").mockImplementation(() => {
+        throw new Error("The implicit grant flow is not enabled for this provider");
       });
 
       // Expect an error response
       await expect(providerWithoutImplicit.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-        'The implicit grant flow is not enabled for this provider'
+        "The implicit grant flow is not enabled for this provider",
       );
     });
 
-    it('should reject plain PKCE when allowPlainPKCE is false', async () => {
+    it("should reject plain PKCE when allowPlainPKCE is false", async () => {
       // Create a provider with plain PKCE disabled
       const providerWithoutPlainPKCE = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         allowPlainPKCE: false, // Enforce S256 only
       });
 
@@ -876,36 +923,36 @@ describe('OAuthProvider', () => {
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&scope=read%20write&state=xyz123` +
-          `&code_challenge=test_challenge&code_challenge_method=plain`
+          `&code_challenge=test_challenge&code_challenge_method=plain`,
       );
 
       // Expect an error response
       await expect(providerWithoutPlainPKCE.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-        'The plain PKCE method is not allowed. Use S256 instead.'
+        "The plain PKCE method is not allowed. Use S256 instead.",
       );
     });
 
-    it('should accept S256 PKCE when allowPlainPKCE is false', async () => {
+    it("should accept S256 PKCE when allowPlainPKCE is false", async () => {
       // Create a provider with plain PKCE disabled
       const providerWithoutPlainPKCE = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         allowPlainPKCE: false, // Enforce S256 only
       });
 
       // Create a valid S256 code challenge (SHA-256 of 'test_verifier' base64url encoded)
-      const codeChallenge = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+      const codeChallenge = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
 
       // Create an authorization request with S256 PKCE
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&scope=read%20write&state=xyz123` +
-          `&code_challenge=${codeChallenge}&code_challenge_method=S256`
+          `&code_challenge=${codeChallenge}&code_challenge_method=S256`,
       );
 
       // This should NOT throw - S256 is allowed
@@ -914,25 +961,25 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(302);
     });
 
-    it('should use the access token to access API directly', async () => {
+    it("should use the access token to access API directly", async () => {
       // Create an implicit flow authorization request
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=token&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       // The default handler will process this request and generate a redirect
       const response = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = response.headers.get('Location')!;
+      const location = response.headers.get("Location")!;
 
       // Parse the fragment to get the access token
       const url = new URL(location);
       const fragment = new URLSearchParams(url.hash.substring(1));
-      const accessToken = fragment.get('access_token')!;
+      const accessToken = fragment.get("access_token")!;
 
       // Now use the access token for an API request
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -942,11 +989,11 @@ describe('OAuthProvider', () => {
 
       const apiData = await apiResponse.json<any>();
       expect(apiData.success).toBe(true);
-      expect(apiData.user).toEqual({ userId: 'test-user-123', username: 'TestUser' });
+      expect(apiData.user).toEqual({ userId: "test-user-123", username: "TestUser" });
     });
   });
 
-  describe('Redirect URI Scheme Validation (Security)', () => {
+  describe("Redirect URI Scheme Validation (Security)", () => {
     let clientId: string;
     let clientSecret: string;
     let redirectUri: string;
@@ -954,16 +1001,16 @@ describe('OAuthProvider', () => {
     // Helper to create a test client before authorization tests
     async function createTestClient() {
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
@@ -971,55 +1018,57 @@ describe('OAuthProvider', () => {
 
       clientId = client.client_id;
       clientSecret = client.client_secret;
-      redirectUri = 'https://client.example.com/callback';
+      redirectUri = "https://client.example.com/callback";
     }
 
     beforeEach(async () => {
       await createTestClient();
     });
 
-    describe('should reject dangerous pseudo-schemes (case-sensitive baseline)', () => {
+    describe("should reject dangerous pseudo-schemes (case-sensitive baseline)", () => {
       const dangerousSchemes = [
-        'javascript:alert(1)',
-        'data:text/html,<script>alert(1)</script>',
-        'vbscript:msgbox(1)',
-        'file:///etc/passwd',
-        'mailto:attacker@evil.com',
-        'blob:https://example.com/uuid',
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:msgbox(1)",
+        "file:///etc/passwd",
+        "mailto:attacker@evil.com",
+        "blob:https://example.com/uuid",
       ];
 
       dangerousSchemes.forEach((maliciousUri) => {
-        it(`should reject ${maliciousUri.split(':')[0]}: scheme`, async () => {
+        it(`should reject ${maliciousUri.split(":")[0]}: scheme`, async () => {
           const authRequest = createMockRequest(
             `https://example.com/authorize?response_type=code&client_id=${clientId}` +
               `&redirect_uri=${encodeURIComponent(maliciousUri)}` +
-              `&scope=read&state=xyz123`
+              `&scope=read&state=xyz123`,
           );
 
-          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+            "Invalid redirect URI",
+          );
 
           // Verify no grant was created
-          const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+          const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
           expect(grants.keys.length).toBe(0);
         });
       });
     });
 
-    describe('should block mixed-case scheme bypass attempts', () => {
+    describe("should block mixed-case scheme bypass attempts", () => {
       const mixedCaseSchemes = [
-        'JaVaScRiPt:alert(1)',
-        'JAVASCRIPT:alert(1)',
-        'JavaScript:alert(1)',
-        'DaTa:text/html,<script>alert(1)</script>',
-        'DATA:text/html,<script>alert(1)</script>',
-        'VbScRiPt:msgbox(1)',
-        'VBSCRIPT:msgbox(1)',
-        'FiLe:///etc/passwd',
-        'FILE:///etc/passwd',
-        'MaIlTo:attacker@evil.com',
-        'MAILTO:attacker@evil.com',
-        'BlOb:https://example.com/uuid',
-        'BLOB:https://example.com/uuid',
+        "JaVaScRiPt:alert(1)",
+        "JAVASCRIPT:alert(1)",
+        "JavaScript:alert(1)",
+        "DaTa:text/html,<script>alert(1)</script>",
+        "DATA:text/html,<script>alert(1)</script>",
+        "VbScRiPt:msgbox(1)",
+        "VBSCRIPT:msgbox(1)",
+        "FiLe:///etc/passwd",
+        "FILE:///etc/passwd",
+        "MaIlTo:attacker@evil.com",
+        "MAILTO:attacker@evil.com",
+        "BlOb:https://example.com/uuid",
+        "BLOB:https://example.com/uuid",
       ];
 
       mixedCaseSchemes.forEach((maliciousUri) => {
@@ -1027,29 +1076,31 @@ describe('OAuthProvider', () => {
           const authRequest = createMockRequest(
             `https://example.com/authorize?response_type=code&client_id=${clientId}` +
               `&redirect_uri=${encodeURIComponent(maliciousUri)}` +
-              `&scope=read&state=xyz123`
+              `&scope=read&state=xyz123`,
           );
 
-          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+            "Invalid redirect URI",
+          );
 
           // Verify no grant was created
-          const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+          const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
           expect(grants.keys.length).toBe(0);
         });
       });
     });
 
-    describe('should block leading whitespace/control character bypass attempts', () => {
+    describe("should block leading whitespace/control character bypass attempts", () => {
       const bypassAttempts = [
-        { desc: 'leading space', uri: ' javascript:alert(1)' },
-        { desc: 'leading tab', uri: '\tjavascript:alert(1)' },
-        { desc: 'leading newline', uri: '\njavascript:alert(1)' },
-        { desc: 'leading carriage return', uri: '\rjavascript:alert(1)' },
-        { desc: 'leading null byte', uri: '\x00javascript:alert(1)' },
-        { desc: 'multiple leading spaces', uri: '   javascript:alert(1)' },
-        { desc: 'leading vertical tab', uri: '\x0Bjavascript:alert(1)' },
-        { desc: 'leading form feed', uri: '\x0Cjavascript:alert(1)' },
-        { desc: 'trailing space with javascript', uri: ' javascript:alert(1) ' },
+        { desc: "leading space", uri: " javascript:alert(1)" },
+        { desc: "leading tab", uri: "\tjavascript:alert(1)" },
+        { desc: "leading newline", uri: "\njavascript:alert(1)" },
+        { desc: "leading carriage return", uri: "\rjavascript:alert(1)" },
+        { desc: "leading null byte", uri: "\x00javascript:alert(1)" },
+        { desc: "multiple leading spaces", uri: "   javascript:alert(1)" },
+        { desc: "leading vertical tab", uri: "\x0Bjavascript:alert(1)" },
+        { desc: "leading form feed", uri: "\x0Cjavascript:alert(1)" },
+        { desc: "trailing space with javascript", uri: " javascript:alert(1) " },
       ];
 
       bypassAttempts.forEach(({ desc, uri }) => {
@@ -1057,27 +1108,29 @@ describe('OAuthProvider', () => {
           const authRequest = createMockRequest(
             `https://example.com/authorize?response_type=code&client_id=${clientId}` +
               `&redirect_uri=${encodeURIComponent(uri)}` +
-              `&scope=read&state=xyz123`
+              `&scope=read&state=xyz123`,
           );
 
-          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+            "Invalid redirect URI",
+          );
 
           // Verify no grant was created
-          const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+          const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
           expect(grants.keys.length).toBe(0);
         });
       });
     });
 
-    describe('should block embedded control character bypass attempts', () => {
+    describe("should block embedded control character bypass attempts", () => {
       const bypassAttempts = [
-        { desc: 'tab in scheme name', uri: 'jav\tascript:alert(1)' },
-        { desc: 'newline in scheme name', uri: 'java\nscript:alert(1)' },
-        { desc: 'null byte in scheme name', uri: 'java\x00script:alert(1)' },
-        { desc: 'carriage return in scheme', uri: 'java\rscript:alert(1)' },
-        { desc: 'vertical tab in scheme', uri: 'java\x0Bscript:alert(1)' },
-        { desc: 'form feed in scheme', uri: 'java\x0Cscript:alert(1)' },
-        { desc: 'multiple control chars', uri: 'ja\x00va\tsc\nript:alert(1)' },
+        { desc: "tab in scheme name", uri: "jav\tascript:alert(1)" },
+        { desc: "newline in scheme name", uri: "java\nscript:alert(1)" },
+        { desc: "null byte in scheme name", uri: "java\x00script:alert(1)" },
+        { desc: "carriage return in scheme", uri: "java\rscript:alert(1)" },
+        { desc: "vertical tab in scheme", uri: "java\x0Bscript:alert(1)" },
+        { desc: "form feed in scheme", uri: "java\x0Cscript:alert(1)" },
+        { desc: "multiple control chars", uri: "ja\x00va\tsc\nript:alert(1)" },
       ];
 
       bypassAttempts.forEach(({ desc, uri }) => {
@@ -1085,30 +1138,32 @@ describe('OAuthProvider', () => {
           const authRequest = createMockRequest(
             `https://example.com/authorize?response_type=code&client_id=${clientId}` +
               `&redirect_uri=${encodeURIComponent(uri)}` +
-              `&scope=read&state=xyz123`
+              `&scope=read&state=xyz123`,
           );
 
-          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+            "Invalid redirect URI",
+          );
 
           // Verify no grant was created
-          const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+          const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
           expect(grants.keys.length).toBe(0);
         });
       });
     });
 
-    describe('should block control characters in legitimate URIs', () => {
+    describe("should block control characters in legitimate URIs", () => {
       const controlCharVariants = [
-        { desc: 'DELETE char (0x7F) in path', uri: 'https://example.com\x7F/callback' },
-        { desc: 'null byte in path', uri: 'https://example.com/call\x00back' },
-        { desc: 'tab in path', uri: 'https://example.com/call\tback' },
-        { desc: 'newline after scheme', uri: 'https:\n//example.com/callback' },
-        { desc: 'C1 control (0x80) in host', uri: 'https://exam\x80ple.com/callback' },
-        { desc: 'C1 control (0x9F) in path', uri: 'https://example.com/call\x9Fback' },
-        { desc: 'boundary C0 (0x1F)', uri: 'https://example.com/call\x1Fback' },
-        { desc: 'boundary C1 (0x9F)', uri: 'https://example.com/call\x9Fback' },
-        { desc: 'control char in query', uri: 'https://example.com/callback?param=val\x00ue' },
-        { desc: 'control char in fragment', uri: 'https://example.com/callback#sec\x00tion' },
+        { desc: "DELETE char (0x7F) in path", uri: "https://example.com\x7F/callback" },
+        { desc: "null byte in path", uri: "https://example.com/call\x00back" },
+        { desc: "tab in path", uri: "https://example.com/call\tback" },
+        { desc: "newline after scheme", uri: "https:\n//example.com/callback" },
+        { desc: "C1 control (0x80) in host", uri: "https://exam\x80ple.com/callback" },
+        { desc: "C1 control (0x9F) in path", uri: "https://example.com/call\x9Fback" },
+        { desc: "boundary C0 (0x1F)", uri: "https://example.com/call\x1Fback" },
+        { desc: "boundary C1 (0x9F)", uri: "https://example.com/call\x9Fback" },
+        { desc: "control char in query", uri: "https://example.com/callback?param=val\x00ue" },
+        { desc: "control char in fragment", uri: "https://example.com/callback#sec\x00tion" },
       ];
 
       controlCharVariants.forEach(({ desc, uri }) => {
@@ -1116,25 +1171,27 @@ describe('OAuthProvider', () => {
           const authRequest = createMockRequest(
             `https://example.com/authorize?response_type=code&client_id=${clientId}` +
               `&redirect_uri=${encodeURIComponent(uri)}` +
-              `&scope=read&state=xyz123`
+              `&scope=read&state=xyz123`,
           );
 
-          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+            "Invalid redirect URI",
+          );
 
           // Verify no grant was created
-          const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+          const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
           expect(grants.keys.length).toBe(0);
         });
       });
     });
 
-    describe('should block data: URI variations', () => {
+    describe("should block data: URI variations", () => {
       const dataUriVariants = [
-        'data:text/html,<script>alert(1)</script>',
-        'DaTa:text/html,<script>alert(1)</script>',
-        ' data:text/html,<script>alert(1)</script>',
-        'da\tta:text/html,<script>alert(1)</script>',
-        'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+        "data:text/html,<script>alert(1)</script>",
+        "DaTa:text/html,<script>alert(1)</script>",
+        " data:text/html,<script>alert(1)</script>",
+        "da\tta:text/html,<script>alert(1)</script>",
+        "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
       ];
 
       dataUriVariants.forEach((uri) => {
@@ -1142,27 +1199,29 @@ describe('OAuthProvider', () => {
           const authRequest = createMockRequest(
             `https://example.com/authorize?response_type=code&client_id=${clientId}` +
               `&redirect_uri=${encodeURIComponent(uri)}` +
-              `&scope=read&state=xyz123`
+              `&scope=read&state=xyz123`,
           );
 
-          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+          await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+            "Invalid redirect URI",
+          );
 
           // Verify no grant was created
-          const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+          const grants = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
           expect(grants.keys.length).toBe(0);
         });
       });
     });
 
-    describe('should allow legitimate URIs', () => {
+    describe("should allow legitimate URIs", () => {
       const legitimateUris = [
-        'https://client.example.com/callback',
-        'https://client.example.com/callback?param=value',
-        'https://client.example.com:8080/callback',
-        'http://localhost:3000/callback',
-        'http://127.0.0.1:8080/callback',
-        'myapp://callback',
-        'com.example.app://oauth/callback',
+        "https://client.example.com/callback",
+        "https://client.example.com/callback?param=value",
+        "https://client.example.com:8080/callback",
+        "http://localhost:3000/callback",
+        "http://127.0.0.1:8080/callback",
+        "myapp://callback",
+        "com.example.app://oauth/callback",
       ];
 
       legitimateUris.forEach((uri) => {
@@ -1170,15 +1229,15 @@ describe('OAuthProvider', () => {
           // First, we need to register a client with this URI
           const clientData = {
             redirect_uris: [uri],
-            client_name: 'Test Client for ' + uri,
-            token_endpoint_auth_method: 'client_secret_basic',
+            client_name: "Test Client for " + uri,
+            token_endpoint_auth_method: "client_secret_basic",
           };
 
           const registerRequest = createMockRequest(
-            'https://example.com/oauth/register',
-            'POST',
-            { 'Content-Type': 'application/json' },
-            JSON.stringify(clientData)
+            "https://example.com/oauth/register",
+            "POST",
+            { "Content-Type": "application/json" },
+            JSON.stringify(clientData),
           );
 
           const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
@@ -1187,58 +1246,58 @@ describe('OAuthProvider', () => {
           const authRequest = createMockRequest(
             `https://example.com/authorize?response_type=code&client_id=${client.client_id}` +
               `&redirect_uri=${encodeURIComponent(uri)}` +
-              `&scope=read&state=xyz123`
+              `&scope=read&state=xyz123`,
           );
 
           const response = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
 
           // Should get a redirect, not an error
           expect(response.status).toBe(302);
-          const location = response.headers.get('Location');
+          const location = response.headers.get("Location");
           expect(location).toBeDefined();
-          expect(location).toContain('code=');
+          expect(location).toContain("code=");
         });
       });
     });
 
-    describe('should handle edge cases', () => {
-      it('should reject empty redirect URI', async () => {
+    describe("should handle edge cases", () => {
+      it("should reject empty redirect URI", async () => {
         const authRequest = createMockRequest(
           `https://example.com/authorize?response_type=code&client_id=${clientId}` +
-            `&redirect_uri=&scope=read&state=xyz123`
+            `&redirect_uri=&scope=read&state=xyz123`,
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow();
       });
 
-      it('should reject relative URIs', async () => {
+      it("should reject relative URIs", async () => {
         // Relative URIs should be rejected at scheme validation
-        const relativeUri = '/callback';
+        const relativeUri = "/callback";
 
         const clientData = {
           redirect_uris: [relativeUri],
-          client_name: 'Test Client with Relative URI',
-          token_endpoint_auth_method: 'client_secret_basic',
+          client_name: "Test Client with Relative URI",
+          token_endpoint_auth_method: "client_secret_basic",
         };
 
         const registerRequest = createMockRequest(
-          'https://example.com/oauth/register',
-          'POST',
-          { 'Content-Type': 'application/json' },
-          JSON.stringify(clientData)
+          "https://example.com/oauth/register",
+          "POST",
+          { "Content-Type": "application/json" },
+          JSON.stringify(clientData),
         );
 
         // Should be rejected with "Invalid redirect URI" error
         const response = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
         expect(response.status).toBe(400);
         const errorBody = await response.json<any>();
-        expect(errorBody.error).toBe('invalid_client_metadata');
-        expect(errorBody.error_description).toBe('Invalid redirect URI');
+        expect(errorBody.error).toBe("invalid_client_metadata");
+        expect(errorBody.error_description).toBe("Invalid redirect URI");
       });
     });
   });
 
-  describe('Authorization Code Flow Exchange', () => {
+  describe("Authorization Code Flow Exchange", () => {
     let clientId: string;
     let clientSecret: string;
     let redirectUri: string;
@@ -1246,16 +1305,16 @@ describe('OAuthProvider', () => {
     // Helper to create a test client before authorization tests
     async function createTestClient() {
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
@@ -1263,41 +1322,41 @@ describe('OAuthProvider', () => {
 
       clientId = client.client_id;
       clientSecret = client.client_secret;
-      redirectUri = 'https://client.example.com/callback';
+      redirectUri = "https://client.example.com/callback";
     }
 
     beforeEach(async () => {
       await createTestClient();
     });
 
-    it('should exchange auth code for tokens', async () => {
+    it("should exchange auth code for tokens", async () => {
       // First get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
+      const location = authResponse.headers.get("Location")!;
       const url = new URL(location);
-      const code = url.searchParams.get('code')!;
+      const code = url.searchParams.get("code")!;
 
       // Now exchange the code for tokens
       // Use URLSearchParams which is proper for application/x-www-form-urlencoded
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       // Use the URLSearchParams object as the body - correctly encoded for Content-Type: application/x-www-form-urlencoded
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -1307,48 +1366,48 @@ describe('OAuthProvider', () => {
       const tokens = await tokenResponse.json<any>();
       expect(tokens.access_token).toBeDefined();
       expect(tokens.refresh_token).toBeDefined();
-      expect(tokens.token_type).toBe('bearer');
+      expect(tokens.token_type).toBe("bearer");
       expect(tokens.expires_in).toBe(3600);
 
       // Verify token was stored in KV
-      const tokenEntries = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      const tokenEntries = await mockEnv.OAUTH_KV.list({ prefix: "token:" });
       expect(tokenEntries.keys.length).toBe(1);
 
       // Verify grant was updated (auth code removed, refresh token added)
-      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       const grantKey = grantEntries.keys[0].name;
-      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
 
       expect(grant.authCodeId).toBeUndefined(); // Auth code should be removed
       expect(grant.refreshTokenId).toBeDefined(); // Refresh token should be added
     });
 
-    it('should reject token exchange without redirect_uri when not using PKCE', async () => {
+    it("should reject token exchange without redirect_uri when not using PKCE", async () => {
       // First get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
+      const location = authResponse.headers.get("Location")!;
       const url = new URL(location);
-      const code = url.searchParams.get('code')!;
+      const code = url.searchParams.get("code")!;
 
       // Now exchange the code without providing redirect_uri
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
       // redirect_uri intentionally omitted
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -1356,37 +1415,37 @@ describe('OAuthProvider', () => {
       // Should fail because redirect_uri is required when not using PKCE
       expect(tokenResponse.status).toBe(400);
       const error = await tokenResponse.json<any>();
-      expect(error.error).toBe('invalid_request');
-      expect(error.error_description).toBe('redirect_uri is required when not using PKCE');
+      expect(error.error).toBe("invalid_request");
+      expect(error.error_description).toBe("redirect_uri is required when not using PKCE");
     });
 
-    it('should reject token exchange with code_verifier when PKCE was not used in authorization', async () => {
+    it("should reject token exchange with code_verifier when PKCE was not used in authorization", async () => {
       // First get an auth code WITHOUT using PKCE
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
+      const location = authResponse.headers.get("Location")!;
       const url = new URL(location);
-      const code = url.searchParams.get('code')!;
+      const code = url.searchParams.get("code")!;
 
       // Now exchange the code and incorrectly provide a code_verifier
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('code_verifier', 'some_random_verifier_that_wasnt_used_in_auth');
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("code_verifier", "some_random_verifier_that_wasnt_used_in_auth");
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -1394,14 +1453,16 @@ describe('OAuthProvider', () => {
       // Should fail because code_verifier is provided but PKCE wasn't used in authorization
       expect(tokenResponse.status).toBe(400);
       const error = await tokenResponse.json<any>();
-      expect(error.error).toBe('invalid_request');
-      expect(error.error_description).toBe('code_verifier provided for a flow that did not use PKCE');
+      expect(error.error).toBe("invalid_request");
+      expect(error.error_description).toBe(
+        "code_verifier provided for a flow that did not use PKCE",
+      );
     });
 
     // Helper function for PKCE tests
     function generateRandomString(length: number): string {
-      const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-      let result = '';
+      const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+      let result = "";
       const values = new Uint8Array(length);
       crypto.getRandomValues(values);
       for (let i = 0; i < length; i++) {
@@ -1412,15 +1473,15 @@ describe('OAuthProvider', () => {
 
     // Helper function for PKCE tests
     function base64UrlEncode(str: string): string {
-      return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+      return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
     }
 
-    it('should accept token exchange without redirect_uri when using PKCE', async () => {
+    it("should accept token exchange without redirect_uri when using PKCE", async () => {
       // Generate PKCE code verifier and challenge
       const codeVerifier = generateRandomString(43); // Recommended length
       const encoder = new TextEncoder();
       const data = encoder.encode(codeVerifier);
-      const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+      const hashBuffer = await crypto.subtle.digest("SHA-256", data);
       const hashArray = Array.from(new Uint8Array(hashBuffer));
       const codeChallenge = base64UrlEncode(String.fromCharCode(...hashArray));
 
@@ -1429,28 +1490,28 @@ describe('OAuthProvider', () => {
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&scope=read%20write&state=xyz123` +
-          `&code_challenge=${codeChallenge}&code_challenge_method=S256`
+          `&code_challenge=${codeChallenge}&code_challenge_method=S256`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
+      const location = authResponse.headers.get("Location")!;
       const url = new URL(location);
-      const code = url.searchParams.get('code')!;
+      const code = url.searchParams.get("code")!;
 
       // Now exchange the code without providing redirect_uri
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
       // redirect_uri intentionally omitted
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('code_verifier', codeVerifier);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("code_verifier", codeVerifier);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -1461,42 +1522,42 @@ describe('OAuthProvider', () => {
       const tokens = await tokenResponse.json<any>();
       expect(tokens.access_token).toBeDefined();
       expect(tokens.refresh_token).toBeDefined();
-      expect(tokens.token_type).toBe('bearer');
+      expect(tokens.token_type).toBe("bearer");
       expect(tokens.expires_in).toBe(3600);
     });
 
-    it('should accept the access token for API requests', async () => {
+    it("should accept the access token for API requests", async () => {
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
       const tokens = await tokenResponse.json<any>();
 
       // Now use the access token for an API request
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${tokens.access_token}`,
       });
 
@@ -1506,110 +1567,110 @@ describe('OAuthProvider', () => {
 
       const apiData = await apiResponse.json<any>();
       expect(apiData.success).toBe(true);
-      expect(apiData.user).toEqual({ userId: 'test-user-123', username: 'TestUser' });
+      expect(apiData.user).toEqual({ userId: "test-user-123", username: "TestUser" });
     });
 
-    it('should downscope token when scope param is subset of grant scopes', async () => {
+    it("should downscope token when scope param is subset of grant scopes", async () => {
       // Get an auth code with broad scopes
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write%20profile&state=xyz123`
+          `&scope=read%20write%20profile&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       // Exchange code with narrower scope param
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('scope', 'read'); // Request only 'read' from granted 'read write profile'
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("scope", "read"); // Request only 'read' from granted 'read write profile'
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
       expect(tokenResponse.status).toBe(200);
 
       const tokens = await tokenResponse.json<any>();
-      expect(tokens.scope).toBe('read');
+      expect(tokens.scope).toBe("read");
     });
 
-    it('should silently filter invalid scopes during auth code exchange', async () => {
+    it("should silently filter invalid scopes during auth code exchange", async () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       // Request scopes including one not in the grant
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('scope', 'read write delete'); // 'delete' not in grant
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("scope", "read write delete"); // 'delete' not in grant
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
       expect(tokenResponse.status).toBe(200);
 
       const tokens = await tokenResponse.json<any>();
-      expect(tokens.scope).toBe('read write'); // 'delete' silently removed
+      expect(tokens.scope).toBe("read write"); // 'delete' silently removed
     });
 
-    it('should return full grant scopes when no scope param is provided', async () => {
+    it("should return full grant scopes when no scope param is provided", async () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
       // No scope param
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
       expect(tokenResponse.status).toBe(200);
 
       const tokens = await tokenResponse.json<any>();
-      expect(tokens.scope).toBe('read write'); // Full grant scopes
+      expect(tokens.scope).toBe("read write"); // Full grant scopes
     });
   });
 
-  describe('Refresh Token Flow', () => {
+  describe("Refresh Token Flow", () => {
     let clientId: string;
     let clientSecret: string;
     let refreshToken: string;
@@ -1618,48 +1679,48 @@ describe('OAuthProvider', () => {
     async function getRefreshToken() {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       clientId = client.client_id;
       clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -1671,19 +1732,19 @@ describe('OAuthProvider', () => {
       await getRefreshToken();
     });
 
-    it('should issue new tokens with refresh token', async () => {
+    it("should issue new tokens with refresh token", async () => {
       // Use the refresh token to get a new access token
       const params = new URLSearchParams();
-      params.append('grant_type', 'refresh_token');
-      params.append('refresh_token', refreshToken);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "refresh_token");
+      params.append("refresh_token", refreshToken);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const refreshResponse = await oauthProvider.fetch(refreshRequest, mockEnv, mockCtx);
@@ -1696,31 +1757,31 @@ describe('OAuthProvider', () => {
       expect(newTokens.refresh_token).not.toBe(refreshToken); // Should get a new refresh token
 
       // Verify we now have a new token in storage
-      const tokenEntries = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      const tokenEntries = await mockEnv.OAUTH_KV.list({ prefix: "token:" });
       expect(tokenEntries.keys.length).toBe(2); // The old one and the new one
 
       // Verify the grant was updated
-      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       const grantKey = grantEntries.keys[0].name;
-      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
 
       expect(grant.previousRefreshTokenId).toBeDefined(); // Old refresh token should be tracked
       expect(grant.refreshTokenId).toBeDefined(); // New refresh token should be set
     });
 
-    it('should allow using the previous refresh token once', async () => {
+    it("should allow using the previous refresh token once", async () => {
       // Use the refresh token to get a new access token (first refresh)
       const params1 = new URLSearchParams();
-      params1.append('grant_type', 'refresh_token');
-      params1.append('refresh_token', refreshToken);
-      params1.append('client_id', clientId);
-      params1.append('client_secret', clientSecret);
+      params1.append("grant_type", "refresh_token");
+      params1.append("refresh_token", refreshToken);
+      params1.append("client_id", clientId);
+      params1.append("client_secret", clientSecret);
 
       const refreshRequest1 = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params1.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params1.toString(),
       );
 
       const refreshResponse1 = await oauthProvider.fetch(refreshRequest1, mockEnv, mockCtx);
@@ -1729,16 +1790,16 @@ describe('OAuthProvider', () => {
 
       // Now try to use the original refresh token again (simulating a retry after failure)
       const params2 = new URLSearchParams();
-      params2.append('grant_type', 'refresh_token');
-      params2.append('refresh_token', refreshToken); // Original token
-      params2.append('client_id', clientId);
-      params2.append('client_secret', clientSecret);
+      params2.append("grant_type", "refresh_token");
+      params2.append("refresh_token", refreshToken); // Original token
+      params2.append("client_id", clientId);
+      params2.append("client_secret", clientSecret);
 
       const refreshRequest2 = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params2.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params2.toString(),
       );
 
       const refreshResponse2 = await oauthProvider.fetch(refreshRequest2, mockEnv, mockCtx);
@@ -1752,83 +1813,83 @@ describe('OAuthProvider', () => {
 
       // Now the grant should have the newest refresh token and the token from the first refresh
       // as the previous token
-      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       const grantKey = grantEntries.keys[0].name;
-      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
 
       // The previousRefreshTokenId should now be from the first refresh, not the original
       expect(grant.previousRefreshTokenId).toBeDefined();
     });
 
-    it('should downscope token when scope param is subset of grant scopes', async () => {
+    it("should downscope token when scope param is subset of grant scopes", async () => {
       // Use the refresh token with narrower scope
       const params = new URLSearchParams();
-      params.append('grant_type', 'refresh_token');
-      params.append('refresh_token', refreshToken);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('scope', 'read'); // Grant had 'read write'
+      params.append("grant_type", "refresh_token");
+      params.append("refresh_token", refreshToken);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("scope", "read"); // Grant had 'read write'
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const refreshResponse = await oauthProvider.fetch(refreshRequest, mockEnv, mockCtx);
       expect(refreshResponse.status).toBe(200);
 
       const newTokens = await refreshResponse.json<any>();
-      expect(newTokens.scope).toBe('read');
+      expect(newTokens.scope).toBe("read");
     });
 
-    it('should silently filter invalid scopes during refresh', async () => {
+    it("should silently filter invalid scopes during refresh", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'refresh_token');
-      params.append('refresh_token', refreshToken);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('scope', 'read admin'); // 'admin' not in grant which had 'read write'
+      params.append("grant_type", "refresh_token");
+      params.append("refresh_token", refreshToken);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("scope", "read admin"); // 'admin' not in grant which had 'read write'
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const refreshResponse = await oauthProvider.fetch(refreshRequest, mockEnv, mockCtx);
       expect(refreshResponse.status).toBe(200);
 
       const newTokens = await refreshResponse.json<any>();
-      expect(newTokens.scope).toBe('read'); // 'admin' silently removed
+      expect(newTokens.scope).toBe("read"); // 'admin' silently removed
     });
 
-    it('should return full grant scopes when no scope param on refresh', async () => {
+    it("should return full grant scopes when no scope param on refresh", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'refresh_token');
-      params.append('refresh_token', refreshToken);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "refresh_token");
+      params.append("refresh_token", refreshToken);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
       // No scope param
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const refreshResponse = await oauthProvider.fetch(refreshRequest, mockEnv, mockCtx);
       expect(refreshResponse.status).toBe(200);
 
       const newTokens = await refreshResponse.json<any>();
-      expect(newTokens.scope).toBe('read write'); // Full grant scopes
+      expect(newTokens.scope).toBe("read write"); // Full grant scopes
     });
   });
 
-  describe('Token Exchange Flow', () => {
+  describe("Token Exchange Flow", () => {
     let clientId: string;
     let clientSecret: string;
     let accessToken: string;
@@ -1839,16 +1900,16 @@ describe('OAuthProvider', () => {
     async function getAccessToken() {
       // Create the original client (the one that got the token)
       const originalClientData = {
-        redirect_uris: ['https://original.example.com/callback'],
-        client_name: 'Original Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://original.example.com/callback"],
+        client_name: "Original Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest1 = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(originalClientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(originalClientData),
       );
 
       const registerResponse1 = await oauthProvider.fetch(registerRequest1, mockEnv, mockCtx);
@@ -1859,27 +1920,27 @@ describe('OAuthProvider', () => {
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${originalClientId}` +
-          `&redirect_uri=${encodeURIComponent('https://original.example.com/callback')}` +
-          `&scope=read%20write%20admin&state=xyz123`
+          `&redirect_uri=${encodeURIComponent("https://original.example.com/callback")}` +
+          `&scope=read%20write%20admin&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', 'https://original.example.com/callback');
-      params.append('client_id', originalClientId);
-      params.append('client_secret', originalClientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", "https://original.example.com/callback");
+      params.append("client_id", originalClientId);
+      params.append("client_secret", originalClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -1890,16 +1951,16 @@ describe('OAuthProvider', () => {
     // Helper to create a different client (the one making the exchange request)
     async function createExchangeClient() {
       const clientData = {
-        redirect_uris: ['https://exchange.example.com/callback'],
-        client_name: 'Exchange Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://exchange.example.com/callback"],
+        client_name: "Exchange Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
@@ -1913,21 +1974,21 @@ describe('OAuthProvider', () => {
       await createExchangeClient();
     });
 
-    it('should exchange an access token for a new one via HTTP endpoint', async () => {
+    it("should exchange an access token for a new one via HTTP endpoint", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token', accessToken);
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token", accessToken);
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -1937,42 +1998,42 @@ describe('OAuthProvider', () => {
       const newTokens = await exchangeResponse.json<any>();
       expect(newTokens.access_token).toBeDefined();
       expect(newTokens.access_token).not.toBe(accessToken); // Should be a new token
-      expect(newTokens.token_type).toBe('bearer');
-      expect(newTokens.issued_token_type).toBe('urn:ietf:params:oauth:token-type:access_token');
+      expect(newTokens.token_type).toBe("bearer");
+      expect(newTokens.issued_token_type).toBe("urn:ietf:params:oauth:token-type:access_token");
       expect(newTokens.expires_in).toBeDefined();
-      expect(newTokens.scope).toBe('read write admin'); // Should preserve original scopes
+      expect(newTokens.scope).toBe("read write admin"); // Should preserve original scopes
 
       // Verify new token works
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${newTokens.access_token}`,
       });
       const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
       expect(apiResponse.status).toBe(200);
 
       // Verify original token still works
-      const originalApiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const originalApiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
       const originalApiResponse = await oauthProvider.fetch(originalApiRequest, mockEnv, mockCtx);
       expect(originalApiResponse.status).toBe(200);
     });
 
-    it('should exchange token with narrowed scopes', async () => {
+    it("should exchange token with narrowed scopes", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token', accessToken);
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('scope', 'read write'); // Narrow from 'read write admin'
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token", accessToken);
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("scope", "read write"); // Narrow from 'read write admin'
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -1980,25 +2041,25 @@ describe('OAuthProvider', () => {
       expect(exchangeResponse.status).toBe(200);
 
       const newTokens = await exchangeResponse.json<any>();
-      expect(newTokens.scope).toBe('read write'); // Should have narrowed scopes
+      expect(newTokens.scope).toBe("read write"); // Should have narrowed scopes
     });
 
-    it('should silently remove invalid scopes from token exchange', async () => {
+    it("should silently remove invalid scopes from token exchange", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token', accessToken);
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('scope', 'read write admin delete'); // 'delete' not in original, should be silently removed
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token", accessToken);
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("scope", "read write admin delete"); // 'delete' not in original, should be silently removed
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2007,34 +2068,34 @@ describe('OAuthProvider', () => {
 
       const newTokens = await exchangeResponse.json<any>();
       // Should return only valid scopes, invalid 'delete' scope should be silently removed
-      expect(newTokens.scope).toBe('read write admin');
+      expect(newTokens.scope).toBe("read write admin");
     });
 
-    it('should exchange token with different audience/resource', async () => {
+    it("should exchange token with different audience/resource", async () => {
       // First, get a token with a resource
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${originalClientId}` +
-          `&redirect_uri=${encodeURIComponent('https://original.example.com/callback')}` +
-          `&scope=read%20write&resource=${encodeURIComponent('https://api1.example.com')}` +
-          `&resource=${encodeURIComponent('https://api2.example.com')}&state=xyz123`
+          `&redirect_uri=${encodeURIComponent("https://original.example.com/callback")}` +
+          `&scope=read%20write&resource=${encodeURIComponent("https://api1.example.com")}` +
+          `&resource=${encodeURIComponent("https://api2.example.com")}&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       const params1 = new URLSearchParams();
-      params1.append('grant_type', 'authorization_code');
-      params1.append('code', code);
-      params1.append('redirect_uri', 'https://original.example.com/callback');
-      params1.append('client_id', originalClientId);
-      params1.append('client_secret', originalClientSecret);
+      params1.append("grant_type", "authorization_code");
+      params1.append("code", code);
+      params1.append("redirect_uri", "https://original.example.com/callback");
+      params1.append("client_id", originalClientId);
+      params1.append("client_secret", originalClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params1.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params1.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2043,20 +2104,20 @@ describe('OAuthProvider', () => {
 
       // Now exchange with a narrowed resource
       const params2 = new URLSearchParams();
-      params2.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params2.append('subject_token', tokenWithResource);
-      params2.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params2.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params2.append('resource', 'https://api1.example.com'); // Narrow to one resource
+      params2.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params2.append("subject_token", tokenWithResource);
+      params2.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params2.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params2.append("resource", "https://api1.example.com"); // Narrow to one resource
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params2.toString()
+        params2.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2064,33 +2125,33 @@ describe('OAuthProvider', () => {
       expect(exchangeResponse.status).toBe(200);
 
       const newTokens = await exchangeResponse.json<any>();
-      expect(newTokens.resource).toBe('https://api1.example.com');
+      expect(newTokens.resource).toBe("https://api1.example.com");
     });
 
-    it('should reject token exchange with invalid resource', async () => {
+    it("should reject token exchange with invalid resource", async () => {
       // Get a token with a resource
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${originalClientId}` +
-          `&redirect_uri=${encodeURIComponent('https://original.example.com/callback')}` +
-          `&scope=read%20write&resource=${encodeURIComponent('https://api1.example.com')}&state=xyz123`
+          `&redirect_uri=${encodeURIComponent("https://original.example.com/callback")}` +
+          `&scope=read%20write&resource=${encodeURIComponent("https://api1.example.com")}&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       const params1 = new URLSearchParams();
-      params1.append('grant_type', 'authorization_code');
-      params1.append('code', code);
-      params1.append('redirect_uri', 'https://original.example.com/callback');
-      params1.append('client_id', originalClientId);
-      params1.append('client_secret', originalClientSecret);
+      params1.append("grant_type", "authorization_code");
+      params1.append("code", code);
+      params1.append("redirect_uri", "https://original.example.com/callback");
+      params1.append("client_id", originalClientId);
+      params1.append("client_secret", originalClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params1.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params1.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2099,20 +2160,20 @@ describe('OAuthProvider', () => {
 
       // Try to exchange with a resource not in the original grant
       const params2 = new URLSearchParams();
-      params2.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params2.append('subject_token', tokenWithResource);
-      params2.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params2.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params2.append('resource', 'https://api2.example.com'); // Not in original grant
+      params2.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params2.append("subject_token", tokenWithResource);
+      params2.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params2.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params2.append("resource", "https://api2.example.com"); // Not in original grant
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params2.toString()
+        params2.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2120,25 +2181,25 @@ describe('OAuthProvider', () => {
       expect(exchangeResponse.status).toBe(400);
 
       const error = await exchangeResponse.json<any>();
-      expect(error.error).toBe('invalid_target');
+      expect(error.error).toBe("invalid_target");
     });
 
-    it('should exchange token with shorter TTL', async () => {
+    it("should exchange token with shorter TTL", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token', accessToken);
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('expires_in', '1800'); // 30 minutes instead of default 1 hour
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token", accessToken);
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("expires_in", "1800"); // 30 minutes instead of default 1 hour
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2149,21 +2210,21 @@ describe('OAuthProvider', () => {
       expect(newTokens.expires_in).toBe(1800);
     });
 
-    it('should reject token exchange with invalid subject token', async () => {
+    it("should reject token exchange with invalid subject token", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token', 'invalid:token:here');
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token", "invalid:token:here");
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2171,23 +2232,23 @@ describe('OAuthProvider', () => {
       expect(exchangeResponse.status).toBe(400);
 
       const error = await exchangeResponse.json<any>();
-      expect(error.error).toBe('invalid_grant');
+      expect(error.error).toBe("invalid_grant");
     });
 
-    it('should reject token exchange without subject_token', async () => {
+    it("should reject token exchange without subject_token", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2195,24 +2256,24 @@ describe('OAuthProvider', () => {
       expect(exchangeResponse.status).toBe(400);
 
       const error = await exchangeResponse.json<any>();
-      expect(error.error).toBe('invalid_request');
+      expect(error.error).toBe("invalid_request");
     });
 
-    it('should reject token exchange with unsupported subject_token_type', async () => {
+    it("should reject token exchange with unsupported subject_token_type", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token', accessToken);
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:refresh_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token", accessToken);
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:refresh_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2220,24 +2281,24 @@ describe('OAuthProvider', () => {
       expect(exchangeResponse.status).toBe(400);
 
       const error = await exchangeResponse.json<any>();
-      expect(error.error).toBe('invalid_request');
+      expect(error.error).toBe("invalid_request");
     });
 
-    it('should reject token exchange with unsupported requested_token_type', async () => {
+    it("should reject token exchange with unsupported requested_token_type", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params.append('subject_token', accessToken);
-      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:refresh_token');
+      params.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params.append("subject_token", accessToken);
+      params.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params.append("requested_token_type", "urn:ietf:params:oauth:token-type:refresh_token");
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params.toString()
+        params.toString(),
       );
 
       const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
@@ -2245,10 +2306,10 @@ describe('OAuthProvider', () => {
       expect(exchangeResponse.status).toBe(400);
 
       const error = await exchangeResponse.json<any>();
-      expect(error.error).toBe('invalid_request');
+      expect(error.error).toBe("invalid_request");
     });
 
-    it('should exchange token via OAuthHelpers.exchangeToken', async () => {
+    it("should exchange token via OAuthHelpers.exchangeToken", async () => {
       const helpers = mockEnv.OAUTH_PROVIDER as OAuthHelpers;
 
       const newToken = await helpers.exchangeToken({
@@ -2257,46 +2318,46 @@ describe('OAuthProvider', () => {
 
       expect(newToken.access_token).toBeDefined();
       expect(newToken.access_token).not.toBe(accessToken);
-      expect(newToken.token_type).toBe('bearer');
+      expect(newToken.token_type).toBe("bearer");
       expect(newToken.expires_in).toBeDefined();
     });
 
-    it('should exchange token via OAuthHelpers with narrowed scopes', async () => {
+    it("should exchange token via OAuthHelpers with narrowed scopes", async () => {
       const helpers = mockEnv.OAUTH_PROVIDER as OAuthHelpers;
 
       const newToken = await helpers.exchangeToken({
         subjectToken: accessToken,
-        scope: ['read', 'write'],
+        scope: ["read", "write"],
       });
 
-      expect(newToken.scope).toBe('read write');
+      expect(newToken.scope).toBe("read write");
     });
 
-    it('should exchange token via OAuthHelpers with different audience', async () => {
+    it("should exchange token via OAuthHelpers with different audience", async () => {
       // Get a token with resource first
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${originalClientId}` +
-          `&redirect_uri=${encodeURIComponent('https://original.example.com/callback')}` +
-          `&scope=read%20write&resource=${encodeURIComponent('https://api1.example.com')}` +
-          `&resource=${encodeURIComponent('https://api2.example.com')}&state=xyz123`
+          `&redirect_uri=${encodeURIComponent("https://original.example.com/callback")}` +
+          `&scope=read%20write&resource=${encodeURIComponent("https://api1.example.com")}` +
+          `&resource=${encodeURIComponent("https://api2.example.com")}&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', 'https://original.example.com/callback');
-      params.append('client_id', originalClientId);
-      params.append('client_secret', originalClientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", "https://original.example.com/callback");
+      params.append("client_id", originalClientId);
+      params.append("client_secret", originalClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2307,13 +2368,13 @@ describe('OAuthProvider', () => {
 
       const newToken = await helpers.exchangeToken({
         subjectToken: tokenWithResource,
-        aud: 'https://api1.example.com',
+        aud: "https://api1.example.com",
       });
 
-      expect(newToken.resource).toBe('https://api1.example.com');
+      expect(newToken.resource).toBe("https://api1.example.com");
     });
 
-    it('should exchange token via OAuthHelpers with custom TTL', async () => {
+    it("should exchange token via OAuthHelpers with custom TTL", async () => {
       const helpers = mockEnv.OAUTH_PROVIDER as OAuthHelpers;
 
       const newToken = await helpers.exchangeToken({
@@ -2324,39 +2385,39 @@ describe('OAuthProvider', () => {
       expect(newToken.expires_in).toBe(1800);
     });
 
-    it('should reject OAuthHelpers.exchangeToken with invalid token', async () => {
+    it("should reject OAuthHelpers.exchangeToken with invalid token", async () => {
       const helpers = mockEnv.OAUTH_PROVIDER as OAuthHelpers;
 
       await expect(
         helpers.exchangeToken({
-          subjectToken: 'invalid:token:here',
-        })
+          subjectToken: "invalid:token:here",
+        }),
       ).rejects.toThrow();
     });
 
-    it('should silently remove invalid scopes from OAuthHelpers.exchangeToken', async () => {
+    it("should silently remove invalid scopes from OAuthHelpers.exchangeToken", async () => {
       const helpers = mockEnv.OAUTH_PROVIDER as OAuthHelpers;
 
       const tokenResponse = await helpers.exchangeToken({
         subjectToken: accessToken,
-        scope: ['read', 'write', 'admin', 'delete'], // 'delete' not in original, should be silently removed
+        scope: ["read", "write", "admin", "delete"], // 'delete' not in original, should be silently removed
       });
 
       // Should return only valid scopes, invalid 'delete' scope should be silently removed
-      expect(tokenResponse.scope).toBe('read write admin');
+      expect(tokenResponse.scope).toBe("read write admin");
     });
 
-    it('should call tokenExchangeCallback during token exchange', async () => {
+    it("should call tokenExchangeCallback during token exchange", async () => {
       let callbackInvoked = false;
       let callbackOptions: any = null;
 
       const providerWithCallback = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         allowTokenExchangeGrant: true,
         tokenExchangeCallback: async (options) => {
           callbackInvoked = true;
@@ -2370,26 +2431,26 @@ describe('OAuthProvider', () => {
       // Get a token with this provider
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${originalClientId}` +
-          `&redirect_uri=${encodeURIComponent('https://original.example.com/callback')}` +
-          `&scope=read%20write&state=xyz123`
+          `&redirect_uri=${encodeURIComponent("https://original.example.com/callback")}` +
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithCallback.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       const params1 = new URLSearchParams();
-      params1.append('grant_type', 'authorization_code');
-      params1.append('code', code);
-      params1.append('redirect_uri', 'https://original.example.com/callback');
-      params1.append('client_id', originalClientId);
-      params1.append('client_secret', originalClientSecret);
+      params1.append("grant_type", "authorization_code");
+      params1.append("code", code);
+      params1.append("redirect_uri", "https://original.example.com/callback");
+      params1.append("client_id", originalClientId);
+      params1.append("client_secret", originalClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params1.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params1.toString(),
       );
 
       const tokenResponse = await providerWithCallback.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2402,32 +2463,32 @@ describe('OAuthProvider', () => {
 
       // Now exchange it
       const params2 = new URLSearchParams();
-      params2.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      params2.append('subject_token', tokenToExchange);
-      params2.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      params2.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params2.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      params2.append("subject_token", tokenToExchange);
+      params2.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      params2.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
 
       const exchangeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        params2.toString()
+        params2.toString(),
       );
 
       await providerWithCallback.fetch(exchangeRequest, mockEnv, mockCtx);
 
       expect(callbackInvoked).toBe(true);
       expect(callbackOptions).toBeDefined();
-      expect(callbackOptions.grantType).toBe('urn:ietf:params:oauth:grant-type:token-exchange');
-      expect(callbackOptions.scope).toEqual(['read', 'write']); // Grant scopes
-      expect(callbackOptions.requestedScope).toEqual(['read', 'write']); // Requested scopes (no downscoping in this test)
+      expect(callbackOptions.grantType).toBe("urn:ietf:params:oauth:grant-type:token-exchange");
+      expect(callbackOptions.scope).toEqual(["read", "write"]); // Grant scopes
+      expect(callbackOptions.requestedScope).toEqual(["read", "write"]); // Requested scopes (no downscoping in this test)
     });
   });
 
-  describe('Refresh Token TTL', () => {
+  describe("Refresh Token TTL", () => {
     let clientId: string;
     let clientSecret: string;
     let redirectUri: string;
@@ -2435,34 +2496,34 @@ describe('OAuthProvider', () => {
     beforeEach(async () => {
       // Create a client for testing
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       clientId = client.client_id;
       clientSecret = client.client_secret;
-      redirectUri = 'https://client.example.com/callback';
+      redirectUri = "https://client.example.com/callback";
     });
 
-    it('should not issue refresh token when TTL is 0', async () => {
+    it("should not issue refresh token when TTL is 0", async () => {
       // Create provider with refreshTokenTTL = 0 (no refresh tokens)
       const providerNoRefresh = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         accessTokenTTL: 3600,
         refreshTokenTTL: 0, // No refresh tokens
       });
@@ -2471,26 +2532,26 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerNoRefresh.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await providerNoRefresh.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2502,19 +2563,19 @@ describe('OAuthProvider', () => {
       expect(tokens.refresh_token).toBeUndefined();
     });
 
-    it('should allow callback to enable refresh tokens when globally disabled', async () => {
+    it("should allow callback to enable refresh tokens when globally disabled", async () => {
       // Create provider with globally disabled refresh tokens, but callback can enable them
       const providerWithCallback = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         accessTokenTTL: 3600,
         refreshTokenTTL: 0, // Globally disabled
         tokenExchangeCallback: async (options) => {
-          if (options.grantType === 'authorization_code') {
+          if (options.grantType === "authorization_code") {
             // Enable refresh tokens for this specific case
             return {
               newProps: { ...options.props, specialUser: true },
@@ -2529,26 +2590,26 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithCallback.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await providerWithCallback.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2560,16 +2621,16 @@ describe('OAuthProvider', () => {
       expect(tokens.refresh_token).toBeDefined(); // Callback override worked!
 
       // Verify the grant has the correct TTL
-      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       const grantKey = grantEntries.keys[0].name;
-      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
       expect(grant.expiresAt).toBeDefined();
       const now = Math.floor(Date.now() / 1000);
       expect(grant.expiresAt).toBeGreaterThan(now);
       expect(grant.expiresAt).toBeLessThanOrEqual(now + 7200);
 
       // Verify props were updated
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${tokens.access_token}`,
       });
       const apiResponse = await providerWithCallback.fetch(apiRequest, mockEnv, mockCtx);
@@ -2577,15 +2638,15 @@ describe('OAuthProvider', () => {
       expect(apiData.user.specialUser).toBe(true);
     });
 
-    it('should set refresh token expiration when global TTL is configured', async () => {
+    it("should set refresh token expiration when global TTL is configured", async () => {
       // Create provider with refresh token TTL
       const providerWithTTL = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         accessTokenTTL: 3600,
         refreshTokenTTL: 7200, // 2 hours
       });
@@ -2594,35 +2655,35 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithTTL.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await providerWithTTL.fetch(tokenRequest, mockEnv, mockCtx);
       const tokens = await tokenResponse.json<any>();
 
       // Check that the grant has the refresh token expiration set
-      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       const grantKey = grantEntries.keys[0].name;
-      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
 
       expect(grant.expiresAt).toBeDefined();
       const now = Math.floor(Date.now() / 1000);
@@ -2630,15 +2691,15 @@ describe('OAuthProvider', () => {
       expect(grant.expiresAt).toBeLessThanOrEqual(now + 7200);
     });
 
-    it('should reject expired refresh tokens', async () => {
+    it("should reject expired refresh tokens", async () => {
       // Create provider with very short refresh token TTL
       const providerWithShortTTL = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         accessTokenTTL: 3600,
         refreshTokenTTL: 1, // 1 second - very short for testing
       });
@@ -2647,26 +2708,26 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithShortTTL.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await providerWithShortTTL.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2678,39 +2739,39 @@ describe('OAuthProvider', () => {
 
       // Try to use the expired refresh token
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', refreshToken);
-      refreshParams.append('client_id', clientId);
-      refreshParams.append('client_secret', clientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", refreshToken);
+      refreshParams.append("client_id", clientId);
+      refreshParams.append("client_secret", clientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
       const refreshResponse = await providerWithShortTTL.fetch(refreshRequest, mockEnv, mockCtx);
 
       expect(refreshResponse.status).toBe(400);
       const error = await refreshResponse.json<any>();
-      expect(error.error).toBe('invalid_grant');
-      expect(error.error_description).toBe('Refresh token has expired');
+      expect(error.error).toBe("invalid_grant");
+      expect(error.error_description).toBe("Refresh token has expired");
     });
 
-    it('should allow overriding refresh token TTL via callback', async () => {
+    it("should allow overriding refresh token TTL via callback", async () => {
       // Create provider with callback that sets custom TTL
       const providerWithCallback = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         accessTokenTTL: 3600,
         refreshTokenTTL: 86400, // Default: 24 hours
         tokenExchangeCallback: async (options) => {
-          if (options.grantType === 'authorization_code') {
+          if (options.grantType === "authorization_code") {
             // Set shorter TTL for authorization code exchange
             return { refreshTokenTTL: 3600 }; // 1 hour
           }
@@ -2722,35 +2783,35 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithCallback.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await providerWithCallback.fetch(tokenRequest, mockEnv, mockCtx);
       await tokenResponse.json<any>();
 
       // Check that the grant has the custom TTL
-      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       const grantKey = grantEntries.keys[0].name;
-      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
 
       expect(grant.expiresAt).toBeDefined();
       const now = Math.floor(Date.now() / 1000);
@@ -2759,15 +2820,15 @@ describe('OAuthProvider', () => {
       expect(grant.expiresAt).toBeGreaterThan(now + 3500); // Allow some margin
     });
 
-    it('should preserve refresh token expiration during token rotation', async () => {
+    it("should preserve refresh token expiration during token rotation", async () => {
       // Create provider with refresh token TTL
       const providerWithTTL = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         accessTokenTTL: 3600,
         refreshTokenTTL: 7200, // 2 hours
       });
@@ -2776,71 +2837,71 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithTTL.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await providerWithTTL.fetch(tokenRequest, mockEnv, mockCtx);
       const tokens = await tokenResponse.json<any>();
 
       // Get the original expiration time
-      const grantEntries1 = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantEntries1 = await mockEnv.OAUTH_KV.list({ prefix: "grant:" });
       const grantKey = grantEntries1.keys[0].name;
-      const grant1 = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant1 = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
       const originalExpiration = grant1.expiresAt;
 
       // Do a refresh without specifying new TTL
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', tokens.refresh_token);
-      refreshParams.append('client_id', clientId);
-      refreshParams.append('client_secret', clientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", tokens.refresh_token);
+      refreshParams.append("client_id", clientId);
+      refreshParams.append("client_secret", clientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
       const refreshResponse = await providerWithTTL.fetch(refreshRequest, mockEnv, mockCtx);
       expect(refreshResponse.status).toBe(200);
 
       // Check that expiration is preserved
-      const grant2 = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      const grant2 = await mockEnv.OAUTH_KV.get(grantKey, { type: "json" });
       expect(grant2.expiresAt).toBe(originalExpiration);
     });
 
-    it('should reject callback attempts to change TTL during refresh', async () => {
+    it("should reject callback attempts to change TTL during refresh", async () => {
       // Create provider with callback that tries to change TTL during refresh
       const providerWithBadCallback = new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
         accessTokenTTL: 3600,
         refreshTokenTTL: 7200,
         tokenExchangeCallback: async (options) => {
-          if (options.grantType === 'refresh_token') {
+          if (options.grantType === "refresh_token") {
             // This should cause an error
             return { refreshTokenTTL: 3600 };
           }
@@ -2852,25 +2913,25 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await providerWithBadCallback.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       const tokenParams = new URLSearchParams();
-      tokenParams.append('grant_type', 'authorization_code');
-      tokenParams.append('code', code);
-      tokenParams.append('redirect_uri', redirectUri);
-      tokenParams.append('client_id', clientId);
-      tokenParams.append('client_secret', clientSecret);
+      tokenParams.append("grant_type", "authorization_code");
+      tokenParams.append("code", code);
+      tokenParams.append("redirect_uri", redirectUri);
+      tokenParams.append("client_id", clientId);
+      tokenParams.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        tokenParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        tokenParams.toString(),
       );
 
       const tokenResponse = await providerWithBadCallback.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2879,76 +2940,78 @@ describe('OAuthProvider', () => {
 
       // Try to refresh - this should return an error
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', tokens.refresh_token);
-      refreshParams.append('client_id', clientId);
-      refreshParams.append('client_secret', clientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", tokens.refresh_token);
+      refreshParams.append("client_id", clientId);
+      refreshParams.append("client_secret", clientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
       const refreshResponse = await providerWithBadCallback.fetch(refreshRequest, mockEnv, mockCtx);
       expect(refreshResponse.status).toBe(400);
 
       const error = await refreshResponse.json<any>();
-      expect(error.error).toBe('invalid_request');
-      expect(error.error_description).toBe('refreshTokenTTL cannot be changed during refresh token exchange');
+      expect(error.error).toBe("invalid_request");
+      expect(error.error_description).toBe(
+        "refreshTokenTTL cannot be changed during refresh token exchange",
+      );
     });
   });
 
-  describe('Token Validation and API Access', () => {
+  describe("Token Validation and API Access", () => {
     let accessToken: string;
 
     // Helper to get through authorization and token exchange to get an access token
     async function getAccessToken() {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -2960,33 +3023,33 @@ describe('OAuthProvider', () => {
       await getAccessToken();
     });
 
-    it('should reject API requests without a token', async () => {
-      const apiRequest = createMockRequest('https://example.com/api/test');
+    it("should reject API requests without a token", async () => {
+      const apiRequest = createMockRequest("https://example.com/api/test");
 
       const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
 
       expect(apiResponse.status).toBe(401);
 
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should include resource_metadata in WWW-Authenticate header on 401 (RFC 9728)', async () => {
-      const apiRequest = createMockRequest('https://example.com/api/test');
+    it("should include resource_metadata in WWW-Authenticate header on 401 (RFC 9728)", async () => {
+      const apiRequest = createMockRequest("https://example.com/api/test");
 
       const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
 
       expect(apiResponse.status).toBe(401);
 
-      const wwwAuth = apiResponse.headers.get('WWW-Authenticate');
+      const wwwAuth = apiResponse.headers.get("WWW-Authenticate");
       expect(wwwAuth).toBe(
-        'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token"'
+        'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token"',
       );
     });
 
-    it('should reject API requests with an invalid token', async () => {
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer invalid-token',
+    it("should reject API requests with an invalid token", async () => {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer invalid-token",
       });
 
       const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
@@ -2994,11 +3057,11 @@ describe('OAuthProvider', () => {
       expect(apiResponse.status).toBe(401);
 
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should accept valid token and pass props to API handler', async () => {
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+    it("should accept valid token and pass props to API handler", async () => {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3008,65 +3071,65 @@ describe('OAuthProvider', () => {
 
       const data = await apiResponse.json<any>();
       expect(data.success).toBe(true);
-      expect(data.user).toEqual({ userId: 'test-user-123', username: 'TestUser' });
+      expect(data.user).toEqual({ userId: "test-user-123", username: "TestUser" });
     });
   });
 
-  describe('Audience Validation (RFC 7519 Section 4.1.3)', () => {
+  describe("Audience Validation (RFC 7519 Section 4.1.3)", () => {
     // Helper to get access token with resource parameter (RFC 8707)
     async function getAccessTokenWithResource(resource?: string | string[]) {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens with resource parameter (RFC 8707)
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
       if (resource !== undefined) {
         // RFC 8707: multiple resources are sent as separate parameters
         if (Array.isArray(resource)) {
-          resource.forEach((r) => params.append('resource', r));
+          resource.forEach((r) => params.append("resource", r));
         } else {
-          params.append('resource', resource);
+          params.append("resource", resource);
         }
       }
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -3074,10 +3137,10 @@ describe('OAuthProvider', () => {
       return tokens.access_token;
     }
 
-    it('should accept token with matching audience (string)', async () => {
-      const accessToken = await getAccessTokenWithResource('https://example.com');
+    it("should accept token with matching audience (string)", async () => {
+      const accessToken = await getAccessTokenWithResource("https://example.com");
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3086,13 +3149,16 @@ describe('OAuthProvider', () => {
       expect(apiResponse.status).toBe(200);
       const data = await apiResponse.json<any>();
       expect(data.success).toBe(true);
-      expect(data.user).toEqual({ userId: 'test-user-123', username: 'TestUser' });
+      expect(data.user).toEqual({ userId: "test-user-123", username: "TestUser" });
     });
 
-    it('should accept token with matching audience in array', async () => {
-      const accessToken = await getAccessTokenWithResource(['https://example.com', 'https://other.example.com']);
+    it("should accept token with matching audience in array", async () => {
+      const accessToken = await getAccessTokenWithResource([
+        "https://example.com",
+        "https://other.example.com",
+      ]);
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3103,12 +3169,15 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should accept token with multiple resources at all specified resource servers (E2E)', async () => {
+    it("should accept token with multiple resources at all specified resource servers (E2E)", async () => {
       // Request token for two resource servers
-      const accessToken = await getAccessTokenWithResource(['https://api1.example.com', 'https://api2.example.com']);
+      const accessToken = await getAccessTokenWithResource([
+        "https://api1.example.com",
+        "https://api2.example.com",
+      ]);
 
       // Should work at first resource server
-      const api1Request = createMockRequest('https://api1.example.com/api/test', 'GET', {
+      const api1Request = createMockRequest("https://api1.example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
       const api1Response = await oauthProvider.fetch(api1Request, mockEnv, mockCtx);
@@ -3117,7 +3186,7 @@ describe('OAuthProvider', () => {
       expect(api1Data.success).toBe(true);
 
       // Should also work at second resource server
-      const api2Request = createMockRequest('https://api2.example.com/api/test', 'GET', {
+      const api2Request = createMockRequest("https://api2.example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
       const api2Response = await oauthProvider.fetch(api2Request, mockEnv, mockCtx);
@@ -3126,19 +3195,19 @@ describe('OAuthProvider', () => {
       expect(api2Data.success).toBe(true);
 
       // Should fail at third resource server not in audience
-      const api3Request = createMockRequest('https://api3.example.com/api/test', 'GET', {
+      const api3Request = createMockRequest("https://api3.example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
       const api3Response = await oauthProvider.fetch(api3Request, mockEnv, mockCtx);
       expect(api3Response.status).toBe(401);
       const api3Error = await api3Response.json<{ error: string }>();
-      expect(api3Error.error).toBe('invalid_token');
+      expect(api3Error.error).toBe("invalid_token");
     });
 
-    it('should accept token without audience claim (backward compatibility)', async () => {
+    it("should accept token without audience claim (backward compatibility)", async () => {
       const accessToken = await getAccessTokenWithResource(undefined);
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3149,10 +3218,10 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should reject token with wrong audience (HTTP 401)', async () => {
-      const accessToken = await getAccessTokenWithResource('https://wrong-server.com');
+    it("should reject token with wrong audience (HTTP 401)", async () => {
+      const accessToken = await getAccessTokenWithResource("https://wrong-server.com");
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3160,21 +3229,26 @@ describe('OAuthProvider', () => {
 
       expect(apiResponse.status).toBe(401);
 
-      const wwwAuth = apiResponse.headers.get('WWW-Authenticate');
-      expect(wwwAuth).toContain('Bearer');
-      expect(wwwAuth).toContain('resource_metadata="https://example.com/.well-known/oauth-protected-resource"');
+      const wwwAuth = apiResponse.headers.get("WWW-Authenticate");
+      expect(wwwAuth).toContain("Bearer");
+      expect(wwwAuth).toContain(
+        'resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+      );
       expect(wwwAuth).toContain('error="invalid_token"');
-      expect(wwwAuth).toContain('Invalid audience');
+      expect(wwwAuth).toContain("Invalid audience");
 
       const error = await apiResponse.json<{ error: string; error_description: string }>();
-      expect(error.error).toBe('invalid_token');
-      expect(error.error_description).toContain('audience');
+      expect(error.error).toBe("invalid_token");
+      expect(error.error_description).toContain("audience");
     });
 
-    it('should reject token when resource server not in audience array', async () => {
-      const accessToken = await getAccessTokenWithResource(['https://other1.com', 'https://other2.com']);
+    it("should reject token when resource server not in audience array", async () => {
+      const accessToken = await getAccessTokenWithResource([
+        "https://other1.com",
+        "https://other2.com",
+      ]);
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3183,13 +3257,13 @@ describe('OAuthProvider', () => {
       expect(apiResponse.status).toBe(401);
 
       const error = await apiResponse.json<{ error: string; error_description: string }>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should reject token with audience mismatch on different host', async () => {
-      const accessToken = await getAccessTokenWithResource('https://api.example.com');
+    it("should reject token with audience mismatch on different host", async () => {
+      const accessToken = await getAccessTokenWithResource("https://api.example.com");
 
-      const apiRequest = createMockRequest('https://api2.example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://api2.example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3197,13 +3271,13 @@ describe('OAuthProvider', () => {
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<{ error: string; error_description: string }>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should reject token with audience mismatch on different protocol', async () => {
-      const accessToken = await getAccessTokenWithResource('http://example.com');
+    it("should reject token with audience mismatch on different protocol", async () => {
+      const accessToken = await getAccessTokenWithResource("http://example.com");
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3211,15 +3285,15 @@ describe('OAuthProvider', () => {
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<{ error: string; error_description: string }>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should reject token with different port', async () => {
+    it("should reject token with different port", async () => {
       // Token issued for port 8080
-      const accessToken = await getAccessTokenWithResource('https://example.com:8080');
+      const accessToken = await getAccessTokenWithResource("https://example.com:8080");
 
       // Request to default port (443)
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3227,15 +3301,15 @@ describe('OAuthProvider', () => {
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should reject token when ports do not match', async () => {
+    it("should reject token when ports do not match", async () => {
       // Token issued for default port
-      const accessToken = await getAccessTokenWithResource('https://example.com');
+      const accessToken = await getAccessTokenWithResource("https://example.com");
 
       // Request to explicit port 8443
-      const apiRequest = createMockRequest('https://example.com:8443/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com:8443/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3243,13 +3317,13 @@ describe('OAuthProvider', () => {
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should accept token with IPv6 resource URI', async () => {
-      const accessToken = await getAccessTokenWithResource('https://[2001:db8::1]:8080');
+    it("should accept token with IPv6 resource URI", async () => {
+      const accessToken = await getAccessTokenWithResource("https://[2001:db8::1]:8080");
 
-      const apiRequest = createMockRequest('https://[2001:db8::1]:8080/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://[2001:db8::1]:8080/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3260,219 +3334,219 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should reject token request with resource containing fragment (RFC 8707)', async () => {
+    it("should reject token request with resource containing fragment (RFC 8707)", async () => {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Try to exchange with resource containing fragment
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('resource', 'https://example.com/api#fragment');
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("resource", "https://example.com/api#fragment");
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
 
       expect(tokenResponse.status).toBe(400);
       const error = await tokenResponse.json<any>();
-      expect(error.error).toBe('invalid_target');
-      expect(error.error_description).toContain('fragment');
+      expect(error.error).toBe("invalid_target");
+      expect(error.error_description).toContain("fragment");
     });
 
-    it('should reject token request with javascript: resource scheme', async () => {
+    it("should reject token request with javascript: resource scheme", async () => {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Try to exchange with javascript: resource
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('resource', 'javascript:alert(1)');
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("resource", "javascript:alert(1)");
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
 
       expect(tokenResponse.status).toBe(400);
       const error = await tokenResponse.json<any>();
-      expect(error.error).toBe('invalid_target');
+      expect(error.error).toBe("invalid_target");
     });
 
-    it('should reject token request with relative URI resource', async () => {
+    it("should reject token request with relative URI resource", async () => {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Try to exchange with relative URI resource
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('resource', '/api/resource');
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("resource", "/api/resource");
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
 
       expect(tokenResponse.status).toBe(400);
       const error = await tokenResponse.json<any>();
-      expect(error.error).toBe('invalid_target');
+      expect(error.error).toBe("invalid_target");
     });
 
-    it('should use resource from authorization request when not provided in token request', async () => {
+    it("should use resource from authorization request when not provided in token request", async () => {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code WITH resource parameter
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&resource=${encodeURIComponent('https://api.example.com')}` +
-          `&scope=read%20write&state=xyz123`
+          `&resource=${encodeURIComponent("https://api.example.com")}` +
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange WITHOUT resource parameter in token request
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
       // No resource parameter here!
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -3481,7 +3555,7 @@ describe('OAuthProvider', () => {
       const accessToken = tokens.access_token;
 
       // Use token at the resource server specified in authorization request
-      const apiRequest = createMockRequest('https://api.example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://api.example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3491,28 +3565,28 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should validate audience for external tokens with matching audience', async () => {
+    it("should validate audience for external tokens with matching audience", async () => {
       const externalProvider = new OAuthProvider({
-        apiRoute: ['/api/', 'https://example.com/'],
+        apiRoute: ["/api/", "https://example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'profile'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "profile"],
         resolveExternalToken: async ({ token }) => {
-          if (token === 'external-token-with-audience') {
+          if (token === "external-token-with-audience") {
             return {
-              props: { userId: 'external-user', source: 'external' },
-              audience: 'https://example.com',
+              props: { userId: "external-user", source: "external" },
+              audience: "https://example.com",
             };
           }
           return null;
         },
       });
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer external-token-with-audience',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer external-token-with-audience",
       });
 
       const apiResponse = await externalProvider.fetch(apiRequest, mockEnv, mockCtx);
@@ -3522,44 +3596,44 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should reject external tokens with wrong audience', async () => {
+    it("should reject external tokens with wrong audience", async () => {
       const externalProvider = new OAuthProvider({
-        apiRoute: ['/api/', 'https://example.com/'],
+        apiRoute: ["/api/", "https://example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'profile'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "profile"],
         resolveExternalToken: async ({ token }) => {
-          if (token === 'external-token-wrong-audience') {
+          if (token === "external-token-wrong-audience") {
             return {
-              props: { userId: 'external-user', source: 'external' },
-              audience: 'https://wrong-server.com',
+              props: { userId: "external-user", source: "external" },
+              audience: "https://wrong-server.com",
             };
           }
           return null;
         },
       });
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer external-token-wrong-audience',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer external-token-wrong-audience",
       });
 
       const apiResponse = await externalProvider.fetch(apiRequest, mockEnv, mockCtx);
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
-      expect(error.error_description).toContain('audience');
+      expect(error.error).toBe("invalid_token");
+      expect(error.error_description).toContain("audience");
     });
 
-    it('should accept token with path-aware audience at matching path (RFC 8707)', async () => {
+    it("should accept token with path-aware audience at matching path (RFC 8707)", async () => {
       // Request token with path-specific resource indicator
-      const accessToken = await getAccessTokenWithResource('https://example.com/api/test');
+      const accessToken = await getAccessTokenWithResource("https://example.com/api/test");
 
       // Request to exact matching path should succeed
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3570,10 +3644,10 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should reject token with path-aware audience at different path (RFC 8707)', async () => {
-      const accessToken = await getAccessTokenWithResource('https://example.com/api/test');
+    it("should reject token with path-aware audience at different path (RFC 8707)", async () => {
+      const accessToken = await getAccessTokenWithResource("https://example.com/api/test");
 
-      const apiRequest = createMockRequest('https://example.com/api/other', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/other", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3581,32 +3655,32 @@ describe('OAuthProvider', () => {
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
-      expect(error.error_description).toContain('audience');
+      expect(error.error).toBe("invalid_token");
+      expect(error.error_description).toContain("audience");
     });
 
-    it('should accept external token with path-aware audience at matching path (RFC 8707)', async () => {
+    it("should accept external token with path-aware audience at matching path (RFC 8707)", async () => {
       const externalProvider = new OAuthProvider({
-        apiRoute: ['/api/', 'https://example.com/'],
+        apiRoute: ["/api/", "https://example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'profile'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "profile"],
         resolveExternalToken: async ({ token }) => {
-          if (token === 'external-token-path-audience') {
+          if (token === "external-token-path-audience") {
             return {
-              props: { userId: 'external-user', source: 'external' },
-              audience: 'https://example.com/api/test',
+              props: { userId: "external-user", source: "external" },
+              audience: "https://example.com/api/test",
             };
           }
           return null;
         },
       });
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer external-token-path-audience',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer external-token-path-audience",
       });
 
       const apiResponse = await externalProvider.fetch(apiRequest, mockEnv, mockCtx);
@@ -3616,42 +3690,42 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should reject external token with path-aware audience at different path (RFC 8707)', async () => {
+    it("should reject external token with path-aware audience at different path (RFC 8707)", async () => {
       const externalProvider = new OAuthProvider({
-        apiRoute: ['/api/', 'https://example.com/'],
+        apiRoute: ["/api/", "https://example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'profile'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "profile"],
         resolveExternalToken: async ({ token }) => {
-          if (token === 'external-token-path-mismatch') {
+          if (token === "external-token-path-mismatch") {
             return {
-              props: { userId: 'external-user', source: 'external' },
-              audience: 'https://example.com/api/test',
+              props: { userId: "external-user", source: "external" },
+              audience: "https://example.com/api/test",
             };
           }
           return null;
         },
       });
 
-      const apiRequest = createMockRequest('https://example.com/api/other', 'GET', {
-        Authorization: 'Bearer external-token-path-mismatch',
+      const apiRequest = createMockRequest("https://example.com/api/other", "GET", {
+        Authorization: "Bearer external-token-path-mismatch",
       });
 
       const apiResponse = await externalProvider.fetch(apiRequest, mockEnv, mockCtx);
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
-      expect(error.error_description).toContain('audience');
+      expect(error.error).toBe("invalid_token");
+      expect(error.error_description).toContain("audience");
     });
 
-    it('should allow sub-path access with parent path audience (prefix matching on path boundary)', async () => {
-      const accessToken = await getAccessTokenWithResource('https://example.com/api');
+    it("should allow sub-path access with parent path audience (prefix matching on path boundary)", async () => {
+      const accessToken = await getAccessTokenWithResource("https://example.com/api");
 
-      const apiRequest = createMockRequest('https://example.com/api/admin', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/admin", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3662,12 +3736,12 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should reject access when audience path is a string prefix but not on a path boundary', async () => {
+    it("should reject access when audience path is a string prefix but not on a path boundary", async () => {
       // audience is "/api/test" but request is "/api/testing" — the audience is a string prefix
       // but NOT a path-boundary prefix, so it must be rejected
-      const accessToken = await getAccessTokenWithResource('https://example.com/api/test');
+      const accessToken = await getAccessTokenWithResource("https://example.com/api/test");
 
-      const apiRequest = createMockRequest('https://example.com/api/testing', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/testing", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3675,14 +3749,14 @@ describe('OAuthProvider', () => {
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
-      expect(error.error_description).toContain('audience');
+      expect(error.error).toBe("invalid_token");
+      expect(error.error_description).toContain("audience");
     });
 
-    it('should match path-aware audience when request includes query string', async () => {
-      const accessToken = await getAccessTokenWithResource('https://example.com/api/test');
+    it("should match path-aware audience when request includes query string", async () => {
+      const accessToken = await getAccessTokenWithResource("https://example.com/api/test");
 
-      const apiRequest = createMockRequest('https://example.com/api/test?foo=bar&baz=qux', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test?foo=bar&baz=qux", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3693,10 +3767,10 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
-    it('should accept trailing slash as sub-path of audience (prefix matching)', async () => {
-      const accessToken = await getAccessTokenWithResource('https://example.com/api/test');
+    it("should accept trailing slash as sub-path of audience (prefix matching)", async () => {
+      const accessToken = await getAccessTokenWithResource("https://example.com/api/test");
 
-      const apiRequest = createMockRequest('https://example.com/api/test/', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test/", "GET", {
         Authorization: `Bearer ${accessToken}`,
       });
 
@@ -3708,110 +3782,110 @@ describe('OAuthProvider', () => {
     });
   });
 
-  describe('Resource Parameter Downscoping (RFC 8707)', () => {
-    it('should reject upscoping attempt (requesting resource not in authorization)', async () => {
+  describe("Resource Parameter Downscoping (RFC 8707)", () => {
+    it("should reject upscoping attempt (requesting resource not in authorization)", async () => {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code with resource=https://api1.example.com
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123&resource=https://api1.example.com`
+          `&scope=read%20write&state=xyz123&resource=https://api1.example.com`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Try to exchange with resource=https://api2.example.com (not in authorization!)
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('resource', 'https://api2.example.com'); // Different resource - upscoping!
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("resource", "https://api2.example.com"); // Different resource - upscoping!
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
 
       expect(tokenResponse.status).toBe(400);
       const error = await tokenResponse.json<any>();
-      expect(error.error).toBe('invalid_target');
-      expect(error.error_description).toContain('not included in the authorization request');
+      expect(error.error).toBe("invalid_target");
+      expect(error.error_description).toContain("not included in the authorization request");
     });
 
-    it('should allow downscoping (requesting subset of authorized resources)', async () => {
+    it("should allow downscoping (requesting subset of authorized resources)", async () => {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get an auth code with TWO resources
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&scope=read%20write&state=xyz123` +
-          `&resource=https://api1.example.com&resource=https://api2.example.com`
+          `&resource=https://api1.example.com&resource=https://api2.example.com`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange with only ONE resource (downscoping - subset of original)
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
-      params.append('resource', 'https://api1.example.com'); // Subset - downscoping allowed!
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
+      params.append("resource", "https://api1.example.com"); // Subset - downscoping allowed!
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -3819,241 +3893,261 @@ describe('OAuthProvider', () => {
       expect(tokenResponse.status).toBe(200);
       const tokens = await tokenResponse.json<any>();
       expect(tokens.access_token).toBeDefined();
-      expect(tokens.resource).toBe('https://api1.example.com');
+      expect(tokens.resource).toBe("https://api1.example.com");
     });
   });
 
-  describe('CORS Support', () => {
-    it('should handle CORS preflight for API requests', async () => {
-      const preflightRequest = createMockRequest('https://example.com/api/test', 'OPTIONS', {
-        Origin: 'https://client.example.com',
-        'Access-Control-Request-Method': 'GET',
-        'Access-Control-Request-Headers': 'Authorization',
+  describe("CORS Support", () => {
+    it("should handle CORS preflight for API requests", async () => {
+      const preflightRequest = createMockRequest("https://example.com/api/test", "OPTIONS", {
+        Origin: "https://client.example.com",
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "Authorization",
       });
 
       const preflightResponse = await oauthProvider.fetch(preflightRequest, mockEnv, mockCtx);
 
       expect(preflightResponse.status).toBe(204);
-      expect(preflightResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://client.example.com');
-      expect(preflightResponse.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(preflightResponse.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+      expect(preflightResponse.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://client.example.com",
+      );
+      expect(preflightResponse.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(preflightResponse.headers.get("Access-Control-Allow-Headers")).toContain(
+        "Authorization",
+      );
     });
 
-    it('should add CORS headers to OAuth metadata discovery endpoint', async () => {
-      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server', 'GET', {
-        Origin: 'https://client.example.com',
-      });
+    it("should add CORS headers to OAuth metadata discovery endpoint", async () => {
+      const request = createMockRequest(
+        "https://example.com/.well-known/oauth-authorization-server",
+        "GET",
+        {
+          Origin: "https://client.example.com",
+        },
+      );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://client.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
-      expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://client.example.com",
+      );
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
+      expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
     });
 
-    it('should handle OPTIONS preflight for metadata discovery endpoint', async () => {
+    it("should handle OPTIONS preflight for metadata discovery endpoint", async () => {
       const preflightRequest = createMockRequest(
-        'https://example.com/.well-known/oauth-authorization-server',
-        'OPTIONS',
+        "https://example.com/.well-known/oauth-authorization-server",
+        "OPTIONS",
         {
-          Origin: 'https://spa.example.com',
-          'Access-Control-Request-Method': 'GET',
-        }
+          Origin: "https://spa.example.com",
+          "Access-Control-Request-Method": "GET",
+        },
       );
 
       const response = await oauthProvider.fetch(preflightRequest, mockEnv, mockCtx);
 
       expect(response.status).toBe(204);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://spa.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
-      expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
-      expect(response.headers.get('Content-Length')).toBe('0');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://spa.example.com");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
+      expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
+      expect(response.headers.get("Content-Length")).toBe("0");
     });
 
-    it('should add CORS headers to token endpoint responses', async () => {
+    it("should add CORS headers to token endpoint responses", async () => {
       // First create a client and get auth code
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'CORS Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "CORS Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Now test token exchange with CORS
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Origin: 'https://webapp.example.com',
+          "Content-Type": "application/x-www-form-urlencoded",
+          Origin: "https://webapp.example.com",
         },
-        params.toString()
+        params.toString(),
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
 
       expect(tokenResponse.status).toBe(200);
-      expect(tokenResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://webapp.example.com');
-      expect(tokenResponse.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(tokenResponse.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
-      expect(tokenResponse.headers.get('Access-Control-Max-Age')).toBe('86400');
+      expect(tokenResponse.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://webapp.example.com",
+      );
+      expect(tokenResponse.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(tokenResponse.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
+      expect(tokenResponse.headers.get("Access-Control-Max-Age")).toBe("86400");
     });
 
-    it('should handle OPTIONS preflight for token endpoint', async () => {
-      const preflightRequest = createMockRequest('https://example.com/oauth/token', 'OPTIONS', {
-        Origin: 'https://mobile.example.com',
-        'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'Content-Type',
+    it("should handle OPTIONS preflight for token endpoint", async () => {
+      const preflightRequest = createMockRequest("https://example.com/oauth/token", "OPTIONS", {
+        Origin: "https://mobile.example.com",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type",
       });
 
       const response = await oauthProvider.fetch(preflightRequest, mockEnv, mockCtx);
 
       expect(response.status).toBe(204);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://mobile.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
-      expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://mobile.example.com",
+      );
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
+      expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
     });
 
-    it('should add CORS headers to client registration endpoint', async () => {
+    it("should add CORS headers to client registration endpoint", async () => {
       const clientData = {
-        redirect_uris: ['https://newapp.example.com/callback'],
-        client_name: 'New CORS Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://newapp.example.com/callback"],
+        client_name: "New CORS Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
+        "https://example.com/oauth/register",
+        "POST",
         {
-          'Content-Type': 'application/json',
-          Origin: 'https://admin.example.com',
+          "Content-Type": "application/json",
+          Origin: "https://admin.example.com",
         },
-        JSON.stringify(clientData)
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(201);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://admin.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://admin.example.com");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
     });
 
-    it('should handle OPTIONS preflight for client registration endpoint', async () => {
-      const preflightRequest = createMockRequest('https://example.com/oauth/register', 'OPTIONS', {
-        Origin: 'https://dashboard.example.com',
-        'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'Content-Type, Authorization',
+    it("should handle OPTIONS preflight for client registration endpoint", async () => {
+      const preflightRequest = createMockRequest("https://example.com/oauth/register", "OPTIONS", {
+        Origin: "https://dashboard.example.com",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type, Authorization",
       });
 
       const response = await oauthProvider.fetch(preflightRequest, mockEnv, mockCtx);
 
       expect(response.status).toBe(204);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://dashboard.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://dashboard.example.com",
+      );
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
     });
 
-    it('should not add CORS headers when no Origin header is present', async () => {
-      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+    it("should not add CORS headers when no Origin header is present", async () => {
+      const request = createMockRequest(
+        "https://example.com/.well-known/oauth-authorization-server",
+      );
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBeNull();
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBeNull();
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBeNull();
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBeNull();
     });
 
-    it('should add CORS headers to API error responses', async () => {
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Origin: 'https://client.example.com',
+    it("should add CORS headers to API error responses", async () => {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Origin: "https://client.example.com",
         // No Authorization header - should get 401 error with CORS headers
       });
 
       const response = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
 
       expect(response.status).toBe(401);
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://client.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://client.example.com",
+      );
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
 
       const error = await response.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
     });
 
-    it('should add CORS headers to token endpoint error responses', async () => {
+    it("should add CORS headers to token endpoint error responses", async () => {
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', 'invalid-code');
-      params.append('client_id', 'invalid-client');
+      params.append("grant_type", "authorization_code");
+      params.append("code", "invalid-code");
+      params.append("client_id", "invalid-client");
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Origin: 'https://evil.example.com',
+          "Content-Type": "application/x-www-form-urlencoded",
+          Origin: "https://evil.example.com",
         },
-        params.toString()
+        params.toString(),
       );
 
       const response = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
 
       expect(response.status).toBe(401); // Should be an error
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://evil.example.com');
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://evil.example.com");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, *");
     });
 
-    it('should not add CORS headers to default handler responses', async () => {
-      const defaultRequest = createMockRequest('https://example.com/some-other-route', 'GET', {
-        Origin: 'https://client.example.com',
+    it("should not add CORS headers to default handler responses", async () => {
+      const defaultRequest = createMockRequest("https://example.com/some-other-route", "GET", {
+        Origin: "https://client.example.com",
       });
 
       const response = await oauthProvider.fetch(defaultRequest, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
       // CORS headers should NOT be added to default handler responses
-      expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
-      expect(response.headers.get('Access-Control-Allow-Methods')).toBeNull();
-      expect(response.headers.get('Access-Control-Allow-Headers')).toBeNull();
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBeNull();
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBeNull();
     });
   });
 
-  describe('Token Exchange Callback', () => {
+  describe("Token Exchange Callback", () => {
     // Test with provider that has token exchange callback
     let oauthProviderWithCallback: OAuthProvider<TestEnv>;
     let callbackInvocations: any[] = [];
@@ -4069,24 +4163,24 @@ describe('OAuthProvider', () => {
         callbackInvocations.push({ ...options });
 
         // Return different props based on the grant type
-        if (options.grantType === 'authorization_code') {
+        if (options.grantType === "authorization_code") {
           return {
             accessTokenProps: {
               ...options.props,
               tokenSpecific: true,
-              tokenUpdatedAt: 'auth_code_flow',
+              tokenUpdatedAt: "auth_code_flow",
             },
             newProps: {
               ...options.props,
               grantUpdated: true,
             },
           };
-        } else if (options.grantType === 'refresh_token') {
+        } else if (options.grantType === "refresh_token") {
           return {
             accessTokenProps: {
               ...options.props,
               tokenSpecific: true,
-              tokenUpdatedAt: 'refresh_token_flow',
+              tokenUpdatedAt: "refresh_token_flow",
             },
             newProps: {
               ...options.props,
@@ -4098,13 +4192,13 @@ describe('OAuthProvider', () => {
       };
 
       return new OAuthProvider({
-        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiRoute: ["/api/", "https://api.example.com/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'profile'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "profile"],
         accessTokenTTL: 3600,
         allowImplicitFlow: true,
         tokenExchangeCallback,
@@ -4118,16 +4212,16 @@ describe('OAuthProvider', () => {
     // Helper to create a test client
     async function createTestClient() {
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProviderWithCallback.fetch(request, mockEnv, mockCtx);
@@ -4135,7 +4229,7 @@ describe('OAuthProvider', () => {
 
       clientId = client.client_id;
       clientSecret = client.client_secret;
-      redirectUri = 'https://client.example.com/callback';
+      redirectUri = "https://client.example.com/callback";
     }
 
     beforeEach(async () => {
@@ -4158,34 +4252,34 @@ describe('OAuthProvider', () => {
       mockEnv.OAUTH_KV.clear();
     });
 
-    it('should call the callback during authorization code flow', async () => {
+    it("should call the callback during authorization code flow", async () => {
       // First get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProviderWithCallback.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Reset callback invocations tracking before token exchange
       callbackInvocations = [];
 
       // Exchange code for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await oauthProviderWithCallback.fetch(tokenRequest, mockEnv, mockCtx);
@@ -4200,12 +4294,12 @@ describe('OAuthProvider', () => {
 
       // Check that callback was called with correct arguments
       const callbackArgs = callbackInvocations[0];
-      expect(callbackArgs.grantType).toBe('authorization_code');
+      expect(callbackArgs.grantType).toBe("authorization_code");
       expect(callbackArgs.clientId).toBe(clientId);
-      expect(callbackArgs.props).toEqual({ userId: 'test-user-123', username: 'TestUser' });
+      expect(callbackArgs.props).toEqual({ userId: "test-user-123", username: "TestUser" });
 
       // Use the token to access API
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${tokens.access_token}`,
       });
 
@@ -4215,38 +4309,38 @@ describe('OAuthProvider', () => {
       // Check that the API received the token-specific props from the callback
       const apiData = await apiResponse.json<any>();
       expect(apiData.user).toEqual({
-        userId: 'test-user-123',
-        username: 'TestUser',
+        userId: "test-user-123",
+        username: "TestUser",
         tokenSpecific: true,
-        tokenUpdatedAt: 'auth_code_flow',
+        tokenUpdatedAt: "auth_code_flow",
       });
     });
 
-    it('should call the callback during refresh token flow', async () => {
+    it("should call the callback during refresh token flow", async () => {
       // First get an auth code and exchange it for tokens
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await oauthProviderWithCallback.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange code for tokens
       const codeParams = new URLSearchParams();
-      codeParams.append('grant_type', 'authorization_code');
-      codeParams.append('code', code);
-      codeParams.append('redirect_uri', redirectUri);
-      codeParams.append('client_id', clientId);
-      codeParams.append('client_secret', clientSecret);
+      codeParams.append("grant_type", "authorization_code");
+      codeParams.append("code", code);
+      codeParams.append("redirect_uri", redirectUri);
+      codeParams.append("client_id", clientId);
+      codeParams.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        codeParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        codeParams.toString(),
       );
 
       const tokenResponse = await oauthProviderWithCallback.fetch(tokenRequest, mockEnv, mockCtx);
@@ -4257,19 +4351,23 @@ describe('OAuthProvider', () => {
 
       // Now use the refresh token
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', tokens.refresh_token);
-      refreshParams.append('client_id', clientId);
-      refreshParams.append('client_secret', clientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", tokens.refresh_token);
+      refreshParams.append("client_id", clientId);
+      refreshParams.append("client_secret", clientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
-      const refreshResponse = await oauthProviderWithCallback.fetch(refreshRequest, mockEnv, mockCtx);
+      const refreshResponse = await oauthProviderWithCallback.fetch(
+        refreshRequest,
+        mockEnv,
+        mockCtx,
+      );
 
       // Check that the refresh was successful
       expect(refreshResponse.status).toBe(200);
@@ -4281,18 +4379,18 @@ describe('OAuthProvider', () => {
 
       // Check that callback was called with correct arguments
       const callbackArgs = callbackInvocations[0];
-      expect(callbackArgs.grantType).toBe('refresh_token');
+      expect(callbackArgs.grantType).toBe("refresh_token");
       expect(callbackArgs.clientId).toBe(clientId);
 
       // The props are from the updated grant during auth code flow
       expect(callbackArgs.props).toEqual({
-        userId: 'test-user-123',
-        username: 'TestUser',
+        userId: "test-user-123",
+        username: "TestUser",
         grantUpdated: true,
       });
 
       // Use the new token to access API
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${newTokens.access_token}`,
       });
 
@@ -4302,31 +4400,35 @@ describe('OAuthProvider', () => {
       // Check that the API received the token-specific props from the refresh callback
       const apiData = await apiResponse.json<any>();
       expect(apiData.user).toEqual({
-        userId: 'test-user-123',
-        username: 'TestUser',
+        userId: "test-user-123",
+        username: "TestUser",
         grantUpdated: true,
         tokenSpecific: true,
-        tokenUpdatedAt: 'refresh_token_flow',
+        tokenUpdatedAt: "refresh_token_flow",
       });
 
       // Do a second refresh to verify that grant props are properly updated
       const refresh2Params = new URLSearchParams();
-      refresh2Params.append('grant_type', 'refresh_token');
-      refresh2Params.append('refresh_token', newTokens.refresh_token);
-      refresh2Params.append('client_id', clientId);
-      refresh2Params.append('client_secret', clientSecret);
+      refresh2Params.append("grant_type", "refresh_token");
+      refresh2Params.append("refresh_token", newTokens.refresh_token);
+      refresh2Params.append("client_id", clientId);
+      refresh2Params.append("client_secret", clientSecret);
 
       // Reset the callback invocations before second refresh
       callbackInvocations = [];
 
       const refresh2Request = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refresh2Params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refresh2Params.toString(),
       );
 
-      const refresh2Response = await oauthProviderWithCallback.fetch(refresh2Request, mockEnv, mockCtx);
+      const refresh2Response = await oauthProviderWithCallback.fetch(
+        refresh2Request,
+        mockEnv,
+        mockCtx,
+      );
       const newerTokens = await refresh2Response.json();
 
       // Check that the refresh count was incremented in the grant props
@@ -4334,11 +4436,11 @@ describe('OAuthProvider', () => {
       expect(callbackInvocations[0].props.refreshCount).toBe(1);
     });
 
-    it('should update token props during refresh when explicitly provided', async () => {
+    it("should update token props during refresh when explicitly provided", async () => {
       // Create a provider with a callback that returns both accessTokenProps and newProps
       // but with different values for each
       const differentPropsCallback = async (options: any) => {
-        if (options.grantType === 'refresh_token') {
+        if (options.grantType === "refresh_token") {
           return {
             accessTokenProps: {
               ...options.props,
@@ -4355,59 +4457,59 @@ describe('OAuthProvider', () => {
       };
 
       const refreshPropsProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write"],
         tokenExchangeCallback: differentPropsCallback,
       });
 
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Refresh Props Test',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Refresh Props Test",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await refreshPropsProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const testClientId = client.client_id;
       const testClientSecret = client.client_secret;
-      const testRedirectUri = 'https://client.example.com/callback';
+      const testRedirectUri = "https://client.example.com/callback";
 
       // Get an auth code and exchange it for tokens
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${testClientId}` +
           `&redirect_uri=${encodeURIComponent(testRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await refreshPropsProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', testRedirectUri);
-      params.append('client_id', testClientId);
-      params.append('client_secret', testClientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", testRedirectUri);
+      params.append("client_id", testClientId);
+      params.append("client_secret", testClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await refreshPropsProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -4415,23 +4517,23 @@ describe('OAuthProvider', () => {
 
       // Now do a refresh token exchange
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', tokens.refresh_token);
-      refreshParams.append('client_id', testClientId);
-      refreshParams.append('client_secret', testClientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", tokens.refresh_token);
+      refreshParams.append("client_id", testClientId);
+      refreshParams.append("client_secret", testClientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
       const refreshResponse = await refreshPropsProvider.fetch(refreshRequest, mockEnv, mockCtx);
       const newTokens = await refreshResponse.json<any>();
 
       // Use the new token to access API
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${newTokens.access_token}`,
       });
 
@@ -4439,22 +4541,22 @@ describe('OAuthProvider', () => {
       const apiData = await apiResponse.json<any>();
 
       // The access token should contain the token-specific props from the refresh callback
-      expect(apiData.user).toHaveProperty('refreshed', true);
-      expect(apiData.user).toHaveProperty('tokenOnly', true);
-      expect(apiData.user).not.toHaveProperty('grantUpdated');
+      expect(apiData.user).toHaveProperty("refreshed", true);
+      expect(apiData.user).toHaveProperty("tokenOnly", true);
+      expect(apiData.user).not.toHaveProperty("grantUpdated");
     });
 
-    it('should handle callback that returns only accessTokenProps or only newProps', async () => {
+    it("should handle callback that returns only accessTokenProps or only newProps", async () => {
       // Create a provider with a callback that returns only accessTokenProps for auth code
       // and only newProps for refresh token
       // Note: With the enhanced implementation, when only newProps is returned
       // without accessTokenProps, the token props will inherit from newProps
       const propsCallback = async (options: any) => {
-        if (options.grantType === 'authorization_code') {
+        if (options.grantType === "authorization_code") {
           return {
             accessTokenProps: { ...options.props, tokenOnly: true },
           };
-        } else if (options.grantType === 'refresh_token') {
+        } else if (options.grantType === "refresh_token") {
           return {
             newProps: { ...options.props, grantOnly: true },
           };
@@ -4462,66 +4564,66 @@ describe('OAuthProvider', () => {
       };
 
       const specialProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write"],
         tokenExchangeCallback: propsCallback,
       });
 
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Token Props Only Test',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Token Props Only Test",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await specialProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const testClientId = client.client_id;
       const testClientSecret = client.client_secret;
-      const testRedirectUri = 'https://client.example.com/callback';
+      const testRedirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${testClientId}` +
           `&redirect_uri=${encodeURIComponent(testRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await specialProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       // Exchange code for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', testRedirectUri);
-      params.append('client_id', testClientId);
-      params.append('client_secret', testClientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", testRedirectUri);
+      params.append("client_id", testClientId);
+      params.append("client_secret", testClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await specialProvider.fetch(tokenRequest, mockEnv, mockCtx);
       const tokens = await tokenResponse.json<any>();
 
       // Verify the token has the tokenOnly property when used for API access
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${tokens.access_token}`,
       });
 
@@ -4531,23 +4633,23 @@ describe('OAuthProvider', () => {
 
       // Now do a refresh token exchange
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', tokens.refresh_token);
-      refreshParams.append('client_id', testClientId);
-      refreshParams.append('client_secret', testClientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", tokens.refresh_token);
+      refreshParams.append("client_id", testClientId);
+      refreshParams.append("client_secret", testClientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
       const refreshResponse = await specialProvider.fetch(refreshRequest, mockEnv, mockCtx);
       const newTokens = await refreshResponse.json<any>();
 
       // Use the new token to access API
-      const api2Request = createMockRequest('https://example.com/api/test', 'GET', {
+      const api2Request = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${newTokens.access_token}`,
       });
 
@@ -4557,16 +4659,16 @@ describe('OAuthProvider', () => {
       // With the enhanced implementation, the token props now inherit from grant props
       // when only newProps is returned but accessTokenProps is not specified
       expect(api2Data.user).toEqual({
-        userId: 'test-user-123',
-        username: 'TestUser',
+        userId: "test-user-123",
+        username: "TestUser",
         grantOnly: true, // This is now included in the token props
       });
     });
 
-    it('should allow customizing access token TTL via callback', async () => {
+    it("should allow customizing access token TTL via callback", async () => {
       // Create a provider with a callback that customizes TTL
       const customTtlCallback = async (options: any) => {
-        if (options.grantType === 'refresh_token') {
+        if (options.grantType === "refresh_token") {
           // Return custom TTL for the access token
           return {
             accessTokenProps: { ...options.props, customTtl: true },
@@ -4577,60 +4679,60 @@ describe('OAuthProvider', () => {
       };
 
       const customTtlProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write"],
         accessTokenTTL: 3600, // Default 1 hour
         tokenExchangeCallback: customTtlCallback,
       });
 
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Custom TTL Test',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Custom TTL Test",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await customTtlProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const testClientId = client.client_id;
       const testClientSecret = client.client_secret;
-      const testRedirectUri = 'https://client.example.com/callback';
+      const testRedirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${testClientId}` +
           `&redirect_uri=${encodeURIComponent(testRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await customTtlProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       // Exchange code for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', testRedirectUri);
-      params.append('client_id', testClientId);
-      params.append('client_secret', testClientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", testRedirectUri);
+      params.append("client_id", testClientId);
+      params.append("client_secret", testClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await customTtlProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -4638,16 +4740,16 @@ describe('OAuthProvider', () => {
 
       // Now do a refresh
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', tokens.refresh_token);
-      refreshParams.append('client_id', testClientId);
-      refreshParams.append('client_secret', testClientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", tokens.refresh_token);
+      refreshParams.append("client_id", testClientId);
+      refreshParams.append("client_secret", testClientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
       const refreshResponse = await customTtlProvider.fetch(refreshRequest, mockEnv, mockCtx);
@@ -4657,7 +4759,7 @@ describe('OAuthProvider', () => {
       expect(newTokens.expires_in).toBe(7200);
 
       // Verify the token contains our custom property
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${newTokens.access_token}`,
       });
 
@@ -4666,7 +4768,7 @@ describe('OAuthProvider', () => {
       expect(apiData.user.customTtl).toBe(true);
     });
 
-    it('should handle callback that returns undefined (keeping original props)', async () => {
+    it("should handle callback that returns undefined (keeping original props)", async () => {
       // Create a provider with a callback that returns undefined
       const noopCallback = async (options: any) => {
         // Don't return anything, which should keep the original props
@@ -4674,66 +4776,66 @@ describe('OAuthProvider', () => {
       };
 
       const noopProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write"],
         tokenExchangeCallback: noopCallback,
       });
 
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Noop Callback Test',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Noop Callback Test",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await noopProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const testClientId = client.client_id;
       const testClientSecret = client.client_secret;
-      const testRedirectUri = 'https://client.example.com/callback';
+      const testRedirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${testClientId}` +
           `&redirect_uri=${encodeURIComponent(testRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await noopProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       // Exchange code for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', testRedirectUri);
-      params.append('client_id', testClientId);
-      params.append('client_secret', testClientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", testRedirectUri);
+      params.append("client_id", testClientId);
+      params.append("client_secret", testClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await noopProvider.fetch(tokenRequest, mockEnv, mockCtx);
       const tokens = await tokenResponse.json<any>();
 
       // Verify the token has the original props when used for API access
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${tokens.access_token}`,
       });
 
@@ -4741,17 +4843,17 @@ describe('OAuthProvider', () => {
       const apiData = await apiResponse.json<any>();
 
       // The props should be the original ones (no change)
-      expect(apiData.user).toEqual({ userId: 'test-user-123', username: 'TestUser' });
+      expect(apiData.user).toEqual({ userId: "test-user-123", username: "TestUser" });
     });
 
-    it('should correctly handle the previous refresh token when callback updates grant props', async () => {
+    it("should correctly handle the previous refresh token when callback updates grant props", async () => {
       // This test verifies fixes for two bugs:
       // 1. previousRefreshTokenWrappedKey not being re-wrapped when grant props change
       // 2. accessTokenProps not inheriting from newProps when only newProps is returned
       let callCount = 0;
       const propUpdatingCallback = async (options: any) => {
         callCount++;
-        if (options.grantType === 'refresh_token') {
+        if (options.grantType === "refresh_token") {
           const updatedProps = {
             ...options.props,
             updatedCount: (options.props.updatedCount || 0) + 1,
@@ -4768,59 +4870,59 @@ describe('OAuthProvider', () => {
       };
 
       const testProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write"],
         tokenExchangeCallback: propUpdatingCallback,
       });
 
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Key-Rewrapping Test',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Key-Rewrapping Test",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const registerResponse = await testProvider.fetch(registerRequest, mockEnv, mockCtx);
       const client = await registerResponse.json<any>();
       const testClientId = client.client_id;
       const testClientSecret = client.client_secret;
-      const testRedirectUri = 'https://client.example.com/callback';
+      const testRedirectUri = "https://client.example.com/callback";
 
       // Get an auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${testClientId}` +
           `&redirect_uri=${encodeURIComponent(testRedirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       const authResponse = await testProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code")!;
 
       // Exchange code for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', testRedirectUri);
-      params.append('client_id', testClientId);
-      params.append('client_secret', testClientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", testRedirectUri);
+      params.append("client_id", testClientId);
+      params.append("client_secret", testClientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenResponse = await testProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -4832,16 +4934,16 @@ describe('OAuthProvider', () => {
 
       // First refresh - this will update the grant props and re-encrypt them with a new key
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', refreshToken);
-      refreshParams.append('client_id', testClientId);
-      refreshParams.append('client_secret', testClientSecret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", refreshToken);
+      refreshParams.append("client_id", testClientId);
+      refreshParams.append("client_secret", testClientSecret);
 
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(),
       );
 
       const refreshResponse = await testProvider.fetch(refreshRequest, mockEnv, mockCtx);
@@ -4854,7 +4956,7 @@ describe('OAuthProvider', () => {
       const newTokens = await refreshResponse.json<any>();
 
       // Get the refresh token's corresponding token data to verify it has the updated props
-      const apiRequest1 = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest1 = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${newTokens.access_token}`,
       });
 
@@ -4862,7 +4964,7 @@ describe('OAuthProvider', () => {
       const apiData1 = await apiResponse1.json<any>();
 
       // Print the actual API response to debug
-      console.log('First API response:', JSON.stringify(apiData1));
+      console.log("First API response:", JSON.stringify(apiData1));
 
       // Verify that the token has the updated props (updatedCount should be 1)
       expect(apiData1.user.updatedCount).toBe(1);
@@ -4873,13 +4975,17 @@ describe('OAuthProvider', () => {
       // Now try to use the SAME refresh token again (which should work once due to token rotation)
       // With the bug, this would fail because previousRefreshTokenWrappedKey wasn't re-wrapped with the new key
       const secondRefreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        refreshParams.toString() // Using same params with the same refresh token
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        refreshParams.toString(), // Using same params with the same refresh token
       );
 
-      const secondRefreshResponse = await testProvider.fetch(secondRefreshRequest, mockEnv, mockCtx);
+      const secondRefreshResponse = await testProvider.fetch(
+        secondRefreshRequest,
+        mockEnv,
+        mockCtx,
+      );
 
       // With the bug, this would fail with an error.
       // When fixed, it should succeed because the previous refresh token is still valid once.
@@ -4892,7 +4998,7 @@ describe('OAuthProvider', () => {
       expect(callCount).toBe(1);
 
       // Use the token to access API and verify it has the updated props
-      const apiRequest2 = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest2 = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${secondTokens.access_token}`,
       });
 
@@ -4903,37 +5009,37 @@ describe('OAuthProvider', () => {
       expect(apiData2.user.updatedCount).toBe(2);
     });
 
-    it('should apply accessTokenScope from callback during auth code exchange', async () => {
+    it("should apply accessTokenScope from callback during auth code exchange", async () => {
       const scopeCallback = async (options: any) => {
-        if (options.grantType === 'authorization_code') {
+        if (options.grantType === "authorization_code") {
           return {
             // Override: only grant 'read' regardless of what was requested
-            accessTokenScope: ['read'],
+            accessTokenScope: ["read"],
           };
         }
       };
 
       const scopeProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'profile'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "profile"],
         tokenExchangeCallback: scopeCallback,
       });
 
       // Register client
       const regReq = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
         JSON.stringify({
-          redirect_uris: ['https://client.example.com/callback'],
-          client_name: 'Scope Test',
-          token_endpoint_auth_method: 'client_secret_basic',
-        })
+          redirect_uris: ["https://client.example.com/callback"],
+          client_name: "Scope Test",
+          token_endpoint_auth_method: "client_secret_basic",
+        }),
       );
       const regRes = await scopeProvider.fetch(regReq, mockEnv, mockCtx);
       const client = await regRes.json<any>();
@@ -4941,67 +5047,67 @@ describe('OAuthProvider', () => {
       // Authorize with broad scopes
       const authReq = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${client.client_id}` +
-          `&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}` +
-          `&scope=read%20write%20profile&state=xyz`
+          `&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}` +
+          `&scope=read%20write%20profile&state=xyz`,
       );
       const authRes = await scopeProvider.fetch(authReq, mockEnv, mockCtx);
-      const code = new URL(authRes.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authRes.headers.get("Location")!).searchParams.get("code")!;
 
       // Exchange code
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', 'https://client.example.com/callback');
-      params.append('client_id', client.client_id);
-      params.append('client_secret', client.client_secret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", "https://client.example.com/callback");
+      params.append("client_id", client.client_id);
+      params.append("client_secret", client.client_secret);
 
       const tokenReq = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       const tokenRes = await scopeProvider.fetch(tokenReq, mockEnv, mockCtx);
       expect(tokenRes.status).toBe(200);
       const tokens = await tokenRes.json<any>();
       // Callback forced scope to 'read' only
-      expect(tokens.scope).toBe('read');
+      expect(tokens.scope).toBe("read");
     });
 
-    it('should apply accessTokenScope from callback during refresh token exchange', async () => {
+    it("should apply accessTokenScope from callback during refresh token exchange", async () => {
       let refreshCount = 0;
       const scopeCallback = async (options: any) => {
-        if (options.grantType === 'refresh_token') {
+        if (options.grantType === "refresh_token") {
           refreshCount++;
           return {
             // On refresh, narrow to write only
-            accessTokenScope: ['write'],
+            accessTokenScope: ["write"],
           };
         }
       };
 
       const scopeProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write"],
         tokenExchangeCallback: scopeCallback,
       });
 
       // Register client
       const regReq = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
         JSON.stringify({
-          redirect_uris: ['https://client.example.com/callback'],
-          client_name: 'Refresh Scope Test',
-          token_endpoint_auth_method: 'client_secret_basic',
-        })
+          redirect_uris: ["https://client.example.com/callback"],
+          client_name: "Refresh Scope Test",
+          token_endpoint_auth_method: "client_secret_basic",
+        }),
       );
       const regRes = await scopeProvider.fetch(regReq, mockEnv, mockCtx);
       const client = await regRes.json<any>();
@@ -5009,102 +5115,102 @@ describe('OAuthProvider', () => {
       // Get tokens via auth code
       const authReq = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${client.client_id}` +
-          `&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}` +
-          `&scope=read%20write&state=xyz`
+          `&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}` +
+          `&scope=read%20write&state=xyz`,
       );
       const authRes = await scopeProvider.fetch(authReq, mockEnv, mockCtx);
-      const code = new URL(authRes.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authRes.headers.get("Location")!).searchParams.get("code")!;
 
       const codeParams = new URLSearchParams();
-      codeParams.append('grant_type', 'authorization_code');
-      codeParams.append('code', code);
-      codeParams.append('redirect_uri', 'https://client.example.com/callback');
-      codeParams.append('client_id', client.client_id);
-      codeParams.append('client_secret', client.client_secret);
+      codeParams.append("grant_type", "authorization_code");
+      codeParams.append("code", code);
+      codeParams.append("redirect_uri", "https://client.example.com/callback");
+      codeParams.append("client_id", client.client_id);
+      codeParams.append("client_secret", client.client_secret);
 
       const tokenRes = await scopeProvider.fetch(
         createMockRequest(
-          'https://example.com/oauth/token',
-          'POST',
-          { 'Content-Type': 'application/x-www-form-urlencoded' },
-          codeParams.toString()
+          "https://example.com/oauth/token",
+          "POST",
+          { "Content-Type": "application/x-www-form-urlencoded" },
+          codeParams.toString(),
         ),
         mockEnv,
-        mockCtx
+        mockCtx,
       );
       const tokens = await tokenRes.json<any>();
-      expect(tokens.scope).toBe('read write'); // No callback for auth_code, full scopes
+      expect(tokens.scope).toBe("read write"); // No callback for auth_code, full scopes
 
       // Now refresh
       const refreshParams = new URLSearchParams();
-      refreshParams.append('grant_type', 'refresh_token');
-      refreshParams.append('refresh_token', tokens.refresh_token);
-      refreshParams.append('client_id', client.client_id);
-      refreshParams.append('client_secret', client.client_secret);
+      refreshParams.append("grant_type", "refresh_token");
+      refreshParams.append("refresh_token", tokens.refresh_token);
+      refreshParams.append("client_id", client.client_id);
+      refreshParams.append("client_secret", client.client_secret);
 
       const refreshRes = await scopeProvider.fetch(
         createMockRequest(
-          'https://example.com/oauth/token',
-          'POST',
-          { 'Content-Type': 'application/x-www-form-urlencoded' },
-          refreshParams.toString()
+          "https://example.com/oauth/token",
+          "POST",
+          { "Content-Type": "application/x-www-form-urlencoded" },
+          refreshParams.toString(),
         ),
         mockEnv,
-        mockCtx
+        mockCtx,
       );
       expect(refreshRes.status).toBe(200);
       const newTokens = await refreshRes.json<any>();
       // Callback forced scope to 'write' only on refresh
-      expect(newTokens.scope).toBe('write');
+      expect(newTokens.scope).toBe("write");
       expect(refreshCount).toBe(1);
     });
 
-    it('should apply accessTokenScope from callback during token exchange', async () => {
+    it("should apply accessTokenScope from callback during token exchange", async () => {
       const scopeCallback = async (options: any) => {
-        if (options.grantType === 'urn:ietf:params:oauth:grant-type:token-exchange') {
+        if (options.grantType === "urn:ietf:params:oauth:grant-type:token-exchange") {
           return {
             // Override: restrict to 'read' only during token exchange
-            accessTokenScope: ['read'],
+            accessTokenScope: ["read"],
           };
         }
       };
 
       const scopeProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'profile'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "profile"],
         allowTokenExchangeGrant: true,
         tokenExchangeCallback: scopeCallback,
       });
 
       // Register original client
       const regReq1 = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
         JSON.stringify({
-          redirect_uris: ['https://original.example.com/callback'],
-          client_name: 'Original',
-          token_endpoint_auth_method: 'client_secret_basic',
-        })
+          redirect_uris: ["https://original.example.com/callback"],
+          client_name: "Original",
+          token_endpoint_auth_method: "client_secret_basic",
+        }),
       );
       const regRes1 = await scopeProvider.fetch(regReq1, mockEnv, mockCtx);
       const origClient = await regRes1.json<any>();
 
       // Register exchange client
       const regReq2 = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
         JSON.stringify({
-          redirect_uris: ['https://exchange.example.com/callback'],
-          client_name: 'Exchange',
-          token_endpoint_auth_method: 'client_secret_basic',
-        })
+          redirect_uris: ["https://exchange.example.com/callback"],
+          client_name: "Exchange",
+          token_endpoint_auth_method: "client_secret_basic",
+        }),
       );
       const regRes2 = await scopeProvider.fetch(regReq2, mockEnv, mockCtx);
       const exchClient = await regRes2.json<any>();
@@ -5112,87 +5218,87 @@ describe('OAuthProvider', () => {
       // Get a token with broad scopes
       const authReq = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${origClient.client_id}` +
-          `&redirect_uri=${encodeURIComponent('https://original.example.com/callback')}` +
-          `&scope=read%20write%20profile&state=xyz`
+          `&redirect_uri=${encodeURIComponent("https://original.example.com/callback")}` +
+          `&scope=read%20write%20profile&state=xyz`,
       );
       const authRes = await scopeProvider.fetch(authReq, mockEnv, mockCtx);
-      const code = new URL(authRes.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authRes.headers.get("Location")!).searchParams.get("code")!;
 
       const codeParams = new URLSearchParams();
-      codeParams.append('grant_type', 'authorization_code');
-      codeParams.append('code', code);
-      codeParams.append('redirect_uri', 'https://original.example.com/callback');
-      codeParams.append('client_id', origClient.client_id);
-      codeParams.append('client_secret', origClient.client_secret);
+      codeParams.append("grant_type", "authorization_code");
+      codeParams.append("code", code);
+      codeParams.append("redirect_uri", "https://original.example.com/callback");
+      codeParams.append("client_id", origClient.client_id);
+      codeParams.append("client_secret", origClient.client_secret);
 
       const tokenRes = await scopeProvider.fetch(
         createMockRequest(
-          'https://example.com/oauth/token',
-          'POST',
-          { 'Content-Type': 'application/x-www-form-urlencoded' },
-          codeParams.toString()
+          "https://example.com/oauth/token",
+          "POST",
+          { "Content-Type": "application/x-www-form-urlencoded" },
+          codeParams.toString(),
         ),
         mockEnv,
-        mockCtx
+        mockCtx,
       );
       const tokens = await tokenRes.json<any>();
 
       // Now exchange — request all scopes, but callback should restrict to 'read'
       const exchParams = new URLSearchParams();
-      exchParams.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
-      exchParams.append('subject_token', tokens.access_token);
-      exchParams.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      exchParams.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
-      exchParams.append('scope', 'read write profile'); // Request all
+      exchParams.append("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+      exchParams.append("subject_token", tokens.access_token);
+      exchParams.append("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      exchParams.append("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+      exchParams.append("scope", "read write profile"); // Request all
 
       const exchRes = await scopeProvider.fetch(
         createMockRequest(
-          'https://example.com/oauth/token',
-          'POST',
+          "https://example.com/oauth/token",
+          "POST",
           {
-            'Content-Type': 'application/x-www-form-urlencoded',
+            "Content-Type": "application/x-www-form-urlencoded",
             Authorization: `Basic ${btoa(`${exchClient.client_id}:${exchClient.client_secret}`)}`,
           },
-          exchParams.toString()
+          exchParams.toString(),
         ),
         mockEnv,
-        mockCtx
+        mockCtx,
       );
       expect(exchRes.status).toBe(200);
       const newTokens = await exchRes.json<any>();
       // Callback overrode scopes to 'read' only
-      expect(newTokens.scope).toBe('read');
+      expect(newTokens.scope).toBe("read");
     });
 
-    it('should clamp accessTokenScope from callback to grant scopes', async () => {
+    it("should clamp accessTokenScope from callback to grant scopes", async () => {
       const scopeCallback = async (options: any) => {
         return {
           // Callback tries to grant 'admin' which is not in the grant
-          accessTokenScope: ['read', 'admin'],
+          accessTokenScope: ["read", "admin"],
         };
       };
 
       const scopeProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write', 'admin'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write", "admin"],
         tokenExchangeCallback: scopeCallback,
       });
 
       // Register client
       const regReq = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
         JSON.stringify({
-          redirect_uris: ['https://client.example.com/callback'],
-          client_name: 'Clamp Test',
-          token_endpoint_auth_method: 'client_secret_basic',
-        })
+          redirect_uris: ["https://client.example.com/callback"],
+          client_name: "Clamp Test",
+          token_endpoint_auth_method: "client_secret_basic",
+        }),
       );
       const regRes = await scopeProvider.fetch(regReq, mockEnv, mockCtx);
       const client = await regRes.json<any>();
@@ -5200,45 +5306,45 @@ describe('OAuthProvider', () => {
       // Authorize with 'read write' only (not admin)
       const authReq = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${client.client_id}` +
-          `&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}` +
-          `&scope=read%20write&state=xyz`
+          `&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}` +
+          `&scope=read%20write&state=xyz`,
       );
       const authRes = await scopeProvider.fetch(authReq, mockEnv, mockCtx);
-      const code = new URL(authRes.headers.get('Location')!).searchParams.get('code')!;
+      const code = new URL(authRes.headers.get("Location")!).searchParams.get("code")!;
 
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', 'https://client.example.com/callback');
-      params.append('client_id', client.client_id);
-      params.append('client_secret', client.client_secret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", "https://client.example.com/callback");
+      params.append("client_id", client.client_id);
+      params.append("client_secret", client.client_secret);
 
       const tokenRes = await scopeProvider.fetch(
         createMockRequest(
-          'https://example.com/oauth/token',
-          'POST',
-          { 'Content-Type': 'application/x-www-form-urlencoded' },
-          params.toString()
+          "https://example.com/oauth/token",
+          "POST",
+          { "Content-Type": "application/x-www-form-urlencoded" },
+          params.toString(),
         ),
         mockEnv,
-        mockCtx
+        mockCtx,
       );
       expect(tokenRes.status).toBe(200);
       const tokens = await tokenRes.json<any>();
       // Callback requested ['read', 'admin'] but grant only had ['read', 'write']
       // downscope() should filter to just 'read'
-      expect(tokens.scope).toBe('read');
+      expect(tokens.scope).toBe("read");
     });
   });
 
-  describe('Error Handling with onError Callback', () => {
-    it('should use the default onError callback that logs a warning', async () => {
+  describe("Error Handling with onError Callback", () => {
+    it("should use the default onError callback that logs a warning", async () => {
       // Spy on console.warn to check default behavior
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       // Create a request that will trigger an error
-      const invalidTokenRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer invalid-token',
+      const invalidTokenRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer invalid-token",
       });
 
       const response = await oauthProvider.fetch(invalidTokenRequest, mockEnv, mockCtx);
@@ -5246,24 +5352,26 @@ describe('OAuthProvider', () => {
       // Verify the error response
       expect(response.status).toBe(401);
       const error = await response.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(error.error).toBe("invalid_token");
 
       // Verify the default onError callback was triggered and logged a warning
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('OAuth error response: 401 invalid_token'));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("OAuth error response: 401 invalid_token"),
+      );
 
       // Restore the spy
       consoleWarnSpy.mockRestore();
     });
 
-    it('should allow custom onError callback to modify the error response', async () => {
+    it("should allow custom onError callback to modify the error response", async () => {
       // Create a provider with custom onError callback
       const customErrorProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         onError: ({ code, description, status }) => {
           // Return a completely different response
           return new Response(
@@ -5275,41 +5383,41 @@ describe('OAuthProvider', () => {
             {
               status,
               headers: {
-                'Content-Type': 'application/json',
-                'X-Custom-Error': 'true',
+                "Content-Type": "application/json",
+                "X-Custom-Error": "true",
               },
-            }
+            },
           );
         },
       });
 
       // Create a request that will trigger an error
-      const invalidTokenRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer invalid-token',
+      const invalidTokenRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer invalid-token",
       });
 
       const response = await customErrorProvider.fetch(invalidTokenRequest, mockEnv, mockCtx);
 
       // Verify the custom error response
       expect(response.status).toBe(401); // Status should be preserved
-      expect(response.headers.get('X-Custom-Error')).toBe('true');
+      expect(response.headers.get("X-Custom-Error")).toBe("true");
 
       const error = await response.json<any>();
       expect(error.custom_error).toBe(true);
-      expect(error.original_code).toBe('invalid_token');
-      expect(error.custom_message).toContain('Custom error handler');
+      expect(error.original_code).toBe("invalid_token");
+      expect(error.custom_message).toContain("Custom error handler");
     });
 
-    it('should use standard error response when onError returns void', async () => {
+    it("should use standard error response when onError returns void", async () => {
       // Create a provider with a callback that performs a side effect but doesn't return a response
       let callbackInvoked = false;
       const sideEffectProvider = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         onError: () => {
           callbackInvoked = true;
           // No return - should use standard error response
@@ -5317,8 +5425,8 @@ describe('OAuthProvider', () => {
       });
 
       // Create a request that will trigger an error
-      const invalidRequest = createMockRequest('https://example.com/oauth/token', 'POST', {
-        'Content-Type': 'application/x-www-form-urlencoded',
+      const invalidRequest = createMockRequest("https://example.com/oauth/token", "POST", {
+        "Content-Type": "application/x-www-form-urlencoded",
       });
 
       const response = await sideEffectProvider.fetch(invalidRequest, mockEnv, mockCtx);
@@ -5326,39 +5434,41 @@ describe('OAuthProvider', () => {
       // Verify the standard error response
       expect(response.status).toBe(401);
       const error = await response.json<any>();
-      expect(error.error).toBe('invalid_client');
+      expect(error.error).toBe("invalid_client");
 
       // Verify callback was invoked
       expect(callbackInvoked).toBe(true);
     });
   });
 
-  describe('OAuthHelpers', () => {
-    it('should allow listing and revoking grants', async () => {
+  describe("OAuthHelpers", () => {
+    it("should allow listing and revoking grants", async () => {
       // Create a client
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Test Client',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       await oauthProvider.fetch(registerRequest, mockEnv, mockCtx);
 
       // Create a grant by going through auth flow
-      const clientId = (await mockEnv.OAUTH_KV.list({ prefix: 'client:' })).keys[0].name.substring(7);
-      const redirectUri = 'https://client.example.com/callback';
+      const clientId = (await mockEnv.OAUTH_KV.list({ prefix: "client:" })).keys[0].name.substring(
+        7,
+      );
+      const redirectUri = "https://client.example.com/callback";
 
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
       await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
@@ -5367,24 +5477,24 @@ describe('OAuthProvider', () => {
       expect(mockEnv.OAUTH_PROVIDER).not.toBeNull();
 
       // List grants for the user
-      const grants = await mockEnv.OAUTH_PROVIDER!.listUserGrants('test-user-123');
+      const grants = await mockEnv.OAUTH_PROVIDER!.listUserGrants("test-user-123");
 
       expect(grants.items.length).toBe(1);
       expect(grants.items[0].clientId).toBe(clientId);
-      expect(grants.items[0].userId).toBe('test-user-123');
+      expect(grants.items[0].userId).toBe("test-user-123");
       expect(grants.items[0].metadata).toEqual({ testConsent: true });
 
       // Revoke the grant
-      await mockEnv.OAUTH_PROVIDER!.revokeGrant(grants.items[0].id, 'test-user-123');
+      await mockEnv.OAUTH_PROVIDER!.revokeGrant(grants.items[0].id, "test-user-123");
 
       // Verify grant was deleted
-      const grantsAfterRevoke = await mockEnv.OAUTH_PROVIDER!.listUserGrants('test-user-123');
+      const grantsAfterRevoke = await mockEnv.OAUTH_PROVIDER!.listUserGrants("test-user-123");
       expect(grantsAfterRevoke.items.length).toBe(0);
     });
 
-    it('should allow listing, updating, and deleting clients', async () => {
+    it("should allow listing, updating, and deleting clients", async () => {
       // First make a simple request to initialize the OAUTH_PROVIDER in the environment
-      const initRequest = createMockRequest('https://example.com/');
+      const initRequest = createMockRequest("https://example.com/");
       await oauthProvider.fetch(initRequest, mockEnv, mockCtx);
 
       // Now OAUTH_PROVIDER should be initialized
@@ -5392,9 +5502,9 @@ describe('OAuthProvider', () => {
 
       // Create a client
       const client = await mockEnv.OAUTH_PROVIDER!.createClient({
-        redirectUris: ['https://client.example.com/callback'],
-        clientName: 'Test Client',
-        tokenEndpointAuthMethod: 'client_secret_basic',
+        redirectUris: ["https://client.example.com/callback"],
+        clientName: "Test Client",
+        tokenEndpointAuthMethod: "client_secret_basic",
       });
 
       expect(client.clientId).toBeDefined();
@@ -5407,11 +5517,11 @@ describe('OAuthProvider', () => {
 
       // Update client
       const updatedClient = await mockEnv.OAUTH_PROVIDER!.updateClient(client.clientId, {
-        clientName: 'Updated Client Name',
+        clientName: "Updated Client Name",
       });
 
       expect(updatedClient).not.toBeNull();
-      expect(updatedClient!.clientName).toBe('Updated Client Name');
+      expect(updatedClient!.clientName).toBe("Updated Client Name");
 
       // Delete client
       await mockEnv.OAUTH_PROVIDER!.deleteClient(client.clientId);
@@ -5422,44 +5532,48 @@ describe('OAuthProvider', () => {
     });
   });
 
-  describe('External Token Resolution', () => {
-    it('should reject unknown tokens when no resolveExternalToken callback is provided', async () => {
+  describe("External Token Resolution", () => {
+    it("should reject unknown tokens when no resolveExternalToken callback is provided", async () => {
       // Create a provider without external token resolution
       const providerWithoutExternalValidation = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         // Intentionally no resolveExternalToken callback
       });
 
       // Try to access API with an unknown token format
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer external-token-from-another-service',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer external-token-from-another-service",
       });
 
-      const apiResponse = await providerWithoutExternalValidation.fetch(apiRequest, mockEnv, mockCtx);
+      const apiResponse = await providerWithoutExternalValidation.fetch(
+        apiRequest,
+        mockEnv,
+        mockCtx,
+      );
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
-      expect(error.error_description).toBe('Invalid access token');
+      expect(error.error).toBe("invalid_token");
+      expect(error.error_description).toBe("Invalid access token");
     });
 
-    it('should successfully resolve external tokens and set props correctly', async () => {
+    it("should successfully resolve external tokens and set props correctly", async () => {
       // Mock external token validation calls
       const externalTokenCalls: any[] = [];
 
       // Create a provider with external token resolution
       const providerWithExternalValidation = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         resolveExternalToken: async (input) => {
           // Record the call for verification
           externalTokenCalls.push({
@@ -5469,13 +5583,13 @@ describe('OAuthProvider', () => {
           });
 
           // Simulate successful external token validation
-          if (input.token === 'external-valid-token') {
+          if (input.token === "external-valid-token") {
             return {
               props: {
-                userId: 'external-user-456',
-                username: 'ExternalUser',
-                source: 'external-oauth-server',
-                permissions: ['read', 'write'],
+                userId: "external-user-456",
+                username: "ExternalUser",
+                source: "external-oauth-server",
+                permissions: ["read", "write"],
               },
             };
           }
@@ -5486,8 +5600,8 @@ describe('OAuthProvider', () => {
       });
 
       // Try to access API with a valid external token
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer external-valid-token',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer external-valid-token",
       });
 
       const apiResponse = await providerWithExternalValidation.fetch(apiRequest, mockEnv, mockCtx);
@@ -5496,31 +5610,31 @@ describe('OAuthProvider', () => {
       const responseData = await apiResponse.json<any>();
       expect(responseData.success).toBe(true);
       expect(responseData.user).toEqual({
-        userId: 'external-user-456',
-        username: 'ExternalUser',
-        source: 'external-oauth-server',
-        permissions: ['read', 'write'],
+        userId: "external-user-456",
+        username: "ExternalUser",
+        source: "external-oauth-server",
+        permissions: ["read", "write"],
       });
 
       // Verify the external token callback was called correctly
       expect(externalTokenCalls.length).toBe(1);
-      expect(externalTokenCalls[0].token).toBe('external-valid-token');
-      expect(externalTokenCalls[0].requestUrl).toBe('https://example.com/api/test');
+      expect(externalTokenCalls[0].token).toBe("external-valid-token");
+      expect(externalTokenCalls[0].requestUrl).toBe("https://example.com/api/test");
       expect(externalTokenCalls[0].hasEnv).toBe(true);
     });
 
-    it('should reject external tokens when callback returns null', async () => {
+    it("should reject external tokens when callback returns null", async () => {
       // Mock external token validation calls
       const externalTokenCalls: any[] = [];
 
       // Create a provider with external token resolution that fails
       const providerWithFailingValidation = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         resolveExternalToken: async (input) => {
           externalTokenCalls.push({ token: input.token });
 
@@ -5530,95 +5644,107 @@ describe('OAuthProvider', () => {
       });
 
       // Try to access API with an invalid external token
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer invalid-external-token',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer invalid-external-token",
       });
 
       const apiResponse = await providerWithFailingValidation.fetch(apiRequest, mockEnv, mockCtx);
 
       expect(apiResponse.status).toBe(401);
       const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
-      expect(error.error_description).toBe('Invalid access token');
+      expect(error.error).toBe("invalid_token");
+      expect(error.error_description).toBe("Invalid access token");
 
       // Verify the external token callback was called
       expect(externalTokenCalls.length).toBe(1);
-      expect(externalTokenCalls[0].token).toBe('invalid-external-token');
+      expect(externalTokenCalls[0].token).toBe("invalid-external-token");
     });
 
-    it('should prioritize internal tokens over external validation', async () => {
+    it("should prioritize internal tokens over external validation", async () => {
       // Mock external token validation to track if it's called
       const externalTokenCalls: any[] = [];
 
       // Create a provider with external token resolution
       const providerWithExternalValidation = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        clientRegistrationEndpoint: "/oauth/register",
+        scopesSupported: ["read", "write"],
         resolveExternalToken: async (input) => {
           externalTokenCalls.push({ token: input.token });
           return {
-            props: { source: 'external', shouldNeverSeeThis: true },
+            props: { source: "external", shouldNeverSeeThis: true },
           };
         },
       });
 
       // First, create a valid internal token through normal OAuth flow
       const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Internal Token Test',
-        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: ["https://client.example.com/callback"],
+        client_name: "Internal Token Test",
+        token_endpoint_auth_method: "client_secret_basic",
       };
 
       const registerRequest = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
-      const registerResponse = await providerWithExternalValidation.fetch(registerRequest, mockEnv, mockCtx);
+      const registerResponse = await providerWithExternalValidation.fetch(
+        registerRequest,
+        mockEnv,
+        mockCtx,
+      );
       const client = await registerResponse.json<any>();
       const clientId = client.client_id;
       const clientSecret = client.client_secret;
-      const redirectUri = 'https://client.example.com/callback';
+      const redirectUri = "https://client.example.com/callback";
 
       // Get auth code
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
+          `&scope=read%20write&state=xyz123`,
       );
 
-      const authResponse = await providerWithExternalValidation.fetch(authRequest, mockEnv, mockCtx);
-      const location = authResponse.headers.get('Location')!;
-      const code = new URL(location).searchParams.get('code')!;
+      const authResponse = await providerWithExternalValidation.fetch(
+        authRequest,
+        mockEnv,
+        mockCtx,
+      );
+      const location = authResponse.headers.get("Location")!;
+      const code = new URL(location).searchParams.get("code")!;
 
       // Exchange for tokens
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
-      const tokenResponse = await providerWithExternalValidation.fetch(tokenRequest, mockEnv, mockCtx);
+      const tokenResponse = await providerWithExternalValidation.fetch(
+        tokenRequest,
+        mockEnv,
+        mockCtx,
+      );
       const tokens = await tokenResponse.json<any>();
       const internalAccessToken = tokens.access_token;
 
       // Now use the internal token - should NOT call external validation
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${internalAccessToken}`,
       });
 
@@ -5627,34 +5753,34 @@ describe('OAuthProvider', () => {
       expect(apiResponse.status).toBe(200);
       const responseData = await apiResponse.json<any>();
       expect(responseData.user).toEqual({
-        userId: 'test-user-123',
-        username: 'TestUser',
+        userId: "test-user-123",
+        username: "TestUser",
       });
 
       // Verify external validation was NOT called for internal token
       expect(externalTokenCalls.length).toBe(0);
     });
 
-    it('should handle external tokens that use the same format as internal tokens', async () => {
+    it("should handle external tokens that use the same format as internal tokens", async () => {
       // Mock external token validation
       const externalTokenCalls: any[] = [];
 
       const providerWithExternalValidation = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         resolveExternalToken: async (input) => {
           externalTokenCalls.push({ token: input.token });
 
           // Even if token looks like internal format, treat it as external
-          if (input.token === 'user123:grant456:secret789') {
+          if (input.token === "user123:grant456:secret789") {
             return {
               props: {
-                userId: 'external-user-from-mimicked-token',
-                source: 'external-service',
+                userId: "external-user-from-mimicked-token",
+                source: "external-service",
               },
             };
           }
@@ -5664,8 +5790,8 @@ describe('OAuthProvider', () => {
       });
 
       // Use a token that mimics internal format but doesn't exist in KV
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer user123:grant456:secret789',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer user123:grant456:secret789",
       });
 
       const apiResponse = await providerWithExternalValidation.fetch(apiRequest, mockEnv, mockCtx);
@@ -5673,45 +5799,45 @@ describe('OAuthProvider', () => {
       expect(apiResponse.status).toBe(200);
       const responseData = await apiResponse.json<any>();
       expect(responseData.user).toEqual({
-        userId: 'external-user-from-mimicked-token',
-        source: 'external-service',
+        userId: "external-user-from-mimicked-token",
+        source: "external-service",
       });
 
       // Verify external validation was called
       expect(externalTokenCalls.length).toBe(1);
-      expect(externalTokenCalls[0].token).toBe('user123:grant456:secret789');
+      expect(externalTokenCalls[0].token).toBe("user123:grant456:secret789");
     });
 
-    it('should call external validation for non-internal token formats', async () => {
+    it("should call external validation for non-internal token formats", async () => {
       const externalTokenCalls: any[] = [];
 
       const providerWithExternalValidation = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         resolveExternalToken: async (input) => {
           externalTokenCalls.push({ token: input.token });
 
           // Handle JWT-like tokens
-          if (input.token.startsWith('eyJ')) {
+          if (input.token.startsWith("eyJ")) {
             return {
               props: {
-                userId: 'jwt-user',
-                tokenType: 'jwt',
-                issuer: 'external-auth-server',
+                userId: "jwt-user",
+                tokenType: "jwt",
+                issuer: "external-auth-server",
               },
             };
           }
 
           // Handle simple bearer tokens
-          if (input.token === 'simple-bearer-token') {
+          if (input.token === "simple-bearer-token") {
             return {
               props: {
-                userId: 'bearer-user',
-                tokenType: 'bearer',
+                userId: "bearer-user",
+                tokenType: "bearer",
               },
             };
           }
@@ -5721,52 +5847,56 @@ describe('OAuthProvider', () => {
       });
 
       // Test JWT-like token
-      const jwtRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mock.token',
+      const jwtRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mock.token",
       });
 
       const jwtResponse = await providerWithExternalValidation.fetch(jwtRequest, mockEnv, mockCtx);
       expect(jwtResponse.status).toBe(200);
       const jwtData = await jwtResponse.json<any>();
-      expect(jwtData.user.tokenType).toBe('jwt');
-      expect(jwtData.user.issuer).toBe('external-auth-server');
+      expect(jwtData.user.tokenType).toBe("jwt");
+      expect(jwtData.user.issuer).toBe("external-auth-server");
 
       // Test simple bearer token
-      const bearerRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer simple-bearer-token',
+      const bearerRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer simple-bearer-token",
       });
 
-      const bearerResponse = await providerWithExternalValidation.fetch(bearerRequest, mockEnv, mockCtx);
+      const bearerResponse = await providerWithExternalValidation.fetch(
+        bearerRequest,
+        mockEnv,
+        mockCtx,
+      );
       expect(bearerResponse.status).toBe(200);
       const bearerData = await bearerResponse.json<any>();
-      expect(bearerData.user.tokenType).toBe('bearer');
+      expect(bearerData.user.tokenType).toBe("bearer");
 
       // Verify both external validations were called
       expect(externalTokenCalls.length).toBe(2);
-      expect(externalTokenCalls[0].token).toBe('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mock.token');
-      expect(externalTokenCalls[1].token).toBe('simple-bearer-token');
+      expect(externalTokenCalls[0].token).toBe("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mock.token");
+      expect(externalTokenCalls[1].token).toBe("simple-bearer-token");
     });
 
-    it('should handle async external token validation properly', async () => {
+    it("should handle async external token validation properly", async () => {
       const externalTokenCalls: any[] = [];
 
       const providerWithAsyncValidation = new OAuthProvider({
-        apiRoute: ['/api/'],
+        apiRoute: ["/api/"],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        authorizeEndpoint: "/authorize",
+        tokenEndpoint: "/oauth/token",
+        scopesSupported: ["read", "write"],
         resolveExternalToken: async (input) => {
           externalTokenCalls.push({ token: input.token, startTime: Date.now() });
 
           // Simulate async work (e.g., calling external API)
           await new Promise((resolve) => setTimeout(resolve, 15));
 
-          if (input.token === 'async-valid-token') {
+          if (input.token === "async-valid-token") {
             return {
               props: {
-                userId: 'async-user',
+                userId: "async-user",
                 validatedAt: new Date().toISOString(),
                 asyncValidation: true,
               },
@@ -5777,8 +5907,8 @@ describe('OAuthProvider', () => {
         },
       });
 
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: 'Bearer async-valid-token',
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
+        Authorization: "Bearer async-valid-token",
       });
 
       const startTime = Date.now();
@@ -5796,30 +5926,30 @@ describe('OAuthProvider', () => {
     });
   });
 
-  describe('Token Revocation', () => {
+  describe("Token Revocation", () => {
     let clientId: string;
     let clientSecret: string;
     let redirectUri: string;
 
     beforeEach(async () => {
-      redirectUri = 'https://client.example.com/callback';
+      redirectUri = "https://client.example.com/callback";
 
       // Create a test client
       const clientResponse = await oauthProvider.fetch(
         createMockRequest(
-          'https://example.com/oauth/register',
-          'POST',
+          "https://example.com/oauth/register",
+          "POST",
           {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
           JSON.stringify({
             redirect_uris: [redirectUri],
-            client_name: 'Test Client for Revocation',
-            token_endpoint_auth_method: 'client_secret_basic',
-          })
+            client_name: "Test Client for Revocation",
+            token_endpoint_auth_method: "client_secret_basic",
+          }),
         ),
         mockEnv,
-        mockCtx
+        mockCtx,
       );
 
       expect(clientResponse.status).toBe(201);
@@ -5828,22 +5958,22 @@ describe('OAuthProvider', () => {
       clientSecret = client.client_secret;
     });
 
-    it('should connect revokeGrant to token endpoint ', async () => {
+    it("should connect revokeGrant to token endpoint ", async () => {
       // Step 1: Get tokens through normal OAuth flow
       const authRequest = createMockRequest(
-        `https://example.com/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read&state=test-state`
+        `https://example.com/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read&state=test-state`,
       );
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code');
+      const code = new URL(authResponse.headers.get("Location")!).searchParams.get("code");
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        `grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(redirectUri)}`
+        `grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(redirectUri)}`,
       );
 
       const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
@@ -5852,22 +5982,22 @@ describe('OAuthProvider', () => {
 
       // Step 2:this should successfully revoke the token
       const revokeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        `token=${tokens.access_token}`
+        `token=${tokens.access_token}`,
       );
 
       const revokeResponse = await oauthProvider.fetch(revokeRequest, mockEnv, mockCtx);
       // Verify response doesn't contain unsupported_grant_type error
       const revokeResponseText = await revokeResponse.text();
-      expect(revokeResponseText).not.toContain('unsupported_grant_type');
+      expect(revokeResponseText).not.toContain("unsupported_grant_type");
 
       // Step 3: Verify the access token is actually revoked
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+      const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
         Authorization: `Bearer ${tokens.access_token}`,
       });
       const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
@@ -5875,13 +6005,13 @@ describe('OAuthProvider', () => {
 
       // Step 4: Verify refresh token still works
       const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
+        "https://example.com/oauth/token",
+        "POST",
         {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
           Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         },
-        `grant_type=refresh_token&refresh_token=${tokens.refresh_token}`
+        `grant_type=refresh_token&refresh_token=${tokens.refresh_token}`,
       );
 
       const refreshResponse = await oauthProvider.fetch(refreshRequest, mockEnv, mockCtx);
@@ -5892,7 +6022,7 @@ describe('OAuthProvider', () => {
     });
   });
 
-  describe('Client ID Metadata Document (CIMD)', () => {
+  describe("Client ID Metadata Document (CIMD)", () => {
     let originalFetch: typeof globalThis.fetch;
     let originalCloudflare: Cloudflare | undefined;
 
@@ -5914,31 +6044,33 @@ describe('OAuthProvider', () => {
 
     function createMockFetchResponse(
       body: object | string,
-      options: { status?: number; headers?: Record<string, string> } = {}
+      options: { status?: number; headers?: Record<string, string> } = {},
     ): Response {
       const { status = 200, headers = {} } = options;
-      const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+      const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
       return new Response(bodyStr, {
         status,
-        headers: { 'Content-Type': 'application/json', ...headers },
+        headers: { "Content-Type": "application/json", ...headers },
       });
     }
 
-    describe('Valid CIMD Flow', () => {
-      it('should accept valid CIMD URL as client_id', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+    describe("Valid CIMD Flow", () => {
+      it("should accept valid CIMD URL as client_id", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          client_name: 'CIMD Test Client',
-          redirect_uris: ['https://client.example.com/callback'],
-          token_endpoint_auth_method: 'none',
+          client_name: "CIMD Test Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          token_endpoint_auth_method: "none",
         };
 
-        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+        globalThis.fetch = vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
@@ -5947,13 +6079,16 @@ describe('OAuthProvider', () => {
         expect(globalThis.fetch).toHaveBeenCalledWith(
           cimdUrl,
           expect.objectContaining({
-            headers: expect.objectContaining({ Accept: 'application/json' }),
-          })
+            headers: expect.objectContaining({ Accept: "application/json" }),
+          }),
         );
       });
 
-      it('should advertise CIMD support in metadata', async () => {
-        const metadataRequest = createMockRequest('https://example.com/.well-known/oauth-authorization-server', 'GET');
+      it("should advertise CIMD support in metadata", async () => {
+        const metadataRequest = createMockRequest(
+          "https://example.com/.well-known/oauth-authorization-server",
+          "GET",
+        );
 
         const metadataResponse = await oauthProvider.fetch(metadataRequest, mockEnv, mockCtx);
         const metadata = await metadataResponse.json<any>();
@@ -5962,71 +6097,73 @@ describe('OAuthProvider', () => {
       });
     });
 
-    describe('Response Size Limit (DoS Prevention)', () => {
-      it('should reject responses exceeding 5KB via Content-Length header', async () => {
-        const cimdUrl = 'https://malicious.example.com/oauth/metadata.json';
+    describe("Response Size Limit (DoS Prevention)", () => {
+      it("should reject responses exceeding 5KB via Content-Length header", async () => {
+        const cimdUrl = "https://malicious.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          redirect_uris: ['https://malicious.example.com/callback'],
+          redirect_uris: ["https://malicious.example.com/callback"],
         };
 
         globalThis.fetch = vi.fn().mockResolvedValue(
           createMockFetchResponse(validMetadata, {
-            headers: { 'Content-Length': '10000' },
-          })
+            headers: { "Content-Length": "10000" },
+          }),
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://malicious.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://malicious.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'Client metadata exceeds size limit'
+          "Client metadata exceeds size limit",
         );
       });
 
-      it('should reject responses exceeding 5KB via streaming', async () => {
-        const cimdUrl = 'https://malicious.example.com/oauth/metadata.json';
+      it("should reject responses exceeding 5KB via streaming", async () => {
+        const cimdUrl = "https://malicious.example.com/oauth/metadata.json";
         const largeBody = JSON.stringify({
           client_id: cimdUrl,
-          redirect_uris: ['https://malicious.example.com/callback'],
-          padding: 'x'.repeat(6000),
+          redirect_uris: ["https://malicious.example.com/callback"],
+          padding: "x".repeat(6000),
         });
 
         globalThis.fetch = vi.fn().mockResolvedValue(
           new Response(largeBody, {
             status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
+            headers: { "Content-Type": "application/json" },
+          }),
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://malicious.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://malicious.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'Response exceeded size limit'
+          "Response exceeded size limit",
         );
       });
     });
 
-    describe('HTTP Caching (Cloudflare)', () => {
-      it('should pass cacheEverything option to fetch for CIMD requests', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+    describe("HTTP Caching (Cloudflare)", () => {
+      it("should pass cacheEverything option to fetch for CIMD requests", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          client_name: 'Cached Client',
-          redirect_uris: ['https://client.example.com/callback'],
-          token_endpoint_auth_method: 'none',
+          client_name: "Cached Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          token_endpoint_auth_method: "none",
         };
 
-        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+        globalThis.fetch = vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
         await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
 
@@ -6035,35 +6172,35 @@ describe('OAuthProvider', () => {
           cimdUrl,
           expect.objectContaining({
             cf: { cacheEverything: true },
-          })
+          }),
         );
 
         // No KV caching anymore
         const cacheKey = `cimd:${cimdUrl}`;
-        const cached = await mockEnv.OAUTH_KV.get(cacheKey, { type: 'json' });
+        const cached = await mockEnv.OAUTH_KV.get(cacheKey, { type: "json" });
         expect(cached).toBeNull();
       });
 
-      it('should fetch CIMD metadata with cacheEverything even with Cache-Control headers', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should fetch CIMD metadata with cacheEverything even with Cache-Control headers", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          client_name: 'Cache TTL Client',
-          redirect_uris: ['https://client.example.com/callback'],
-          token_endpoint_auth_method: 'none',
+          client_name: "Cache TTL Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          token_endpoint_auth_method: "none",
         };
 
         globalThis.fetch = vi.fn().mockImplementation(() =>
           Promise.resolve(
             createMockFetchResponse(validMetadata, {
-              headers: { 'Cache-Control': 'max-age=7200' },
-            })
-          )
+              headers: { "Cache-Control": "max-age=7200" },
+            }),
+          ),
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
         await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
 
@@ -6072,127 +6209,129 @@ describe('OAuthProvider', () => {
           cimdUrl,
           expect.objectContaining({
             cf: { cacheEverything: true },
-          })
+          }),
         );
       });
 
-      it('should NOT cache error responses (Cloudflare HTTP cache handles caching)', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
-        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
+      it("should NOT cache error responses (Cloudflare HTTP cache handles caching)", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
+        globalThis.fetch = vi.fn().mockResolvedValue(new Response("Not Found", { status: 404 }));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'Failed to fetch client metadata: HTTP 404'
+          "Failed to fetch client metadata: HTTP 404",
         );
 
         // No KV caching anymore - Cloudflare HTTP cache handles caching
         const cacheKey = `cimd:${cimdUrl}`;
-        const cached = await mockEnv.OAUTH_KV.get(cacheKey, { type: 'json' });
+        const cached = await mockEnv.OAUTH_KV.get(cacheKey, { type: "json" });
         expect(cached).toBeNull();
       });
 
-      it('should NOT cache invalid metadata documents (Cloudflare HTTP cache handles caching)', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should NOT cache invalid metadata documents (Cloudflare HTTP cache handles caching)", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const invalidMetadata = {
-          client_id: 'https://different.example.com/metadata.json',
-          redirect_uris: ['https://client.example.com/callback'],
+          client_id: "https://different.example.com/metadata.json",
+          redirect_uris: ["https://client.example.com/callback"],
         };
 
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'client_id "https://different.example.com/metadata.json" does not match metadata URL'
+          'client_id "https://different.example.com/metadata.json" does not match metadata URL',
         );
 
         // No KV caching anymore - Cloudflare HTTP cache handles caching
         const cacheKey = `cimd:${cimdUrl}`;
-        const cached = await mockEnv.OAUTH_KV.get(cacheKey, { type: 'json' });
+        const cached = await mockEnv.OAUTH_KV.get(cacheKey, { type: "json" });
         expect(cached).toBeNull();
       });
     });
 
-    describe('Symmetric Auth Method Rejection', () => {
-      it('should reject client_secret_post auth method', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+    describe("Symmetric Auth Method Rejection", () => {
+      it("should reject client_secret_post auth method", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         globalThis.fetch = vi.fn().mockResolvedValue(
           createMockFetchResponse({
             client_id: cimdUrl,
-            redirect_uris: ['https://client.example.com/callback'],
-            token_endpoint_auth_method: 'client_secret_post',
-          })
+            redirect_uris: ["https://client.example.com/callback"],
+            token_endpoint_auth_method: "client_secret_post",
+          }),
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'is not allowed for CIMD clients. Allowed methods: none, private_key_jwt'
+          "is not allowed for CIMD clients. Allowed methods: none, private_key_jwt",
         );
       });
 
-      it('should reject client_secret_basic auth method', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should reject client_secret_basic auth method", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         globalThis.fetch = vi.fn().mockResolvedValue(
           createMockFetchResponse({
             client_id: cimdUrl,
-            redirect_uris: ['https://client.example.com/callback'],
-            token_endpoint_auth_method: 'client_secret_basic',
-          })
+            redirect_uris: ["https://client.example.com/callback"],
+            token_endpoint_auth_method: "client_secret_basic",
+          }),
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'is not allowed for CIMD clients. Allowed methods: none, private_key_jwt'
+          "is not allowed for CIMD clients. Allowed methods: none, private_key_jwt",
         );
       });
 
-      it('should reject client_secret_jwt auth method', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should reject client_secret_jwt auth method", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         globalThis.fetch = vi.fn().mockResolvedValue(
           createMockFetchResponse({
             client_id: cimdUrl,
-            redirect_uris: ['https://client.example.com/callback'],
-            token_endpoint_auth_method: 'client_secret_jwt',
-          })
+            redirect_uris: ["https://client.example.com/callback"],
+            token_endpoint_auth_method: "client_secret_jwt",
+          }),
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'is not allowed for CIMD clients. Allowed methods: none, private_key_jwt'
+          "is not allowed for CIMD clients. Allowed methods: none, private_key_jwt",
         );
       });
 
-      it('should accept none auth method', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should accept none auth method", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          client_name: 'Public CIMD Client',
-          redirect_uris: ['https://client.example.com/callback'],
-          token_endpoint_auth_method: 'none',
+          client_name: "Public CIMD Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          token_endpoint_auth_method: "none",
         };
 
-        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+        globalThis.fetch = vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
@@ -6201,21 +6340,23 @@ describe('OAuthProvider', () => {
         expect(authResponse.status).toBe(302);
       });
 
-      it('should accept private_key_jwt auth method', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should accept private_key_jwt auth method", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          client_name: 'Private Key CIMD Client',
-          redirect_uris: ['https://client.example.com/callback'],
-          token_endpoint_auth_method: 'private_key_jwt',
-          jwks_uri: 'https://client.example.com/.well-known/jwks.json',
+          client_name: "Private Key CIMD Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          token_endpoint_auth_method: "private_key_jwt",
+          jwks_uri: "https://client.example.com/.well-known/jwks.json",
         };
 
-        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+        globalThis.fetch = vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
@@ -6225,165 +6366,177 @@ describe('OAuthProvider', () => {
       });
     });
 
-    describe('Metadata Validation', () => {
-      it('should reject when client_id does not match URL', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+    describe("Metadata Validation", () => {
+      it("should reject when client_id does not match URL", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const invalidMetadata = {
-          client_id: 'https://different.example.com/metadata.json',
-          redirect_uris: ['https://client.example.com/callback'],
+          client_id: "https://different.example.com/metadata.json",
+          redirect_uris: ["https://client.example.com/callback"],
         };
 
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'client_id "https://different.example.com/metadata.json" does not match metadata URL'
+          'client_id "https://different.example.com/metadata.json" does not match metadata URL',
         );
       });
 
-      it('should reject when redirect_uris is missing', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should reject when redirect_uris is missing", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const invalidMetadata = {
           client_id: cimdUrl,
-          client_name: 'Missing Redirects Client',
+          client_name: "Missing Redirects Client",
         };
 
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'redirect_uris is required and must not be empty'
+          "redirect_uris is required and must not be empty",
         );
       });
 
-      it('should reject when redirect_uris is empty', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should reject when redirect_uris is empty", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const invalidMetadata = {
           client_id: cimdUrl,
-          client_name: 'Empty Redirects Client',
+          client_name: "Empty Redirects Client",
           redirect_uris: [],
         };
 
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'redirect_uris is required and must not be empty'
+          "redirect_uris is required and must not be empty",
         );
       });
 
-      it('should reject invalid JSON response', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should reject invalid JSON response", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
 
         globalThis.fetch = vi.fn().mockResolvedValue(
-          new Response('not valid json {{{', {
+          new Response("not valid json {{{", {
             status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
+            headers: { "Content-Type": "application/json" },
+          }),
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('is not valid JSON');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+          "is not valid JSON",
+        );
       });
     });
 
-    describe('URL Detection', () => {
-      it('should NOT treat HTTP URLs as CIMD', async () => {
-        const httpUrl = 'http://client.example.com/oauth/metadata.json';
+    describe("URL Detection", () => {
+      it("should NOT treat HTTP URLs as CIMD", async () => {
+        const httpUrl = "http://client.example.com/oauth/metadata.json";
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(httpUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(httpUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+          "Invalid client",
+        );
         expect(globalThis.fetch).not.toHaveBeenCalled();
       });
 
-      it('should NOT treat HTTPS URLs without path as CIMD', async () => {
-        const urlWithoutPath = 'https://client.example.com';
+      it("should NOT treat HTTPS URLs without path as CIMD", async () => {
+        const urlWithoutPath = "https://client.example.com";
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithoutPath)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithoutPath)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+          "Invalid client",
+        );
         expect(globalThis.fetch).not.toHaveBeenCalled();
       });
 
-      it('should NOT treat HTTPS URLs with only root path as CIMD', async () => {
-        const urlWithRootPath = 'https://client.example.com/';
+      it("should NOT treat HTTPS URLs with only root path as CIMD", async () => {
+        const urlWithRootPath = "https://client.example.com/";
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithRootPath)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithRootPath)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+          "Invalid client",
+        );
         expect(globalThis.fetch).not.toHaveBeenCalled();
       });
 
-      it('should treat regular client_id strings as KV lookup', async () => {
-        const regularClientId = 'my-client-id';
+      it("should treat regular client_id strings as KV lookup", async () => {
+        const regularClientId = "my-client-id";
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(regularClientId)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(regularClientId)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+          "Invalid client",
+        );
         expect(globalThis.fetch).not.toHaveBeenCalled();
       });
     });
 
-    describe('Request Timeout', () => {
-      it('should handle fetch abort gracefully', async () => {
-        const cimdUrl = 'https://abort.example.com/oauth/metadata.json';
-        globalThis.fetch = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+    describe("Request Timeout", () => {
+      it("should handle fetch abort gracefully", async () => {
+        const cimdUrl = "https://abort.example.com/oauth/metadata.json";
+        globalThis.fetch = vi.fn().mockRejectedValue(new DOMException("Aborted", "AbortError"));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://abort.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://abort.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Aborted');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow("Aborted");
       });
 
-      it('should pass AbortSignal to fetch', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+      it("should pass AbortSignal to fetch", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          client_name: 'Test Client',
-          redirect_uris: ['https://client.example.com/callback'],
-          token_endpoint_auth_method: 'none',
+          client_name: "Test Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          token_endpoint_auth_method: "none",
         };
 
-        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+        globalThis.fetch = vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
@@ -6391,55 +6544,59 @@ describe('OAuthProvider', () => {
           cimdUrl,
           expect.objectContaining({
             signal: expect.any(AbortSignal),
-          })
+          }),
         );
       });
     });
 
-    describe('HTTP Error Handling', () => {
-      it('should reject 404 responses', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
-        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
+    describe("HTTP Error Handling", () => {
+      it("should reject 404 responses", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
+        globalThis.fetch = vi.fn().mockResolvedValue(new Response("Not Found", { status: 404 }));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'Failed to fetch client metadata: HTTP 404'
+          "Failed to fetch client metadata: HTTP 404",
         );
       });
 
-      it('should reject 500 responses', async () => {
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
-        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Internal Server Error', { status: 500 }));
+      it("should reject 500 responses", async () => {
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
+        globalThis.fetch = vi
+          .fn()
+          .mockResolvedValue(new Response("Internal Server Error", { status: 500 }));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          'Failed to fetch client metadata: HTTP 500'
+          "Failed to fetch client metadata: HTTP 500",
         );
       });
 
-      it('should handle network errors gracefully', async () => {
-        const cimdUrl = 'https://unreachable.example.com/oauth/metadata.json';
-        globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      it("should handle network errors gracefully", async () => {
+        const cimdUrl = "https://unreachable.example.com/oauth/metadata.json";
+        globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://unreachable.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://unreachable.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Network error');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+          "Network error",
+        );
       });
     });
 
-    describe('SSRF Protection', () => {
-      it('should reject CIMD fetch when global_fetch_strictly_public is not enabled', async () => {
+    describe("SSRF Protection", () => {
+      it("should reject CIMD fetch when global_fetch_strictly_public is not enabled", async () => {
         // Remove the compatibility flag to simulate it not being enabled
         (globalThis as any).Cloudflare = {
           compatibilityFlags: {
@@ -6447,126 +6604,141 @@ describe('OAuthProvider', () => {
           },
         };
 
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
         const validMetadata = {
           client_id: cimdUrl,
-          client_name: 'CIMD Test Client',
-          redirect_uris: ['https://client.example.com/callback'],
-          token_endpoint_auth_method: 'none',
+          client_name: "CIMD Test Client",
+          redirect_uris: ["https://client.example.com/callback"],
+          token_endpoint_auth_method: "none",
         };
 
         // Fetch should not even be called
         const fetchSpy = vi.fn().mockResolvedValue(
           new Response(JSON.stringify(validMetadata), {
             status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
+            headers: { "Content-Type": "application/json" },
+          }),
         );
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          "global_fetch_strictly_public' compatibility flag is not enabled"
+          "global_fetch_strictly_public' compatibility flag is not enabled",
         );
         expect(fetchSpy).not.toHaveBeenCalled();
       });
 
-      it('should reject CIMD fetch when Cloudflare global is undefined', async () => {
+      it("should reject CIMD fetch when Cloudflare global is undefined", async () => {
         // Remove the Cloudflare global entirely
         delete (globalThis as any).Cloudflare;
 
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
 
         const fetchSpy = vi.fn();
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          "global_fetch_strictly_public' compatibility flag is not enabled"
+          "global_fetch_strictly_public' compatibility flag is not enabled",
         );
         expect(fetchSpy).not.toHaveBeenCalled();
       });
 
-      it('should reject CIMD fetch when compatibilityFlags is undefined', async () => {
+      it("should reject CIMD fetch when compatibilityFlags is undefined", async () => {
         // Cloudflare exists but without compatibilityFlags
         (globalThis as any).Cloudflare = {};
 
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+        const cimdUrl = "https://client.example.com/oauth/metadata.json";
 
         const fetchSpy = vi.fn();
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
-          'GET'
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent("https://client.example.com/callback")}&response_type=code&state=test-state`,
+          "GET",
         );
 
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-          "global_fetch_strictly_public' compatibility flag is not enabled"
+          "global_fetch_strictly_public' compatibility flag is not enabled",
         );
         expect(fetchSpy).not.toHaveBeenCalled();
       });
 
-      it('should report client_id_metadata_document_supported as true when flag is enabled', async () => {
+      it("should report client_id_metadata_document_supported as true when flag is enabled", async () => {
         // Flag is enabled in beforeEach
-        const metadataRequest = createMockRequest('https://example.com/.well-known/oauth-authorization-server', 'GET');
+        const metadataRequest = createMockRequest(
+          "https://example.com/.well-known/oauth-authorization-server",
+          "GET",
+        );
         const response = await oauthProvider.fetch(metadataRequest, mockEnv, mockCtx);
-        const metadata = (await response.json()) as { client_id_metadata_document_supported: boolean };
+        const metadata = (await response.json()) as {
+          client_id_metadata_document_supported: boolean;
+        };
 
         expect(metadata.client_id_metadata_document_supported).toBe(true);
       });
 
-      it('should report client_id_metadata_document_supported as false when flag is not enabled', async () => {
+      it("should report client_id_metadata_document_supported as false when flag is not enabled", async () => {
         (globalThis as any).Cloudflare = {
           compatibilityFlags: {
             global_fetch_strictly_public: false,
           },
         };
 
-        const metadataRequest = createMockRequest('https://example.com/.well-known/oauth-authorization-server', 'GET');
+        const metadataRequest = createMockRequest(
+          "https://example.com/.well-known/oauth-authorization-server",
+          "GET",
+        );
         const response = await oauthProvider.fetch(metadataRequest, mockEnv, mockCtx);
-        const metadata = (await response.json()) as { client_id_metadata_document_supported: boolean };
+        const metadata = (await response.json()) as {
+          client_id_metadata_document_supported: boolean;
+        };
 
         expect(metadata.client_id_metadata_document_supported).toBe(false);
       });
 
-      it('should report client_id_metadata_document_supported as false when Cloudflare global is undefined', async () => {
+      it("should report client_id_metadata_document_supported as false when Cloudflare global is undefined", async () => {
         delete (globalThis as any).Cloudflare;
 
-        const metadataRequest = createMockRequest('https://example.com/.well-known/oauth-authorization-server', 'GET');
+        const metadataRequest = createMockRequest(
+          "https://example.com/.well-known/oauth-authorization-server",
+          "GET",
+        );
         const response = await oauthProvider.fetch(metadataRequest, mockEnv, mockCtx);
-        const metadata = (await response.json()) as { client_id_metadata_document_supported: boolean };
+        const metadata = (await response.json()) as {
+          client_id_metadata_document_supported: boolean;
+        };
 
         expect(metadata.client_id_metadata_document_supported).toBe(false);
       });
     });
   });
 
-  describe('RFC 8252 Loopback Redirect URI Port Flexibility', () => {
+  describe("RFC 8252 Loopback Redirect URI Port Flexibility", () => {
     let clientId: string;
     let clientSecret: string;
 
     // Helper to register a client with given redirect URIs
-    async function registerClient(redirectUris: string[], authMethod = 'client_secret_basic') {
+    async function registerClient(redirectUris: string[], authMethod = "client_secret_basic") {
       const clientData = {
         redirect_uris: redirectUris,
-        client_name: 'Loopback Test Client',
+        client_name: "Loopback Test Client",
         token_endpoint_auth_method: authMethod,
       };
 
       const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
+        "https://example.com/oauth/register",
+        "POST",
+        { "Content-Type": "application/json" },
+        JSON.stringify(clientData),
       );
 
       const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
@@ -6580,289 +6752,303 @@ describe('OAuthProvider', () => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read&state=xyz123`
+          `&scope=read&state=xyz123`,
       );
       return oauthProvider.fetch(authRequest, mockEnv, mockCtx);
     }
 
     // Helper to extract auth code from redirect response
     function extractCode(response: Response): string {
-      const location = response.headers.get('Location')!;
+      const location = response.headers.get("Location")!;
       const url = new URL(location);
-      return url.searchParams.get('code')!;
+      return url.searchParams.get("code")!;
     }
 
     // Helper to exchange auth code for tokens
     async function exchangeCode(code: string, redirectUri: string) {
       const params = new URLSearchParams();
-      params.append('grant_type', 'authorization_code');
-      params.append('code', code);
-      params.append('redirect_uri', redirectUri);
-      params.append('client_id', clientId);
-      params.append('client_secret', clientSecret);
+      params.append("grant_type", "authorization_code");
+      params.append("code", code);
+      params.append("redirect_uri", redirectUri);
+      params.append("client_id", clientId);
+      params.append("client_secret", clientSecret);
 
       const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        { 'Content-Type': 'application/x-www-form-urlencoded' },
-        params.toString()
+        "https://example.com/oauth/token",
+        "POST",
+        { "Content-Type": "application/x-www-form-urlencoded" },
+        params.toString(),
       );
 
       return oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
     }
 
-    describe('should allow different ports for loopback redirect URIs', () => {
-      it('should accept 127.0.0.1 with different port than registered', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
-        const response = await makeAuthRequest('http://127.0.0.1:52431/callback');
+    describe("should allow different ports for loopback redirect URIs", () => {
+      it("should accept 127.0.0.1 with different port than registered", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
+        const response = await makeAuthRequest("http://127.0.0.1:52431/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
 
-      it('should accept 127.0.0.1 with no port when registered has port', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
-        const response = await makeAuthRequest('http://127.0.0.1/callback');
+      it("should accept 127.0.0.1 with no port when registered has port", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
+        const response = await makeAuthRequest("http://127.0.0.1/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
 
-      it('should accept 127.0.0.1 with port when registered has no port', async () => {
-        await registerClient(['http://127.0.0.1/callback']);
-        const response = await makeAuthRequest('http://127.0.0.1:9999/callback');
+      it("should accept 127.0.0.1 with port when registered has no port", async () => {
+        await registerClient(["http://127.0.0.1/callback"]);
+        const response = await makeAuthRequest("http://127.0.0.1:9999/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
 
-      it('should accept IPv6 loopback [::1] with different port', async () => {
-        await registerClient(['http://[::1]:8080/callback']);
-        const response = await makeAuthRequest('http://[::1]:43210/callback');
+      it("should accept IPv6 loopback [::1] with different port", async () => {
+        await registerClient(["http://[::1]:8080/callback"]);
+        const response = await makeAuthRequest("http://[::1]:43210/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
 
-      it('should accept 127.0.0.1 with same port (exact match still works)', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
-        const response = await makeAuthRequest('http://127.0.0.1:8080/callback');
+      it("should accept 127.0.0.1 with same port (exact match still works)", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
+        const response = await makeAuthRequest("http://127.0.0.1:8080/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
 
-      it('should accept loopback in the full 127.x.x.x range', async () => {
-        await registerClient(['http://127.255.255.255:8080/callback']);
-        const response = await makeAuthRequest('http://127.255.255.255:9999/callback');
+      it("should accept loopback in the full 127.x.x.x range", async () => {
+        await registerClient(["http://127.255.255.255:8080/callback"]);
+        const response = await makeAuthRequest("http://127.255.255.255:9999/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
     });
 
-    describe('should reject loopback URIs when non-port components differ', () => {
-      it('should reject loopback with different path', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
-        await expect(makeAuthRequest('http://127.0.0.1:8080/evil')).rejects.toThrow('Invalid redirect URI');
+    describe("should reject loopback URIs when non-port components differ", () => {
+      it("should reject loopback with different path", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
+        await expect(makeAuthRequest("http://127.0.0.1:8080/evil")).rejects.toThrow(
+          "Invalid redirect URI",
+        );
       });
 
-      it('should reject loopback with different scheme (http vs https)', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
-        await expect(makeAuthRequest('https://127.0.0.1:8080/callback')).rejects.toThrow('Invalid redirect URI');
+      it("should reject loopback with different scheme (http vs https)", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
+        await expect(makeAuthRequest("https://127.0.0.1:8080/callback")).rejects.toThrow(
+          "Invalid redirect URI",
+        );
       });
 
-      it('should reject loopback with different hostname (127.0.0.1 vs 127.0.0.2)', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
-        await expect(makeAuthRequest('http://127.0.0.2:8080/callback')).rejects.toThrow('Invalid redirect URI');
+      it("should reject loopback with different hostname (127.0.0.1 vs 127.0.0.2)", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
+        await expect(makeAuthRequest("http://127.0.0.2:8080/callback")).rejects.toThrow(
+          "Invalid redirect URI",
+        );
       });
 
-      it('should reject loopback IPv4 vs IPv6 mismatch', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
-        await expect(makeAuthRequest('http://[::1]:8080/callback')).rejects.toThrow('Invalid redirect URI');
+      it("should reject loopback IPv4 vs IPv6 mismatch", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
+        await expect(makeAuthRequest("http://[::1]:8080/callback")).rejects.toThrow(
+          "Invalid redirect URI",
+        );
       });
     });
 
-    describe('should NOT treat localhost as loopback (RFC 8252 Section 7.3)', () => {
-      it('should reject localhost with different port (exact match required)', async () => {
-        await registerClient(['http://localhost:8080/callback']);
-        await expect(makeAuthRequest('http://localhost:9999/callback')).rejects.toThrow('Invalid redirect URI');
+    describe("should NOT treat localhost as loopback (RFC 8252 Section 7.3)", () => {
+      it("should reject localhost with different port (exact match required)", async () => {
+        await registerClient(["http://localhost:8080/callback"]);
+        await expect(makeAuthRequest("http://localhost:9999/callback")).rejects.toThrow(
+          "Invalid redirect URI",
+        );
       });
 
-      it('should accept localhost with exact same URI', async () => {
-        await registerClient(['http://localhost:8080/callback']);
-        const response = await makeAuthRequest('http://localhost:8080/callback');
+      it("should accept localhost with exact same URI", async () => {
+        await registerClient(["http://localhost:8080/callback"]);
+        const response = await makeAuthRequest("http://localhost:8080/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
     });
 
-    describe('should preserve exact match for non-loopback URIs', () => {
-      it('should reject non-loopback with different port', async () => {
-        await registerClient(['https://example.com:8080/callback']);
-        await expect(makeAuthRequest('https://example.com:9090/callback')).rejects.toThrow('Invalid redirect URI');
+    describe("should preserve exact match for non-loopback URIs", () => {
+      it("should reject non-loopback with different port", async () => {
+        await registerClient(["https://example.com:8080/callback"]);
+        await expect(makeAuthRequest("https://example.com:9090/callback")).rejects.toThrow(
+          "Invalid redirect URI",
+        );
       });
 
-      it('should accept non-loopback with exact match', async () => {
-        await registerClient(['https://example.com/callback']);
-        const response = await makeAuthRequest('https://example.com/callback');
+      it("should accept non-loopback with exact match", async () => {
+        await registerClient(["https://example.com/callback"]);
+        const response = await makeAuthRequest("https://example.com/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
     });
 
-    describe('should validate loopback redirect URI in token exchange', () => {
-      it('should accept token exchange with different loopback port', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
+    describe("should validate loopback redirect URI in token exchange", () => {
+      it("should accept token exchange with different loopback port", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
 
         // Authorize with one port
-        const authResponse = await makeAuthRequest('http://127.0.0.1:52431/callback');
+        const authResponse = await makeAuthRequest("http://127.0.0.1:52431/callback");
         expect(authResponse.status).toBe(302);
         const code = extractCode(authResponse);
 
         // Exchange with yet another port
-        const tokenResponse = await exchangeCode(code, 'http://127.0.0.1:33333/callback');
+        const tokenResponse = await exchangeCode(code, "http://127.0.0.1:33333/callback");
         expect(tokenResponse.status).toBe(200);
         const tokens = await tokenResponse.json<any>();
         expect(tokens.access_token).toBeDefined();
         expect(tokens.refresh_token).toBeDefined();
       });
 
-      it('should reject token exchange with non-matching loopback path', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
+      it("should reject token exchange with non-matching loopback path", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
 
         // Authorize with valid loopback
-        const authResponse = await makeAuthRequest('http://127.0.0.1:52431/callback');
+        const authResponse = await makeAuthRequest("http://127.0.0.1:52431/callback");
         expect(authResponse.status).toBe(302);
         const code = extractCode(authResponse);
 
         // Exchange with different path
-        const tokenResponse = await exchangeCode(code, 'http://127.0.0.1:52431/evil');
+        const tokenResponse = await exchangeCode(code, "http://127.0.0.1:52431/evil");
         expect(tokenResponse.status).toBe(400);
         const error = await tokenResponse.json<any>();
-        expect(error.error).toBe('invalid_grant');
+        expect(error.error).toBe("invalid_grant");
       });
     });
 
-    describe('should validate loopback redirect URI in completeAuthorization', () => {
-      it('should reject completeAuthorization with tampered non-loopback redirect URI', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
+    describe("should validate loopback redirect URI in completeAuthorization", () => {
+      it("should reject completeAuthorization with tampered non-loopback redirect URI", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
 
         // Get helpers
-        await oauthProvider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+        await oauthProvider.fetch(createMockRequest("https://example.com/"), mockEnv, mockCtx);
         const helpers = mockEnv.OAUTH_PROVIDER!;
 
         // Parse a valid auth request
         const authRequest = createMockRequest(
           `https://example.com/authorize?response_type=code&client_id=${clientId}` +
-            `&redirect_uri=${encodeURIComponent('http://127.0.0.1:52431/callback')}` +
-            `&scope=read&state=xyz123`
+            `&redirect_uri=${encodeURIComponent("http://127.0.0.1:52431/callback")}` +
+            `&scope=read&state=xyz123`,
         );
         const oauthReqInfo = await helpers.parseAuthRequest(authRequest);
 
         // Tamper with redirect URI to a non-loopback address
-        const tamperedRequest = { ...oauthReqInfo, redirectUri: 'https://attacker.com/callback' };
+        const tamperedRequest = { ...oauthReqInfo, redirectUri: "https://attacker.com/callback" };
 
         await expect(
           helpers.completeAuthorization({
             request: tamperedRequest,
-            userId: 'test-user-123',
+            userId: "test-user-123",
             metadata: {},
             scope: tamperedRequest.scope,
             props: {},
-          })
-        ).rejects.toThrow('Invalid redirect URI');
+          }),
+        ).rejects.toThrow("Invalid redirect URI");
       });
 
-      it('should accept completeAuthorization with valid loopback different port', async () => {
-        await registerClient(['http://127.0.0.1:8080/callback']);
+      it("should accept completeAuthorization with valid loopback different port", async () => {
+        await registerClient(["http://127.0.0.1:8080/callback"]);
 
         // Get helpers
-        await oauthProvider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+        await oauthProvider.fetch(createMockRequest("https://example.com/"), mockEnv, mockCtx);
         const helpers = mockEnv.OAUTH_PROVIDER!;
 
         // Parse auth request with different port
         const authRequest = createMockRequest(
           `https://example.com/authorize?response_type=code&client_id=${clientId}` +
-            `&redirect_uri=${encodeURIComponent('http://127.0.0.1:52431/callback')}` +
-            `&scope=read&state=xyz123`
+            `&redirect_uri=${encodeURIComponent("http://127.0.0.1:52431/callback")}` +
+            `&scope=read&state=xyz123`,
         );
         const oauthReqInfo = await helpers.parseAuthRequest(authRequest);
 
         // Should succeed - loopback with different port
         const result = await helpers.completeAuthorization({
           request: oauthReqInfo,
-          userId: 'test-user-123',
+          userId: "test-user-123",
           metadata: {},
           scope: oauthReqInfo.scope,
           props: {},
         });
 
-        expect(result.redirectTo).toContain('http://127.0.0.1:52431/callback');
-        expect(result.redirectTo).toContain('code=');
+        expect(result.redirectTo).toContain("http://127.0.0.1:52431/callback");
+        expect(result.redirectTo).toContain("code=");
       });
     });
 
-    describe('full end-to-end flow with loopback ephemeral ports', () => {
-      it('should complete full auth code flow with different loopback ports at each stage', async () => {
+    describe("full end-to-end flow with loopback ephemeral ports", () => {
+      it("should complete full auth code flow with different loopback ports at each stage", async () => {
         // Register with one port
-        await registerClient(['http://127.0.0.1:8080/callback']);
+        await registerClient(["http://127.0.0.1:8080/callback"]);
 
         // Authorize with an ephemeral port (simulating native app)
-        const authResponse = await makeAuthRequest('http://127.0.0.1:52431/callback');
+        const authResponse = await makeAuthRequest("http://127.0.0.1:52431/callback");
         expect(authResponse.status).toBe(302);
 
-        const location = authResponse.headers.get('Location')!;
+        const location = authResponse.headers.get("Location")!;
         // Verify the redirect goes to the ephemeral port, not the registered one
-        expect(location).toContain('http://127.0.0.1:52431/callback');
+        expect(location).toContain("http://127.0.0.1:52431/callback");
         const code = extractCode(authResponse);
 
         // Exchange code with the same ephemeral port used during authorization
-        const tokenResponse = await exchangeCode(code, 'http://127.0.0.1:52431/callback');
+        const tokenResponse = await exchangeCode(code, "http://127.0.0.1:52431/callback");
         expect(tokenResponse.status).toBe(200);
 
         const tokens = await tokenResponse.json<any>();
         expect(tokens.access_token).toBeDefined();
         expect(tokens.refresh_token).toBeDefined();
-        expect(tokens.token_type).toBe('bearer');
+        expect(tokens.token_type).toBe("bearer");
 
         // Use the access token to access a protected API
-        const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+        const apiRequest = createMockRequest("https://example.com/api/test", "GET", {
           Authorization: `Bearer ${tokens.access_token}`,
         });
         const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
         expect(apiResponse.status).toBe(200);
       });
 
-      it('should complete full flow with IPv6 loopback', async () => {
-        await registerClient(['http://[::1]:3000/callback']);
+      it("should complete full flow with IPv6 loopback", async () => {
+        await registerClient(["http://[::1]:3000/callback"]);
 
         // Authorize with different port
-        const authResponse = await makeAuthRequest('http://[::1]:48721/callback');
+        const authResponse = await makeAuthRequest("http://[::1]:48721/callback");
         expect(authResponse.status).toBe(302);
         const code = extractCode(authResponse);
 
         // Exchange with the port used during auth
-        const tokenResponse = await exchangeCode(code, 'http://[::1]:48721/callback');
+        const tokenResponse = await exchangeCode(code, "http://[::1]:48721/callback");
         expect(tokenResponse.status).toBe(200);
         const tokens = await tokenResponse.json<any>();
         expect(tokens.access_token).toBeDefined();
       });
     });
 
-    describe('multiple registered redirect URIs with loopback', () => {
-      it('should match correct loopback URI from multiple registered URIs', async () => {
+    describe("multiple registered redirect URIs with loopback", () => {
+      it("should match correct loopback URI from multiple registered URIs", async () => {
         await registerClient([
-          'https://example.com/callback',
-          'http://127.0.0.1:8080/callback',
-          'http://127.0.0.1:8080/other-callback',
+          "https://example.com/callback",
+          "http://127.0.0.1:8080/callback",
+          "http://127.0.0.1:8080/other-callback",
         ]);
 
         // Should match the second registered URI (loopback with port flexibility)
-        const response = await makeAuthRequest('http://127.0.0.1:55555/callback');
+        const response = await makeAuthRequest("http://127.0.0.1:55555/callback");
         expect(response.status).toBe(302);
-        expect(response.headers.get('Location')).toContain('code=');
+        expect(response.headers.get("Location")).toContain("code=");
       });
 
-      it('should still reject when no registered URI matches loopback criteria', async () => {
-        await registerClient(['https://example.com/callback', 'http://127.0.0.1:8080/other-path']);
+      it("should still reject when no registered URI matches loopback criteria", async () => {
+        await registerClient(["https://example.com/callback", "http://127.0.0.1:8080/other-path"]);
 
         // Different path, should not match any registered URI
-        await expect(makeAuthRequest('http://127.0.0.1:55555/callback')).rejects.toThrow('Invalid redirect URI');
+        await expect(makeAuthRequest("http://127.0.0.1:55555/callback")).rejects.toThrow(
+          "Invalid redirect URI",
+        );
       });
     });
   });

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,8 +1,8 @@
-import { vi } from 'vitest';
-import { WorkerEntrypoint } from './mocks/cloudflare-workers';
+import { vi } from "vitest";
+import { WorkerEntrypoint } from "./mocks/cloudflare-workers";
 
 // Mock the 'cloudflare:workers' module
-vi.mock('cloudflare:workers', () => {
+vi.mock("cloudflare:workers", () => {
   return {
     WorkerEntrypoint,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,9 @@
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
         "@cloudflare/workers-types": "^4.20251218.0",
+        "oxfmt": "^0.31.0",
+        "oxlint": "^1.46.0",
         "pkg-pr-new": "^0.0.62",
-        "prettier": "^3.7.4",
         "tsdown": "^0.18.1",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -1417,6 +1418,652 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.31.0.tgz",
+      "integrity": "sha512-2A7s+TmsY7xF3yM0VWXq2YJ82Z7Rd7AOKraotyp58Fbk7q9cFZKczW6Zrz/iaMaJYfR/UHDxF3kMR11vayflug==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.31.0.tgz",
+      "integrity": "sha512-3ppKOIf2lQv/BFhRyENWs/oarueppCEnPNo0Az2fKkz63JnenRuJPoHaGRrMHg1oFMUitdYy+YH29Cv5ISZWRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.31.0.tgz",
+      "integrity": "sha512-eFhNnle077DPRW6QPsBtl/wEzPoqgsB1LlzDRYbbztizObHdCo6Yo8T0hew9+HoYtnVMAP19zcRE7VG9OfqkMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.31.0.tgz",
+      "integrity": "sha512-9UQSunEqokhR1WnlQCgJjkjw13y8PSnBvR98L78beGudTtNSaPMgwE7t/T0IPDibtDTxeEt+IQVKoQJ+8Jo6Lg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.31.0.tgz",
+      "integrity": "sha512-FHo7ITkDku3kQ8/44nU6IGR1UNH22aqYM3LV2ytV40hWSMVllXFlM+xIVusT+I/SZBAtuFpwEWzyS+Jn4TkkAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.31.0.tgz",
+      "integrity": "sha512-o1NiDlJDO9SOoY5wH8AyPUX60yQcOwu5oVuepi2eetArBp0iFF9qIH1uLlZsUu4QQ6ywqxcJSMjXCqGKC5uQFg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.31.0.tgz",
+      "integrity": "sha512-VXiRxlBz7ivAIjhnnVBEYdjCQ66AsjM0YKxYAcliS0vPqhWKiScIT61gee0DPCVaw1XcuW8u19tfRwpfdYoreg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.31.0.tgz",
+      "integrity": "sha512-ryGPOtPViNcjs8N8Ap+wn7SM6ViiLzR9f0Pu7yprae+wjl6qwnNytzsUe7wcb+jT43DJYmvemFqE8tLVUavYbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.31.0.tgz",
+      "integrity": "sha512-BA3Euxp4bfd+AU3cKPgmHL44BbuBtmQTyAQoVDhX/nqPgbS/auoGp71uQBE4SAPTsQM/FcXxfKmCAdBS7ygF9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.31.0.tgz",
+      "integrity": "sha512-wIiKHulVWE9s6PSftPItucTviyCvjugwPqEyUl1VD47YsFqa5UtQTknBN49NODHJvBgO+eqqUodgRqmNMp3xyw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.31.0.tgz",
+      "integrity": "sha512-6cM8Jt54bg9V/JoeUWhwnzHAS9Kvgc0oFsxql8PVs/njAGs0H4r+GEU4d+LXZPwI3b3ZUuzpbxlRJzer8KW+Cg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.31.0.tgz",
+      "integrity": "sha512-d+b05wXVRGaO6gobTaDqUdBvTXwYc0ro7k1UVC37k4VimLRQOzEZqTwVinqIX3LxTaFCmfO1yG00u9Pct3AKwQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.31.0.tgz",
+      "integrity": "sha512-Q+i2kj8e+two9jTZ3vxmxdNlg++qShe1ODL6xV4+Qt6SnJYniMxfcqphuXli4ft270kuHqd8HSVZs84CsSh1EA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.31.0.tgz",
+      "integrity": "sha512-F2Z5ffj2okhaQBi92MylwZddKvFPBjrsZnGvvRmVvWRf8WJ0WkKUTtombDgRYNDgoW7GBUUrNNNgWhdB7kVjBA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.31.0.tgz",
+      "integrity": "sha512-Vz7dZQd1yhE5wTWujGanPmZgDtzLZS1PQoeMmUj89p4eMTmpIkvWaIr3uquJCbh8dQd5cPZrFvMmdDgcY5z+GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.31.0.tgz",
+      "integrity": "sha512-nm0gus6R5V9tM1XaELiiIduUzmdBuCefkwToWKL4UtuFoMCGkigVQnbzHwPTGLVWOEF6wTQucFA8Fn1U8hxxVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.31.0.tgz",
+      "integrity": "sha512-mMpvvPpoLD97Q2TMhjWDJSn+ib3kN+H+F4gq9p88zpeef6sqWc9djorJ3JXM2sOZMJ6KZ+1kSJfe0rkji74Pog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.31.0.tgz",
+      "integrity": "sha512-zTngbPyrTDBYJFVQa4OJldM6w1Rqzi8c0/eFxAEbZRoj6x149GkyMkAY3kM+09ZhmszFitCML2S3p10NE2XmHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.31.0.tgz",
+      "integrity": "sha512-TB30D+iRLe6eUbc/utOA93+FNz5C6vXSb/TEhwvlODhKYZZSSKn/lFpYzZC7bdhx3a8m4Jq8fEUoCJ6lKnzdpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.50.0.tgz",
+      "integrity": "sha512-G7MRGk/6NCe+L8ntonRdZP7IkBfEpiZ/he3buLK6JkLgMHgJShXZ+BeOwADmspXez7U7F7L1Anf4xLSkLHiGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.50.0.tgz",
+      "integrity": "sha512-GeSuMoJWCVpovJi/e3xDSNgjeR8WEZ6MCXL6EtPiCIM2NTzv7LbflARINTXTJy2oFBYyvdf/l2PwHzYo6EdXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.50.0.tgz",
+      "integrity": "sha512-w3SY5YtxGnxCHPJ8Twl3KmS9oja1gERYk3AMoZ7Hv8P43ZtB6HVfs02TxvarxfL214Tm3uzvc2vn+DhtUNeKnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.50.0.tgz",
+      "integrity": "sha512-hNfogDqy7tvmllXKBSlHo6k5x7dhTUVOHbMSE15CCAcXzmqf5883aPvBYPOq9AE7DpDUQUZ1kVE22YbiGW+tuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.50.0.tgz",
+      "integrity": "sha512-ykZevOWEyu0nsxolA911ucxpEv0ahw8jfEeGWOwwb/VPoE4xoexuTOAiPNlWZNJqANlJl7yp8OyzCtXTUAxotw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.50.0.tgz",
+      "integrity": "sha512-hif3iDk7vo5GGJ4OLCCZAf2vjnU9FztGw4L0MbQL0M2iY9LKFtDMMiQAHmkF0PQGQMVbTYtPdXCLKVgdkiqWXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.50.0.tgz",
+      "integrity": "sha512-dVp9iSssiGAnTNey2Ruf6xUaQhdnvcFOJyRWd/mu5o2jVbFK15E5fbWGeFRfmuobu5QXuROtFga44+7DOS3PLg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.50.0.tgz",
+      "integrity": "sha512-1cT7yz2HA910CKA9NkH1ZJo50vTtmND2fkoW1oyiSb0j6WvNtJ0Wx2zoySfXWc/c+7HFoqRK5AbEoL41LOn9oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.50.0.tgz",
+      "integrity": "sha512-++B3k/HEPFVlj89cOz8kWfQccMZB/aWL9AhsW7jPIkG++63Mpwb2cE9XOEsd0PATbIan78k2Gky+09uWM1d/gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.50.0.tgz",
+      "integrity": "sha512-Z9b/KpFMkx66w3gVBqjIC1AJBTZAGoI9+U+K5L4QM0CB/G0JSNC1es9b3Y0Vcrlvtdn8A+IQTkYjd/Q0uCSaZw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.50.0.tgz",
+      "integrity": "sha512-jvmuIw8wRSohsQlFNIST5uUwkEtEJmOQYr33bf/K2FrFPXHhM4KqGekI3ShYJemFS/gARVacQFgBzzJKCAyJjg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.50.0.tgz",
+      "integrity": "sha512-x+UrN47oYNh90nmAAyql8eQaaRpHbDPu5guasDg10+OpszUQ3/1+1J6zFMmV4xfIEgTcUXG/oI5fxJhF4eWCNA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.50.0.tgz",
+      "integrity": "sha512-i/JLi2ljLUIVfekMj4ISmdt+Hn11wzYUdRRrkVUYsCWw7zAy5xV7X9iA+KMyM156LTFympa7s3oKBjuCLoTAUQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.50.0.tgz",
+      "integrity": "sha512-/C7brhn6c6UUPccgSPCcpLQXcp+xKIW/3sji/5VZ8/OItL3tQ2U7KalHz887UxxSQeEOmd1kY6lrpuwFnmNqOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.50.0.tgz",
+      "integrity": "sha512-oDR1f+bGOYU8LfgtEW8XtotWGB63ghtcxk5Jm6IDTCk++rTA/IRMsjOid2iMd+1bW+nP9Mdsmcdc7VbPD3+iyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.50.0.tgz",
+      "integrity": "sha512-4CmRGPp5UpvXyu4jjP9Tey/SrXDQLRvZXm4pb4vdZBxAzbFZkCyh0KyRy4txld/kZKTJlW4TO8N1JKrNEk+mWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.50.0.tgz",
+      "integrity": "sha512-Fq0M6vsGcFsSfeuWAACDhd5KJrO85ckbEfe1EGuBj+KPyJz7KeWte2fSFrFGmNKNXyhEMyx4tbgxiWRujBM2KQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.50.0.tgz",
+      "integrity": "sha512-qTdWR9KwY/vxJGhHVIZG2eBOhidOQvOwzDxnX+jhW/zIVacal1nAhR8GLkiywW8BIFDkQKXo/zOfT+/DY+ns/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.50.0.tgz",
+      "integrity": "sha512-682t7npLC4G2Ca+iNlI9fhAKTcFPYYXJjwoa88H4q+u5HHHlsnL/gHULapX3iqp+A8FIJbgdylL5KMYo2LaluQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@quansync/fs": {
@@ -3083,6 +3730,101 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oxfmt": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.31.0.tgz",
+      "integrity": "sha512-ukl7nojEuJUGbqR4ijC0Z/7a6BYpD4RxLS2UsyJKgbeZfx6TNrsa48veG0z2yQbhTx1nVnes4GIcqMn7n2jFtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.31.0",
+        "@oxfmt/binding-android-arm64": "0.31.0",
+        "@oxfmt/binding-darwin-arm64": "0.31.0",
+        "@oxfmt/binding-darwin-x64": "0.31.0",
+        "@oxfmt/binding-freebsd-x64": "0.31.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.31.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.31.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.31.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.31.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.31.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-x64-musl": "0.31.0",
+        "@oxfmt/binding-openharmony-arm64": "0.31.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.31.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.31.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.31.0"
+      }
+    },
+    "node_modules/oxfmt/node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.50.0.tgz",
+      "integrity": "sha512-iSJ4IZEICBma8cZX7kxIIz9PzsYLF2FaLAYN6RKu7VwRVKdu7RIgpP99bTZaGl//Yao7fsaGZLSEo5xBrI5ReQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.50.0",
+        "@oxlint/binding-android-arm64": "1.50.0",
+        "@oxlint/binding-darwin-arm64": "1.50.0",
+        "@oxlint/binding-darwin-x64": "1.50.0",
+        "@oxlint/binding-freebsd-x64": "1.50.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.50.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.50.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.50.0",
+        "@oxlint/binding-linux-arm64-musl": "1.50.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.50.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.50.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.50.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.50.0",
+        "@oxlint/binding-linux-x64-gnu": "1.50.0",
+        "@oxlint/binding-linux-x64-musl": "1.50.0",
+        "@oxlint/binding-openharmony-arm64": "1.50.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.50.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.50.0",
+        "@oxlint/binding-win32-x64-msvc": "1.50.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.14.1"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-filter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
@@ -3291,22 +4033,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/quansync": {

--- a/package.json
+++ b/package.json
@@ -2,44 +2,48 @@
   "name": "@cloudflare/workers-oauth-provider",
   "version": "0.2.3",
   "description": "OAuth provider for Cloudflare Workers",
-  "main": "dist/oauth-provider.js",
-  "types": "dist/oauth-provider.d.ts",
-  "author": "Kenton Varda <kenton@cloudflare.com>",
+  "homepage": "https://github.com/cloudflare/workers-oauth-provider#readme",
+  "bugs": {
+    "url": "https://github.com/cloudflare/workers-oauth-provider/issues"
+  },
   "license": "MIT",
-  "sideEffects": false,
+  "author": "Kenton Varda <kenton@cloudflare.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/workers-oauth-provider"
+  },
   "files": [
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
+  "main": "dist/oauth-provider.js",
+  "types": "dist/oauth-provider.d.ts",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "build": "tsdown",
     "build:watch": "tsdown --watch",
-    "check": "npm run typecheck && npm run test",
+    "check": "oxlint && tsc && npm run test",
     "typecheck": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepublishOnly": "npm run build",
-    "prettier": "prettier -w ."
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "@cloudflare/workers-types": "^4.20251218.0",
+    "oxfmt": "^0.31.0",
+    "oxlint": "^1.46.0",
     "pkg-pr-new": "^0.0.62",
-    "prettier": "^3.7.4",
     "tsdown": "^0.18.1",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/cloudflare/workers-oauth-provider"
-  },
-  "bugs": {
-    "url": "https://github.com/cloudflare/workers-oauth-provider/issues"
-  },
-  "homepage": "https://github.com/cloudflare/workers-oauth-provider#readme"
+  }
 }

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1,13 +1,14 @@
-import { WorkerEntrypoint } from 'cloudflare:workers';
+import { WorkerEntrypoint } from "cloudflare:workers";
 
 // Log CIMD status on module load
 const hasStrictlyPublicFetch =
-  typeof Cloudflare !== 'undefined' && Cloudflare.compatibilityFlags?.global_fetch_strictly_public === true;
+  typeof Cloudflare !== "undefined" &&
+  Cloudflare.compatibilityFlags?.global_fetch_strictly_public === true;
 
 if (!hasStrictlyPublicFetch) {
   console.warn(
     `CIMD (Client ID Metadata Document) is disabled: add '"compatibility_flags": ["global_fetch_strictly_public"]' to your wrangler.jsonc to enable. ` +
-      `See: https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public`
+      `See: https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public`,
   );
 }
 
@@ -25,21 +26,21 @@ enum HandlerType {
  * Enum representing OAuth grant types
  */
 export enum GrantType {
-  AUTHORIZATION_CODE = 'authorization_code',
-  REFRESH_TOKEN = 'refresh_token',
-  TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange',
+  AUTHORIZATION_CODE = "authorization_code",
+  REFRESH_TOKEN = "refresh_token",
+  TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange",
 }
 
 /** ExecutionContext with writable props — ctx.props is read-only in types but writable at runtime */
-type MutableExecutionContext = Omit<ExecutionContext, 'props'> & { props: any };
+type MutableExecutionContext = Omit<ExecutionContext, "props"> & { props: any };
 
 /**
  * Aliases for either type of Handler that makes .fetch required
  */
 type ExportedHandlerWithFetch<Env = Cloudflare.Env> = ExportedHandler<Env> &
-  Pick<Required<ExportedHandler<Env>>, 'fetch'>;
+  Pick<Required<ExportedHandler<Env>>, "fetch">;
 type WorkerEntrypointWithFetch<Env = Cloudflare.Env> = WorkerEntrypoint<Env> & {
-  fetch: NonNullable<WorkerEntrypoint['fetch']>;
+  fetch: NonNullable<WorkerEntrypoint["fetch"]>;
 };
 
 /**
@@ -210,14 +211,17 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    */
   apiHandlers?: Record<
     string,
-    ExportedHandlerWithFetch<Env> | (new (ctx: ExecutionContext, env: Env) => WorkerEntrypointWithFetch<Env>)
+    | ExportedHandlerWithFetch<Env>
+    | (new (ctx: ExecutionContext, env: Env) => WorkerEntrypointWithFetch<Env>)
   >;
 
   /**
    * Handler for all non-API requests or API requests without a valid token.
    * Can be either an ExportedHandler object with a fetch method or a class extending WorkerEntrypoint.
    */
-  defaultHandler: ExportedHandler<Env> | (new (ctx: ExecutionContext, env: Env) => WorkerEntrypointWithFetch<Env>);
+  defaultHandler:
+    | ExportedHandler<Env>
+    | (new (ctx: ExecutionContext, env: Env) => WorkerEntrypointWithFetch<Env>);
 
   /**
    * URL of the OAuth authorization endpoint where users can grant permissions.
@@ -297,7 +301,7 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * If the callback returns nothing or undefined for a props field, the original props will be used.
    */
   tokenExchangeCallback?: (
-    options: TokenExchangeCallbackOptions
+    options: TokenExchangeCallbackOptions,
   ) => Promise<TokenExchangeCallbackResult | void> | TokenExchangeCallbackResult | void;
 
   /**
@@ -309,7 +313,9 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * The callback can optionally return props values that will passed-through to the apiHandlers.
    * The callback can return `null` to signal resolution failure.
    */
-  resolveExternalToken?: (input: ResolveExternalTokenInput) => Promise<ResolveExternalTokenResult | null>;
+  resolveExternalToken?: (
+    input: ResolveExternalTokenInput,
+  ) => Promise<ResolveExternalTokenResult | null>;
 
   /**
    * Optional callback function that is called whenever the OAuthProvider returns an error response
@@ -736,7 +742,7 @@ export interface Grant {
  */
 interface TokenResponse {
   access_token: string;
-  token_type: 'bearer';
+  token_type: "bearer";
   expires_in: number;
   refresh_token?: string;
   scope: string;
@@ -1003,7 +1009,10 @@ export class OAuthProvider<Env = Cloudflare.Env> {
  * @param env - Cloudflare Worker environment variables
  * @returns An instance of OAuthHelpers
  */
-export function getOAuthApi<Env = Cloudflare.Env>(options: OAuthProviderOptions<Env>, env: Env): OAuthHelpers {
+export function getOAuthApi<Env = Cloudflare.Env>(
+  options: OAuthProviderOptions<Env>,
+  env: Env,
+): OAuthHelpers {
   const impl = new OAuthProviderImpl<Env>(options);
   return impl.createOAuthHelpers(env);
 }
@@ -1048,24 +1057,25 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     if (hasSingleHandlerConfig && hasMultiHandlerConfig) {
       throw new TypeError(
-        'Cannot use both apiRoute/apiHandler and apiHandlers. ' +
-          'Use either apiRoute + apiHandler OR apiHandlers, not both.'
+        "Cannot use both apiRoute/apiHandler and apiHandlers. " +
+          "Use either apiRoute + apiHandler OR apiHandlers, not both.",
       );
     }
 
     if (!hasSingleHandlerConfig && !hasMultiHandlerConfig) {
       throw new TypeError(
-        'Must provide either apiRoute + apiHandler OR apiHandlers. ' + 'No API route configuration provided.'
+        "Must provide either apiRoute + apiHandler OR apiHandlers. " +
+          "No API route configuration provided.",
       );
     }
 
     // Validate default handler
-    this.typedDefaultHandler = this.validateHandler(options.defaultHandler, 'defaultHandler');
+    this.typedDefaultHandler = this.validateHandler(options.defaultHandler, "defaultHandler");
 
     // Process and validate the API handlers
     if (hasSingleHandlerConfig) {
       // Single handler mode with apiRoute + apiHandler
-      const apiHandler = this.validateHandler(options.apiHandler!, 'apiHandler');
+      const apiHandler = this.validateHandler(options.apiHandler!, "apiHandler");
 
       // For single handler mode, process the apiRoute(s) and map them all to the single apiHandler
       if (Array.isArray(options.apiRoute)) {
@@ -1074,7 +1084,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
           this.typedApiHandlers.push([route, apiHandler]);
         });
       } else {
-        this.validateEndpoint(options.apiRoute!, 'apiRoute');
+        this.validateEndpoint(options.apiRoute!, "apiRoute");
         this.typedApiHandlers.push([options.apiRoute!, apiHandler]);
       }
     } else {
@@ -1086,10 +1096,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     // Validate that the oauth endpoints are either absolute paths or full URLs
-    this.validateEndpoint(options.authorizeEndpoint, 'authorizeEndpoint');
-    this.validateEndpoint(options.tokenEndpoint, 'tokenEndpoint');
+    this.validateEndpoint(options.authorizeEndpoint, "authorizeEndpoint");
+    this.validateEndpoint(options.tokenEndpoint, "tokenEndpoint");
     if (options.clientRegistrationEndpoint) {
-      this.validateEndpoint(options.clientRegistrationEndpoint, 'clientRegistrationEndpoint');
+      this.validateEndpoint(options.clientRegistrationEndpoint, "clientRegistrationEndpoint");
     }
 
     this.options = {
@@ -1109,7 +1119,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private validateEndpoint(endpoint: string, name: string): void {
     if (this.isPath(endpoint)) {
       // It should be an absolute path starting with /
-      if (!endpoint.startsWith('/')) {
+      if (!endpoint.startsWith("/")) {
         throw new TypeError(`${name} path must be an absolute path starting with /`);
       }
     } else {
@@ -1117,7 +1127,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       try {
         new URL(endpoint);
       } catch (e) {
-        throw new TypeError(`${name} must be either an absolute path starting with / or a valid URL`);
+        throw new TypeError(
+          `${name} must be either an absolute path starting with / or a valid URL`,
+        );
       }
     }
   }
@@ -1130,18 +1142,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @throws TypeError if the handler is invalid
    */
   private validateHandler(handler: any, name: string): TypedHandler<Env> {
-    if (typeof handler === 'object' && handler !== null && typeof handler.fetch === 'function') {
+    if (typeof handler === "object" && handler !== null && typeof handler.fetch === "function") {
       // It's an ExportedHandler object
       return { type: HandlerType.EXPORTED_HANDLER, handler };
     }
 
     // Check if it's a class constructor extending WorkerEntrypoint
-    if (typeof handler === 'function' && handler.prototype instanceof WorkerEntrypoint) {
+    if (typeof handler === "function" && handler.prototype instanceof WorkerEntrypoint) {
       return { type: HandlerType.WORKER_ENTRYPOINT, handler };
     }
 
     throw new TypeError(
-      `${name} must be either an ExportedHandler object with a fetch method or a class extending WorkerEntrypoint`
+      `${name} must be either an ExportedHandler object with a fetch method or a class extending WorkerEntrypoint`,
     );
   }
 
@@ -1157,12 +1169,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const url = new URL(request.url);
 
     // Special handling for OPTIONS requests (CORS preflight)
-    if (request.method === 'OPTIONS') {
+    if (request.method === "OPTIONS") {
       // For API routes and OAuth endpoints, respond with CORS headers
       if (
         this.isApiRequest(url) ||
-        url.pathname === '/.well-known/oauth-authorization-server' ||
-        url.pathname === '/.well-known/oauth-protected-resource' ||
+        url.pathname === "/.well-known/oauth-authorization-server" ||
+        url.pathname === "/.well-known/oauth-protected-resource" ||
         this.isTokenEndpoint(url) ||
         (this.options.clientRegistrationEndpoint && this.isClientRegistrationEndpoint(url))
       ) {
@@ -1170,9 +1182,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         return this.addCorsHeaders(
           new Response(null, {
             status: 204,
-            headers: { 'Content-Length': '0' },
+            headers: { "Content-Length": "0" },
           }),
-          request
+          request,
         );
       }
 
@@ -1180,13 +1192,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     // Handle .well-known/oauth-authorization-server
-    if (url.pathname === '/.well-known/oauth-authorization-server') {
+    if (url.pathname === "/.well-known/oauth-authorization-server") {
       const response = await this.handleMetadataDiscovery(url);
       return this.addCorsHeaders(response, request);
     }
 
     // Handle .well-known/oauth-protected-resource (RFC 9728)
-    if (url.pathname === '/.well-known/oauth-protected-resource') {
+    if (url.pathname === "/.well-known/oauth-protected-resource") {
       const response = this.handleProtectedResourceMetadata(url);
       return this.addCorsHeaders(response, request);
     }
@@ -1232,9 +1244,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (this.typedDefaultHandler.type === HandlerType.EXPORTED_HANDLER) {
       // It's an object with a fetch method
       return this.typedDefaultHandler.handler.fetch(
-        request as Parameters<ExportedHandlerWithFetch<Env>['fetch']>[0],
+        request as Parameters<ExportedHandlerWithFetch<Env>["fetch"]>[0],
         env,
-        ctx
+        ctx,
       );
     } else {
       // It's a WorkerEntrypoint class - instantiate it with ctx and env in that order
@@ -1250,7 +1262,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @returns Promise resolving to token data with decrypted props, or null if token is invalid
    */
   async unwrapToken<T = any>(token: string, env: any): Promise<TokenSummary<T> | null> {
-    const parts = token.split(':');
+    const parts = token.split(":");
     const isPossiblyInternalFormat = parts.length === 3;
 
     if (!isPossiblyInternalFormat) {
@@ -1260,7 +1272,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Retrieve the token from KV
     const [userId, grantId] = parts;
     const id = await generateTokenId(token);
-    const tokenData: Token | null = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${id}`, { type: 'json' });
+    const tokenData: Token | null = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${id}`, {
+      type: "json",
+    });
 
     // Return null if missing or expired
     if (!tokenData) {
@@ -1299,7 +1313,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @returns True if the endpoint is a path (starts with /), false if it's a full URL
    */
   private isPath(endpoint: string): boolean {
-    return endpoint.startsWith('/');
+    return endpoint.startsWith("/");
   }
 
   /**
@@ -1345,7 +1359,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async parseTokenEndpointRequest(
     request: Request,
-    env: any
+    env: any,
   ): Promise<
     | {
         body: any;
@@ -1355,16 +1369,20 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     | Response
   > {
     // Only accept POST requests
-    if (request.method !== 'POST') {
-      return this.createErrorResponse('invalid_request', 'Method not allowed', 405);
+    if (request.method !== "POST") {
+      return this.createErrorResponse("invalid_request", "Method not allowed", 405);
     }
 
-    let contentType = request.headers.get('Content-Type') || '';
+    let contentType = request.headers.get("Content-Type") || "";
     let body: any = {};
 
     // According to OAuth 2.0 RFC 6749/7009, requests MUST use application/x-www-form-urlencoded
-    if (!contentType.includes('application/x-www-form-urlencoded')) {
-      return this.createErrorResponse('invalid_request', 'Content-Type must be application/x-www-form-urlencoded', 400);
+    if (!contentType.includes("application/x-www-form-urlencoded")) {
+      return this.createErrorResponse(
+        "invalid_request",
+        "Content-Type must be application/x-www-form-urlencoded",
+        400,
+      );
     }
 
     // Process application/x-www-form-urlencoded
@@ -1376,53 +1394,61 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     // Get client ID from request
-    const authHeader = request.headers.get('Authorization');
-    let clientId = '';
-    let clientSecret = '';
+    const authHeader = request.headers.get("Authorization");
+    let clientId = "";
+    let clientSecret = "";
 
-    if (authHeader && authHeader.startsWith('Basic ')) {
+    if (authHeader && authHeader.startsWith("Basic ")) {
       // Basic auth
       const credentials = atob(authHeader.substring(6));
-      const [id, secret] = credentials.split(':', 2);
+      const [id, secret] = credentials.split(":", 2);
       clientId = decodeURIComponent(id);
-      clientSecret = decodeURIComponent(secret || '');
+      clientSecret = decodeURIComponent(secret || "");
     } else {
       // Form parameters
       clientId = body.client_id;
-      clientSecret = body.client_secret || '';
+      clientSecret = body.client_secret || "";
     }
 
     if (!clientId) {
-      return this.createErrorResponse('invalid_client', 'Client ID is required', 401);
+      return this.createErrorResponse("invalid_client", "Client ID is required", 401);
     }
 
     // Verify client exists
     const clientInfo = await this.getClient(env, clientId);
     if (!clientInfo) {
-      return this.createErrorResponse('invalid_client', 'Client not found', 401);
+      return this.createErrorResponse("invalid_client", "Client not found", 401);
     }
 
     // Determine authentication requirements based on token endpoint auth method
-    const isPublicClient = clientInfo.tokenEndpointAuthMethod === 'none';
+    const isPublicClient = clientInfo.tokenEndpointAuthMethod === "none";
 
     // For confidential clients, validate the secret
     if (!isPublicClient) {
       if (!clientSecret) {
-        return this.createErrorResponse('invalid_client', 'Client authentication failed: missing client_secret', 401);
+        return this.createErrorResponse(
+          "invalid_client",
+          "Client authentication failed: missing client_secret",
+          401,
+        );
       }
 
       // Verify the client secret matches
       if (!clientInfo.clientSecret) {
         return this.createErrorResponse(
-          'invalid_client',
-          'Client authentication failed: client has no registered secret',
-          401
+          "invalid_client",
+          "Client authentication failed: client has no registered secret",
+          401,
         );
       }
 
       const providedSecretHash = await hashSecret(clientSecret);
       if (providedSecretHash !== clientInfo.clientSecret) {
-        return this.createErrorResponse('invalid_client', 'Client authentication failed: invalid client_secret', 401);
+        return this.createErrorResponse(
+          "invalid_client",
+          "Client authentication failed: invalid client_secret",
+          401,
+        );
       }
     }
 
@@ -1447,8 +1473,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (this.isPath(route)) {
       // It's a path - match only the pathname
       // Special case: '/' should match exactly, not all paths (which would break OAuth routes)
-      if (route === '/') {
-        return url.pathname === '/';
+      if (route === "/") {
+        return url.pathname === "/";
       }
       return url.pathname.startsWith(route);
     } else {
@@ -1513,7 +1539,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private addCorsHeaders(response: Response, request: Request): Response {
     // Get the Origin header from the request
-    const origin = request.headers.get('Origin');
+    const origin = request.headers.get("Origin");
 
     // If there's no Origin header, return the original response
     if (!origin) {
@@ -1525,11 +1551,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const newResponse = new Response(response.body, response);
 
     // Add CORS headers
-    newResponse.headers.set('Access-Control-Allow-Origin', origin);
-    newResponse.headers.set('Access-Control-Allow-Methods', '*');
+    newResponse.headers.set("Access-Control-Allow-Origin", origin);
+    newResponse.headers.set("Access-Control-Allow-Methods", "*");
     // Include Authorization explicitly since it's not included in * for security reasons
-    newResponse.headers.set('Access-Control-Allow-Headers', 'Authorization, *');
-    newResponse.headers.set('Access-Control-Max-Age', '86400'); // 24 hours
+    newResponse.headers.set("Access-Control-Allow-Headers", "Authorization, *");
+    newResponse.headers.set("Access-Control-Max-Age", "86400"); // 24 hours
 
     return newResponse;
   }
@@ -1547,15 +1573,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     let registrationEndpoint: string | undefined = undefined;
     if (this.options.clientRegistrationEndpoint) {
-      registrationEndpoint = this.getFullEndpointUrl(this.options.clientRegistrationEndpoint, requestUrl);
+      registrationEndpoint = this.getFullEndpointUrl(
+        this.options.clientRegistrationEndpoint,
+        requestUrl,
+      );
     }
 
     // Determine supported response types
-    const responseTypesSupported = ['code'];
+    const responseTypesSupported = ["code"];
 
     // Add token response type if implicit flow is allowed
     if (this.options.allowImplicitFlow) {
-      responseTypesSupported.push('token');
+      responseTypesSupported.push("token");
     }
 
     // Determine supported grant types
@@ -1572,10 +1601,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       registration_endpoint: registrationEndpoint,
       scopes_supported: this.options.scopesSupported,
       response_types_supported: responseTypesSupported,
-      response_modes_supported: ['query'],
+      response_modes_supported: ["query"],
       grant_types_supported: grantTypesSupported,
       // Support "none" auth method for public clients
-      token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
+      token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
       // not implemented: token_endpoint_auth_signing_alg_values_supported
       // not implemented: service_documentation
       // not implemented: ui_locales_supported
@@ -1587,14 +1616,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // not implemented: introspection_endpoint
       // not implemented: introspection_endpoint_auth_methods_supported
       // not implemented: introspection_endpoint_auth_signing_alg_values_supported
-      code_challenge_methods_supported: this.options.allowPlainPKCE !== false ? ['plain', 'S256'] : ['S256'], // PKCE support
+      code_challenge_methods_supported:
+        this.options.allowPlainPKCE !== false ? ["plain", "S256"] : ["S256"], // PKCE support
       // MCP Client ID Metadata Document support (CIMD)
       // Only enabled when global_fetch_strictly_public compat flag is set (for SSRF protection)
       client_id_metadata_document_supported: this.hasGlobalFetchStrictlyPublic(),
     };
 
     return new Response(JSON.stringify(metadata), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
@@ -1615,7 +1645,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       resource: rm?.resource ?? requestUrl.origin,
       authorization_servers: rm?.authorization_servers ?? [authServerOrigin],
       scopes_supported: rm?.scopes_supported ?? this.options.scopesSupported,
-      bearer_methods_supported: rm?.bearer_methods_supported ?? ['header'],
+      bearer_methods_supported: rm?.bearer_methods_supported ?? ["header"],
     };
 
     if (rm?.resource_name) {
@@ -1623,7 +1653,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     return new Response(JSON.stringify(metadata), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
@@ -1646,7 +1676,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     } else if (grantType === GrantType.TOKEN_EXCHANGE && this.options.allowTokenExchangeGrant) {
       return this.handleTokenExchangeGrant(body, clientInfo, env);
     } else {
-      return this.createErrorResponse('unsupported_grant_type', 'Grant type not supported');
+      return this.createErrorResponse("unsupported_grant_type", "Grant type not supported");
     }
   }
 
@@ -1658,45 +1688,52 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Response with token data or error
    */
-  private async handleAuthorizationCodeGrant(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+  private async handleAuthorizationCodeGrant(
+    body: any,
+    clientInfo: ClientInfo,
+    env: any,
+  ): Promise<Response> {
     const code = body.code;
     const redirectUri = body.redirect_uri;
     const codeVerifier = body.code_verifier;
 
     if (!code) {
-      return this.createErrorResponse('invalid_request', 'Authorization code is required');
+      return this.createErrorResponse("invalid_request", "Authorization code is required");
     }
 
     // Parse the authorization code to extract user ID and grant ID
-    const codeParts = code.split(':');
+    const codeParts = code.split(":");
     if (codeParts.length !== 3) {
-      return this.createErrorResponse('invalid_grant', 'Invalid authorization code format');
+      return this.createErrorResponse("invalid_grant", "Invalid authorization code format");
     }
 
     const [userId, grantId, _] = codeParts;
 
     // Get the grant
     const grantKey = `grant:${userId}:${grantId}`;
-    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: "json" });
 
     if (!grantData) {
-      return this.createErrorResponse('invalid_grant', 'Grant not found or authorization code expired');
+      return this.createErrorResponse(
+        "invalid_grant",
+        "Grant not found or authorization code expired",
+      );
     }
 
     // Verify that the grant contains an auth code hash
     if (!grantData.authCodeId) {
-      return this.createErrorResponse('invalid_grant', 'Authorization code already used');
+      return this.createErrorResponse("invalid_grant", "Authorization code already used");
     }
 
     // Verify the authorization code by comparing its hash to the one in the grant
     const codeHash = await hashSecret(code);
     if (codeHash !== grantData.authCodeId) {
-      return this.createErrorResponse('invalid_grant', 'Invalid authorization code');
+      return this.createErrorResponse("invalid_grant", "Invalid authorization code");
     }
 
     // Verify client ID matches
     if (grantData.clientId !== clientInfo.clientId) {
-      return this.createErrorResponse('invalid_grant', 'Client ID mismatch');
+      return this.createErrorResponse("invalid_grant", "Client ID mismatch");
     }
 
     // Check if PKCE is being used
@@ -1704,33 +1741,39 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // OAuth 2.1 requires redirect_uri parameter unless PKCE is used
     if (!redirectUri && !isPkceEnabled) {
-      return this.createErrorResponse('invalid_request', 'redirect_uri is required when not using PKCE');
+      return this.createErrorResponse(
+        "invalid_request",
+        "redirect_uri is required when not using PKCE",
+      );
     }
 
     // Verify redirect URI if provided
     if (redirectUri && !isValidRedirectUri(redirectUri, clientInfo.redirectUris)) {
-      return this.createErrorResponse('invalid_grant', 'Invalid redirect URI');
+      return this.createErrorResponse("invalid_grant", "Invalid redirect URI");
     }
 
     // Reject if code_verifier is provided but PKCE wasn't used in authorization
     if (!isPkceEnabled && codeVerifier) {
-      return this.createErrorResponse('invalid_request', 'code_verifier provided for a flow that did not use PKCE');
+      return this.createErrorResponse(
+        "invalid_request",
+        "code_verifier provided for a flow that did not use PKCE",
+      );
     }
 
     // Verify PKCE code_verifier if code_challenge was provided during authorization
     if (isPkceEnabled) {
       if (!codeVerifier) {
-        return this.createErrorResponse('invalid_request', 'code_verifier is required for PKCE');
+        return this.createErrorResponse("invalid_request", "code_verifier is required for PKCE");
       }
 
       // Verify the code verifier against the stored code challenge
       let calculatedChallenge: string;
 
-      if (grantData.codeChallengeMethod === 'S256') {
+      if (grantData.codeChallengeMethod === "S256") {
         // SHA-256 transformation for S256 method
         const encoder = new TextEncoder();
         const data = encoder.encode(codeVerifier);
-        const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+        const hashBuffer = await crypto.subtle.digest("SHA-256", data);
         const hashArray = Array.from(new Uint8Array(hashBuffer));
         calculatedChallenge = base64UrlEncode(String.fromCharCode(...hashArray));
       } else {
@@ -1739,7 +1782,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       }
 
       if (calculatedChallenge !== grantData.codeChallenge) {
-        return this.createErrorResponse('invalid_grant', 'Invalid PKCE code_verifier');
+        return this.createErrorResponse("invalid_grant", "Invalid PKCE code_verifier");
       }
     }
 
@@ -1778,7 +1821,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         props: decryptedProps,
       };
 
-      const callbackResult = await Promise.resolve(this.options.tokenExchangeCallback(callbackOptions));
+      const callbackResult = await Promise.resolve(
+        this.options.tokenExchangeCallback(callbackOptions),
+      );
 
       if (callbackResult) {
         // Use the returned props if provided, otherwise keep the original props
@@ -1803,7 +1848,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         }
 
         // If refreshTokenTTL was specified, use that for this grant
-        if ('refreshTokenTTL' in callbackResult) {
+        if ("refreshTokenTTL" in callbackResult) {
           refreshTokenTTL = callbackResult.refreshTokenTTL;
         }
 
@@ -1872,14 +1917,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Validate downscoping: token request resources must be subset of grant resources
     if (body.resource && grantData.resource) {
       const requestedResources = Array.isArray(body.resource) ? body.resource : [body.resource];
-      const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
+      const grantedResources = Array.isArray(grantData.resource)
+        ? grantData.resource
+        : [grantData.resource];
 
       // Check that all requested resources are in the granted resources
       for (const requested of requestedResources) {
         if (!grantedResources.includes(requested)) {
           return this.createErrorResponse(
-            'invalid_target',
-            'Requested resource was not included in the authorization request'
+            "invalid_target",
+            "Requested resource was not included in the authorization request",
           );
         }
       }
@@ -1890,8 +1937,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if ((body.resource || grantData.resource) && !audience) {
       // RFC 8707 Section 2.1: invalid or unacceptable resource
       return this.createErrorResponse(
-        'invalid_target',
-        'The resource parameter must be a valid absolute URI without a fragment'
+        "invalid_target",
+        "The resource parameter must be a valid absolute URI without a fragment",
       );
     }
 
@@ -1911,9 +1958,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Build the response
     const tokenResponse: TokenResponse = {
       access_token: accessToken,
-      token_type: 'bearer',
+      token_type: "bearer",
       expires_in: accessTokenTTL,
-      scope: tokenScopes.join(' '),
+      scope: tokenScopes.join(" "),
     };
 
     if (refreshToken) {
@@ -1927,7 +1974,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Return the tokens
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
@@ -1939,17 +1986,21 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Response with token data or error
    */
-  private async handleRefreshTokenGrant(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+  private async handleRefreshTokenGrant(
+    body: any,
+    clientInfo: ClientInfo,
+    env: any,
+  ): Promise<Response> {
     const refreshToken = body.refresh_token;
 
     if (!refreshToken) {
-      return this.createErrorResponse('invalid_request', 'Refresh token is required');
+      return this.createErrorResponse("invalid_request", "Refresh token is required");
     }
 
     // Parse the token to extract user ID and grant ID
-    const tokenParts = refreshToken.split(':');
+    const tokenParts = refreshToken.split(":");
     if (tokenParts.length !== 3) {
-      return this.createErrorResponse('invalid_grant', 'Invalid token format');
+      return this.createErrorResponse("invalid_grant", "Invalid token format");
     }
 
     const [userId, grantId, _] = tokenParts;
@@ -1959,10 +2010,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Get the associated grant using userId in the key
     const grantKey = `grant:${userId}:${grantId}`;
-    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: "json" });
 
     if (!grantData) {
-      return this.createErrorResponse('invalid_grant', 'Grant not found');
+      return this.createErrorResponse("invalid_grant", "Grant not found");
     }
 
     // Check if the provided token matches either the current or previous refresh token
@@ -1970,19 +2021,19 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const isPreviousToken = grantData.previousRefreshTokenId === providedTokenHash;
 
     if (!isCurrentToken && !isPreviousToken) {
-      return this.createErrorResponse('invalid_grant', 'Invalid refresh token');
+      return this.createErrorResponse("invalid_grant", "Invalid refresh token");
     }
 
     // Verify client ID matches
     if (grantData.clientId !== clientInfo.clientId) {
-      return this.createErrorResponse('invalid_grant', 'Client ID mismatch');
+      return this.createErrorResponse("invalid_grant", "Client ID mismatch");
     }
 
     // Check if the refresh token has expired
     if (grantData.expiresAt !== undefined) {
       const now = Math.floor(Date.now() / 1000);
       if (now >= grantData.expiresAt) {
-        return this.createErrorResponse('invalid_grant', 'Refresh token has expired');
+        return this.createErrorResponse("invalid_grant", "Refresh token has expired");
       }
     }
 
@@ -2035,7 +2086,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         props: decryptedProps,
       };
 
-      const callbackResult = await Promise.resolve(this.options.tokenExchangeCallback(callbackOptions));
+      const callbackResult = await Promise.resolve(
+        this.options.tokenExchangeCallback(callbackOptions),
+      );
 
       if (callbackResult) {
         // Use the returned props if provided, otherwise keep the original props
@@ -2061,10 +2114,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         }
 
         // refreshTokenTTL changes are not supported during refresh token exchange
-        if ('refreshTokenTTL' in callbackResult) {
+        if ("refreshTokenTTL" in callbackResult) {
           return this.createErrorResponse(
-            'invalid_request',
-            'refreshTokenTTL cannot be changed during refresh token exchange'
+            "invalid_request",
+            "refreshTokenTTL cannot be changed during refresh token exchange",
           );
         }
 
@@ -2148,14 +2201,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Validate downscoping: token request resources must be subset of grant resources
     if (body.resource && grantData.resource) {
       const requestedResources = Array.isArray(body.resource) ? body.resource : [body.resource];
-      const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
+      const grantedResources = Array.isArray(grantData.resource)
+        ? grantData.resource
+        : [grantData.resource];
 
       // Check that all requested resources are in the granted resources
       for (const requested of requestedResources) {
         if (!grantedResources.includes(requested)) {
           return this.createErrorResponse(
-            'invalid_target',
-            'Requested resource was not included in the authorization request'
+            "invalid_target",
+            "Requested resource was not included in the authorization request",
           );
         }
       }
@@ -2166,8 +2221,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if ((body.resource || grantData.resource) && !audience) {
       // RFC 8707 Section 2.1: invalid or unacceptable resource
       return this.createErrorResponse(
-        'invalid_target',
-        'The resource parameter must be a valid absolute URI without a fragment'
+        "invalid_target",
+        "The resource parameter must be a valid absolute URI without a fragment",
       );
     }
 
@@ -2189,17 +2244,21 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     };
 
     // Save access token with TTL (using the potentially callback-provided TTL)
-    await env.OAUTH_KV.put(`token:${userId}:${grantId}:${accessTokenId}`, JSON.stringify(accessTokenData), {
-      expirationTtl: accessTokenTTL,
-    });
+    await env.OAUTH_KV.put(
+      `token:${userId}:${grantId}:${accessTokenId}`,
+      JSON.stringify(accessTokenData),
+      {
+        expirationTtl: accessTokenTTL,
+      },
+    );
 
     // Build the response
     const tokenResponse: TokenResponse = {
       access_token: newAccessToken,
-      token_type: 'bearer',
+      token_type: "bearer",
       expires_in: accessTokenTTL,
       refresh_token: newRefreshToken,
-      scope: tokenScopes.join(' '),
+      scope: tokenScopes.join(" "),
     };
 
     // RFC 8707 Section 2.2: SHOULD return resource parameter in response
@@ -2209,7 +2268,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Return the tokens
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
@@ -2234,19 +2293,19 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     requestedResource: string | string[] | undefined,
     expiresIn: number | undefined,
     clientInfo: ClientInfo,
-    env: any
+    env: any,
   ): Promise<TokenResponse & { issued_token_type?: string }> {
     // Unwrap and validate the subject token
     const tokenSummary = await this.unwrapToken(subjectToken, env);
     if (!tokenSummary) {
-      throw new OAuthError('invalid_grant', 'Invalid or expired subject token');
+      throw new OAuthError("invalid_grant", "Invalid or expired subject token");
     }
 
     // Get the grant to access resource information
     const grantKey = `grant:${tokenSummary.userId}:${tokenSummary.grantId}`;
-    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: "json" });
     if (!grantData) {
-      throw new OAuthError('invalid_grant', 'Grant not found');
+      throw new OAuthError("invalid_grant", "Grant not found");
     }
 
     // If scopes are requested, validate they are a subset of the original grant scopes
@@ -2257,13 +2316,20 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (requestedResource) {
       // Validate downscoping: requested resources must be subset of grant resources if grant had resources
       if (grantData.resource) {
-        const requestedResources = Array.isArray(requestedResource) ? requestedResource : [requestedResource];
-        const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
+        const requestedResources = Array.isArray(requestedResource)
+          ? requestedResource
+          : [requestedResource];
+        const grantedResources = Array.isArray(grantData.resource)
+          ? grantData.resource
+          : [grantData.resource];
 
         // Check that all requested resources are in the granted resources
         for (const requested of requestedResources) {
           if (!grantedResources.includes(requested)) {
-            throw new OAuthError('invalid_target', 'Requested resource was not included in the authorization request');
+            throw new OAuthError(
+              "invalid_target",
+              "Requested resource was not included in the authorization request",
+            );
           }
         }
       }
@@ -2272,8 +2338,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       const parsedResource = parseResourceParameter(requestedResource);
       if (!parsedResource) {
         throw new OAuthError(
-          'invalid_target',
-          'The resource parameter must be a valid absolute URI without a fragment'
+          "invalid_target",
+          "The resource parameter must be a valid absolute URI without a fragment",
         );
       }
       newAudience = parsedResource;
@@ -2287,7 +2353,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // If expiresIn is provided, use it but clamp to subject token's remaining lifetime
     if (expiresIn !== undefined) {
       if (expiresIn <= 0) {
-        throw new OAuthError('invalid_request', 'Invalid expires_in parameter');
+        throw new OAuthError("invalid_request", "Invalid expires_in parameter");
       }
       accessTokenTTL = Math.min(expiresIn, subjectTokenRemainingLifetime);
     } else {
@@ -2298,15 +2364,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Get the subject token data to access encryption key
     const subjectTokenData: Token | null = await env.OAUTH_KV.get(
       `token:${tokenSummary.userId}:${tokenSummary.grantId}:${tokenSummary.id}`,
-      { type: 'json' }
+      { type: "json" },
     );
 
     if (!subjectTokenData) {
-      throw new OAuthError('invalid_grant', 'Subject token data not found');
+      throw new OAuthError("invalid_grant", "Subject token data not found");
     }
 
     // Unwrap the encryption key from the subject token
-    const encryptionKey = await unwrapKeyWithToken(subjectToken, subjectTokenData.wrappedEncryptionKey);
+    const encryptionKey = await unwrapKeyWithToken(
+      subjectToken,
+      subjectTokenData.wrappedEncryptionKey,
+    );
 
     // Use the same props as the subject token
     let accessTokenEncryptionKey = encryptionKey;
@@ -2314,7 +2383,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Process token exchange callback if provided
     if (this.options.tokenExchangeCallback) {
-      const decryptedProps = await decryptProps(encryptionKey, subjectTokenData.grant.encryptedProps);
+      const decryptedProps = await decryptProps(
+        encryptionKey,
+        subjectTokenData.grant.encryptedProps,
+      );
 
       const callbackOptions: TokenExchangeCallbackOptions = {
         grantType: GrantType.TOKEN_EXCHANGE,
@@ -2325,7 +2397,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         props: decryptedProps,
       };
 
-      const callbackResult = await Promise.resolve(this.options.tokenExchangeCallback(callbackOptions));
+      const callbackResult = await Promise.resolve(
+        this.options.tokenExchangeCallback(callbackOptions),
+      );
 
       if (callbackResult) {
         let accessTokenProps = decryptedProps;
@@ -2376,10 +2450,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Build the response per RFC 8693
     const tokenResponse: TokenResponse & { issued_token_type?: string } = {
       access_token: newAccessToken,
-      issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
-      token_type: 'bearer',
+      issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+      token_type: "bearer",
       expires_in: accessTokenTTL,
-      scope: tokenScopes.join(' '),
+      scope: tokenScopes.join(" "),
     };
 
     // RFC 8707 Section 2.2: SHOULD return resource parameter in response
@@ -2398,41 +2472,52 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Response with new token data or error
    */
-  private async handleTokenExchangeGrant(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+  private async handleTokenExchangeGrant(
+    body: any,
+    clientInfo: ClientInfo,
+    env: any,
+  ): Promise<Response> {
     const subjectToken = body.subject_token;
     const subjectTokenType = body.subject_token_type;
-    const requestedTokenType = body.requested_token_type || 'urn:ietf:params:oauth:token-type:access_token';
+    const requestedTokenType =
+      body.requested_token_type || "urn:ietf:params:oauth:token-type:access_token";
     const requestedScope = body.scope;
     const requestedResource = body.resource;
 
     // Validate required parameters
     if (!subjectToken) {
-      return this.createErrorResponse('invalid_request', 'subject_token is required');
+      return this.createErrorResponse("invalid_request", "subject_token is required");
     }
 
     if (!subjectTokenType) {
-      return this.createErrorResponse('invalid_request', 'subject_token_type is required');
+      return this.createErrorResponse("invalid_request", "subject_token_type is required");
     }
 
     // Only support access token as subject token type
-    if (subjectTokenType !== 'urn:ietf:params:oauth:token-type:access_token') {
-      return this.createErrorResponse('invalid_request', 'Only access_token subject_token_type is supported');
+    if (subjectTokenType !== "urn:ietf:params:oauth:token-type:access_token") {
+      return this.createErrorResponse(
+        "invalid_request",
+        "Only access_token subject_token_type is supported",
+      );
     }
 
     // Only support access token as requested token type
-    if (requestedTokenType !== 'urn:ietf:params:oauth:token-type:access_token') {
-      return this.createErrorResponse('invalid_request', 'Only access_token requested_token_type is supported');
+    if (requestedTokenType !== "urn:ietf:params:oauth:token-type:access_token") {
+      return this.createErrorResponse(
+        "invalid_request",
+        "Only access_token requested_token_type is supported",
+      );
     }
 
     // Parse requested scopes
     let requestedScopes: string[] | undefined;
     if (requestedScope) {
-      if (typeof requestedScope === 'string') {
-        requestedScopes = requestedScope.split(' ').filter(Boolean);
+      if (typeof requestedScope === "string") {
+        requestedScopes = requestedScope.split(" ").filter(Boolean);
       } else if (Array.isArray(requestedScope)) {
         requestedScopes = requestedScope;
       } else {
-        return this.createErrorResponse('invalid_request', 'Invalid scope parameter format');
+        return this.createErrorResponse("invalid_request", "Invalid scope parameter format");
       }
     }
 
@@ -2441,7 +2526,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (body.expires_in !== undefined) {
       const requestedTTL = parseInt(body.expires_in, 10);
       if (isNaN(requestedTTL) || requestedTTL <= 0) {
-        return this.createErrorResponse('invalid_request', 'Invalid expires_in parameter');
+        return this.createErrorResponse("invalid_request", "Invalid expires_in parameter");
       }
       expiresIn = requestedTTL;
     }
@@ -2454,12 +2539,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         requestedResource,
         expiresIn,
         clientInfo,
-        env
+        env,
       );
 
       // Return the token
       return new Response(JSON.stringify(tokenResponse), {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { "Content-Type": "application/json" },
       });
     } catch (error) {
       // Convert OAuthError to HTTP error response
@@ -2493,11 +2578,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const token = body.token;
 
     if (!token) {
-      return this.createErrorResponse('invalid_request', 'Token parameter is required');
+      return this.createErrorResponse("invalid_request", "Token parameter is required");
     }
-    const tokenParts = token.split(':');
+    const tokenParts = token.split(":");
     if (tokenParts.length !== 3) {
-      return new Response('', { status: 200 });
+      return new Response("", { status: 200 });
     }
 
     const [userId, grantId, _] = tokenParts;
@@ -2511,7 +2596,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     } else if (isRefreshToken) {
       await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
     }
-    return new Response('', { status: 200 });
+    return new Response("", { status: 200 });
   }
 
   /**
@@ -2521,7 +2606,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param grantId - The grant ID extracted from the token
    * @param env - Cloudflare Worker environment variables
    */
-  private async revokeSpecificAccessToken(tokenId: string, userId: string, grantId: string, env: any): Promise<void> {
+  private async revokeSpecificAccessToken(
+    tokenId: string,
+    userId: string,
+    grantId: string,
+    env: any,
+  ): Promise<void> {
     const tokenKey = `token:${userId}:${grantId}:${tokenId}`;
     await env.OAUTH_KV.delete(tokenKey);
   }
@@ -2534,9 +2624,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Promise<boolean> indicating if the token is valid
    */
-  private async validateAccessToken(tokenId: string, userId: string, grantId: string, env: any): Promise<boolean> {
+  private async validateAccessToken(
+    tokenId: string,
+    userId: string,
+    grantId: string,
+    env: any,
+  ): Promise<boolean> {
     const tokenKey = `token:${userId}:${grantId}:${tokenId}`;
-    const tokenData = await env.OAUTH_KV.get(tokenKey, { type: 'json' });
+    const tokenData = await env.OAUTH_KV.get(tokenKey, { type: "json" });
 
     if (!tokenData) {
       return false;
@@ -2555,9 +2650,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Promise<boolean> indicating if the token is valid
    */
-  private async validateRefreshToken(tokenId: string, userId: string, grantId: string, env: any): Promise<boolean> {
+  private async validateRefreshToken(
+    tokenId: string,
+    userId: string,
+    grantId: string,
+    env: any,
+  ): Promise<boolean> {
     const grantKey = `grant:${userId}:${grantId}`;
-    const grantData = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData = await env.OAUTH_KV.get(grantKey, { type: "json" });
 
     if (!grantData) {
       return false;
@@ -2575,19 +2675,23 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async handleClientRegistration(request: Request, env: any): Promise<Response> {
     if (!this.options.clientRegistrationEndpoint) {
-      return this.createErrorResponse('not_implemented', 'Client registration is not enabled', 501);
+      return this.createErrorResponse("not_implemented", "Client registration is not enabled", 501);
     }
 
     // Check method
-    if (request.method !== 'POST') {
-      return this.createErrorResponse('invalid_request', 'Method not allowed', 405);
+    if (request.method !== "POST") {
+      return this.createErrorResponse("invalid_request", "Method not allowed", 405);
     }
 
     // Check content length to ensure it's not too large (1 MiB limit)
-    const contentLength = parseInt(request.headers.get('Content-Length') || '0', 10);
+    const contentLength = parseInt(request.headers.get("Content-Length") || "0", 10);
     if (contentLength > 1048576) {
       // 1 MiB = 1048576 bytes
-      return this.createErrorResponse('invalid_request', 'Request payload too large, must be under 1 MiB', 413);
+      return this.createErrorResponse(
+        "invalid_request",
+        "Request payload too large, must be under 1 MiB",
+        413,
+      );
     }
 
     // Parse client metadata with a size limitation
@@ -2596,21 +2700,29 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       const text = await request.text();
       if (text.length > 1048576) {
         // Double-check text length
-        return this.createErrorResponse('invalid_request', 'Request payload too large, must be under 1 MiB', 413);
+        return this.createErrorResponse(
+          "invalid_request",
+          "Request payload too large, must be under 1 MiB",
+          413,
+        );
       }
       clientMetadata = JSON.parse(text);
     } catch (error) {
-      return this.createErrorResponse('invalid_request', 'Invalid JSON payload', 400);
+      return this.createErrorResponse("invalid_request", "Invalid JSON payload", 400);
     }
 
     // Get token endpoint auth method, default to client_secret_basic
     const authMethod =
-      OAuthProviderImpl.validateStringField(clientMetadata.token_endpoint_auth_method) || 'client_secret_basic';
-    const isPublicClient = authMethod === 'none';
+      OAuthProviderImpl.validateStringField(clientMetadata.token_endpoint_auth_method) ||
+      "client_secret_basic";
+    const isPublicClient = authMethod === "none";
 
     // Check if public client registrations are disallowed
     if (isPublicClient && this.options.disallowPublicClientRegistration) {
-      return this.createErrorResponse('invalid_client_metadata', 'Public client registration is not allowed');
+      return this.createErrorResponse(
+        "invalid_client_metadata",
+        "Public client registration is not allowed",
+      );
     }
 
     // Create client ID
@@ -2630,7 +2742,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // Validate redirect URIs - must exist and have at least one entry
       const redirectUris = OAuthProviderImpl.validateStringArray(clientMetadata.redirect_uris);
       if (!redirectUris || redirectUris.length === 0) {
-        throw new Error('At least one redirect URI is required');
+        throw new Error("At least one redirect URI is required");
       }
 
       // Validate each redirect URI scheme
@@ -2653,7 +2765,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
           GrantType.REFRESH_TOKEN,
           ...(this.options.allowTokenExchangeGrant ? [GrantType.TOKEN_EXCHANGE] : []),
         ],
-        responseTypes: OAuthProviderImpl.validateStringArray(clientMetadata.response_types) || ['code'],
+        responseTypes: OAuthProviderImpl.validateStringArray(clientMetadata.response_types) || [
+          "code",
+        ],
         registrationDate: Math.floor(Date.now() / 1000),
         tokenEndpointAuthMethod: authMethod,
       };
@@ -2664,8 +2778,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       }
     } catch (error) {
       return this.createErrorResponse(
-        'invalid_client_metadata',
-        error instanceof Error ? error.message : 'Invalid client metadata'
+        "invalid_client_metadata",
+        error instanceof Error ? error.message : "Invalid client metadata",
       );
     }
 
@@ -2697,7 +2811,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     return new Response(JSON.stringify(response), {
       status: 201,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
@@ -2708,42 +2822,46 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param ctx - Cloudflare Worker execution context
    * @returns Response from the API handler or error
    */
-  private async handleApiRequest(request: Request, env: any, ctx: ExecutionContext): Promise<Response> {
+  private async handleApiRequest(
+    request: Request,
+    env: any,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
     const url = new URL(request.url);
     const resourceMetadataUrl = `${url.origin}/.well-known/oauth-protected-resource`;
 
     // Get access token from Authorization header
-    const authHeader = request.headers.get('Authorization');
+    const authHeader = request.headers.get("Authorization");
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return this.createErrorResponse('invalid_token', 'Missing or invalid access token', 401, {
-        'WWW-Authenticate': this.buildWwwAuthenticateHeader(
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return this.createErrorResponse("invalid_token", "Missing or invalid access token", 401, {
+        "WWW-Authenticate": this.buildWwwAuthenticateHeader(
           resourceMetadataUrl,
-          'invalid_token',
-          'Missing or invalid access token'
+          "invalid_token",
+          "Missing or invalid access token",
         ),
       });
     }
 
     const accessToken = authHeader.substring(7);
-    const parts = accessToken.split(':');
+    const parts = accessToken.split(":");
     const isPossiblyInternalFormat = parts.length === 3;
 
     let tokenData: Token | null = null;
-    let userId = '';
-    let grantId = '';
+    let userId = "";
+    let grantId = "";
 
     // It's a token generated by workers-oauth-provider
     if (isPossiblyInternalFormat) {
       [userId, grantId] = parts;
       const id = await generateTokenId(accessToken);
-      tokenData = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${id}`, { type: 'json' });
+      tokenData = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${id}`, { type: "json" });
     }
 
     // No internal token found in KV and no external token validator provided
     if (!tokenData && !this.options.resolveExternalToken) {
-      return this.createErrorResponse('invalid_token', 'Invalid access token', 401, {
-        'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
+      return this.createErrorResponse("invalid_token", "Invalid access token", 401, {
+        "WWW-Authenticate": this.buildWwwAuthenticateHeader(resourceMetadataUrl, "invalid_token"),
       });
     }
 
@@ -2752,8 +2870,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // Check if token is expired (should be auto-deleted by KV TTL, but double-check)
       const now = Math.floor(Date.now() / 1000);
       if (tokenData.expiresAt < now) {
-        return this.createErrorResponse('invalid_token', 'Access token expired', 401, {
-          'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
+        return this.createErrorResponse("invalid_token", "Access token expired", 401, {
+          "WWW-Authenticate": this.buildWwwAuthenticateHeader(resourceMetadataUrl, "invalid_token"),
         });
       }
 
@@ -2763,18 +2881,25 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       if (tokenData.audience) {
         const requestUrl = new URL(request.url);
         const resourceServer = `${requestUrl.protocol}//${requestUrl.host}${requestUrl.pathname}`;
-        const audiences = Array.isArray(tokenData.audience) ? tokenData.audience : [tokenData.audience];
+        const audiences = Array.isArray(tokenData.audience)
+          ? tokenData.audience
+          : [tokenData.audience];
 
         // Check if any audience matches (RFC 3986: case-insensitive hostname comparison)
         const matches = audiences.some((aud) => audienceMatches(resourceServer, aud));
         if (!matches) {
-          return this.createErrorResponse('invalid_token', 'Token audience does not match resource server', 401, {
-            'WWW-Authenticate': this.buildWwwAuthenticateHeader(
-              resourceMetadataUrl,
-              'invalid_token',
-              'Invalid audience'
-            ),
-          });
+          return this.createErrorResponse(
+            "invalid_token",
+            "Token audience does not match resource server",
+            401,
+            {
+              "WWW-Authenticate": this.buildWwwAuthenticateHeader(
+                resourceMetadataUrl,
+                "invalid_token",
+                "Invalid audience",
+              ),
+            },
+          );
         }
       }
 
@@ -2792,8 +2917,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
       // Failed external validation
       if (!ext) {
-        return this.createErrorResponse('invalid_token', 'Invalid access token', 401, {
-          'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
+        return this.createErrorResponse("invalid_token", "Invalid access token", 401, {
+          "WWW-Authenticate": this.buildWwwAuthenticateHeader(resourceMetadataUrl, "invalid_token"),
         });
       }
 
@@ -2806,13 +2931,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         // Check if any audience matches (RFC 3986: case-insensitive hostname comparison)
         const matches = audiences.some((aud) => audienceMatches(resourceServer, aud));
         if (!matches) {
-          return this.createErrorResponse('invalid_token', 'Token audience does not match resource server', 401, {
-            'WWW-Authenticate': this.buildWwwAuthenticateHeader(
-              resourceMetadataUrl,
-              'invalid_token',
-              'Invalid audience'
-            ),
-          });
+          return this.createErrorResponse(
+            "invalid_token",
+            "Token audience does not match resource server",
+            401,
+            {
+              "WWW-Authenticate": this.buildWwwAuthenticateHeader(
+                resourceMetadataUrl,
+                "invalid_token",
+                "Invalid audience",
+              ),
+            },
+          );
         }
       }
 
@@ -2831,13 +2961,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (!apiHandler) {
       // This shouldn't happen since we already checked with isApiRequest,
       // but handle it gracefully just in case
-      return this.createErrorResponse('invalid_request', 'No handler found for API route', 404);
+      return this.createErrorResponse("invalid_request", "No handler found for API route", 404);
     }
 
     // Call the API handler based on its type
     if (apiHandler.type === HandlerType.EXPORTED_HANDLER) {
       // It's an object with a fetch method
-      return apiHandler.handler.fetch(request as Parameters<ExportedHandlerWithFetch['fetch']>[0], env, ctx);
+      return apiHandler.handler.fetch(
+        request as Parameters<ExportedHandlerWithFetch["fetch"]>[0],
+        env,
+        ctx,
+      );
     } else {
       // It's a WorkerEntrypoint class - instantiate it with ctx and env in that order
       const handler = new apiHandler.handler(ctx, env);
@@ -2861,7 +2995,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param grantData - The grant data to save
    * @param now - Current timestamp in seconds
    */
-  private async saveGrantWithTTL(env: any, grantKey: string, grantData: Grant, now: number): Promise<void> {
+  private async saveGrantWithTTL(
+    env: any,
+    grantKey: string,
+    grantData: Grant,
+    now: number,
+  ): Promise<void> {
     // Use absolute expiration timestamp if grant has an expiration
     const kvOptions = grantData.expiresAt !== undefined ? { expiration: grantData.expiresAt } : {};
     await env.OAUTH_KV.put(grantKey, JSON.stringify(grantData), kvOptions);
@@ -2886,7 +3025,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       if (!this.hasGlobalFetchStrictlyPublic()) {
         throw new Error(
           `Client ID "${clientId}" appears to be a CIMD URL, but the 'global_fetch_strictly_public' ` +
-            `compatibility flag is not enabled. Add this flag to your wrangler.jsonc to enable CIMD support.`
+            `compatibility flag is not enabled. Add this flag to your wrangler.jsonc to enable CIMD support.`,
         );
       }
       return this.fetchClientMetadataDocument(clientId);
@@ -2894,7 +3033,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Standard KV lookup
     const clientKey = `client:${clientId}`;
-    return env.OAUTH_KV.get(clientKey, { type: 'json' });
+    return env.OAUTH_KV.get(clientKey, { type: "json" });
   }
 
   /**
@@ -2903,7 +3042,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @returns The access token string
    */
   private async createAccessToken(params: CreateAccessTokenOptions): Promise<string> {
-    const { userId, grantId, clientId, scope, encryptedProps, encryptionKey, expiresIn, audience, env } = params;
+    const {
+      userId,
+      grantId,
+      clientId,
+      scope,
+      encryptedProps,
+      encryptionKey,
+      expiresIn,
+      audience,
+      env,
+    } = params;
 
     // Generate access token
     const accessTokenSecret = generateRandomString(TOKEN_LENGTH);
@@ -2934,9 +3083,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     };
 
     // Save access token with TTL
-    await env.OAUTH_KV.put(`token:${userId}:${grantId}:${accessTokenId}`, JSON.stringify(accessTokenData), {
-      expirationTtl: expiresIn,
-    });
+    await env.OAUTH_KV.put(
+      `token:${userId}:${grantId}:${accessTokenId}`,
+      JSON.stringify(accessTokenData),
+      {
+        expirationTtl: expiresIn,
+      },
+    );
 
     return accessToken;
   }
@@ -2948,11 +3101,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param grantedScopes - The scopes that were granted in the authorization
    * @returns The filtered scopes that are a subset of the granted scopes
    */
-  private downscope(requestedScope: string | string[] | undefined, grantedScopes: string[]): string[] {
+  private downscope(
+    requestedScope: string | string[] | undefined,
+    grantedScopes: string[],
+  ): string[] {
     if (!requestedScope) return grantedScopes;
 
     const requestedScopes: string[] =
-      typeof requestedScope === 'string' ? requestedScope.split(' ').filter(Boolean) : requestedScope;
+      typeof requestedScope === "string"
+        ? requestedScope.split(" ").filter(Boolean)
+        : requestedScope;
 
     // Filter out any requested scopes that are not in the grant
     return requestedScopes.filter((scope: string) => grantedScopes.includes(scope));
@@ -2965,7 +3123,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private hasGlobalFetchStrictlyPublic(): boolean {
     const compatFlags =
-      typeof Cloudflare !== 'undefined' && Cloudflare.compatibilityFlags ? Cloudflare.compatibilityFlags : null;
+      typeof Cloudflare !== "undefined" && Cloudflare.compatibilityFlags
+        ? Cloudflare.compatibilityFlags
+        : null;
     return !!compatFlags?.global_fetch_strictly_public;
   }
 
@@ -2975,7 +3135,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private isClientMetadataUrl(clientId: string): boolean {
     try {
       const url = new URL(clientId);
-      return url.protocol === 'https:' && url.pathname !== '/';
+      return url.protocol === "https:" && url.pathname !== "/";
     } catch {
       return false;
     }
@@ -2996,7 +3156,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * Allowed authentication methods for CIMD clients (per IETF spec)
    * CIMD clients cannot use symmetric secrets since there's no pre-shared secret
    */
-  private static readonly CIMD_ALLOWED_AUTH_METHODS = ['none', 'private_key_jwt'];
+  private static readonly CIMD_ALLOWED_AUTH_METHODS = ["none", "private_key_jwt"];
 
   /**
    * Validates that a field is a string or undefined
@@ -3007,9 +3167,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private static validateStringField(field: unknown, fieldName?: string): string | undefined {
     if (field === undefined) return undefined;
-    if (typeof field !== 'string') {
+    if (typeof field !== "string") {
       throw new Error(
-        fieldName ? `Invalid ${fieldName}: expected string, got ${typeof field}` : 'Field must be a string'
+        fieldName
+          ? `Invalid ${fieldName}: expected string, got ${typeof field}`
+          : "Field must be a string",
       );
     }
     return field;
@@ -3025,11 +3187,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private static validateStringArray(arr: unknown, fieldName?: string): string[] | undefined {
     if (arr === undefined) return undefined;
     if (!Array.isArray(arr)) {
-      throw new Error(fieldName ? `Invalid ${fieldName}: expected array, got ${typeof arr}` : 'Field must be an array');
-    }
-    if (!arr.every((item) => typeof item === 'string')) {
       throw new Error(
-        fieldName ? `Invalid ${fieldName}: array must contain only strings` : 'All array elements must be strings'
+        fieldName
+          ? `Invalid ${fieldName}: expected array, got ${typeof arr}`
+          : "Field must be an array",
+      );
+    }
+    if (!arr.every((item) => typeof item === "string")) {
+      throw new Error(
+        fieldName
+          ? `Invalid ${fieldName}: array must contain only strings`
+          : "All array elements must be strings",
       );
     }
     return arr;
@@ -3048,11 +3216,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async fetchClientMetadataDocument(metadataUrl: string): Promise<ClientInfo> {
     const abortController = new AbortController();
-    const timeoutId = setTimeout(() => abortController.abort(), OAuthProviderImpl.CIMD_FETCH_TIMEOUT_MS);
+    const timeoutId = setTimeout(
+      () => abortController.abort(),
+      OAuthProviderImpl.CIMD_FETCH_TIMEOUT_MS,
+    );
 
     try {
       const response = await fetch(metadataUrl, {
-        headers: { Accept: 'application/json' },
+        headers: { Accept: "application/json" },
         signal: abortController.signal,
         cf: { cacheEverything: true },
       });
@@ -3063,20 +3234,26 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         throw new Error(`Failed to fetch client metadata: HTTP ${response.status}`);
       }
 
-      const contentLength = response.headers.get('content-length');
+      const contentLength = response.headers.get("content-length");
       if (contentLength && parseInt(contentLength, 10) > OAuthProviderImpl.CIMD_MAX_SIZE_BYTES) {
         throw new Error(
-          `Client metadata exceeds size limit: ${contentLength} bytes (max ${OAuthProviderImpl.CIMD_MAX_SIZE_BYTES})`
+          `Client metadata exceeds size limit: ${contentLength} bytes (max ${OAuthProviderImpl.CIMD_MAX_SIZE_BYTES})`,
         );
       }
 
-      const rawMetadata = await this.readJsonWithSizeLimit(response, OAuthProviderImpl.CIMD_MAX_SIZE_BYTES);
+      const rawMetadata = await this.readJsonWithSizeLimit(
+        response,
+        OAuthProviderImpl.CIMD_MAX_SIZE_BYTES,
+      );
 
-      const clientId = OAuthProviderImpl.validateStringField(rawMetadata.client_id, 'client_id');
-      const redirectUris = OAuthProviderImpl.validateStringArray(rawMetadata.redirect_uris, 'redirect_uris');
+      const clientId = OAuthProviderImpl.validateStringField(rawMetadata.client_id, "client_id");
+      const redirectUris = OAuthProviderImpl.validateStringArray(
+        rawMetadata.redirect_uris,
+        "redirect_uris",
+      );
       const tokenEndpointAuthMethod = OAuthProviderImpl.validateStringField(
         rawMetadata.token_endpoint_auth_method,
-        'token_endpoint_auth_method'
+        "token_endpoint_auth_method",
       );
 
       // Validate that client_id matches the URL (required by spec)
@@ -3085,31 +3262,38 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       }
 
       if (!redirectUris || redirectUris.length === 0) {
-        throw new Error('redirect_uris is required and must not be empty');
+        throw new Error("redirect_uris is required and must not be empty");
       }
 
-      if (tokenEndpointAuthMethod && !OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(tokenEndpointAuthMethod)) {
+      if (
+        tokenEndpointAuthMethod &&
+        !OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(tokenEndpointAuthMethod)
+      ) {
         throw new Error(
           `token_endpoint_auth_method "${tokenEndpointAuthMethod}" is not allowed for CIMD clients. ` +
-            `Allowed methods: ${OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.join(', ')}`
+            `Allowed methods: ${OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.join(", ")}`,
         );
       }
 
       return {
         clientId,
         redirectUris,
-        clientName: OAuthProviderImpl.validateStringField(rawMetadata.client_name, 'client_name'),
-        clientUri: OAuthProviderImpl.validateStringField(rawMetadata.client_uri, 'client_uri'),
-        logoUri: OAuthProviderImpl.validateStringField(rawMetadata.logo_uri, 'logo_uri'),
-        policyUri: OAuthProviderImpl.validateStringField(rawMetadata.policy_uri, 'policy_uri'),
-        tosUri: OAuthProviderImpl.validateStringField(rawMetadata.tos_uri, 'tos_uri'),
-        jwksUri: OAuthProviderImpl.validateStringField(rawMetadata.jwks_uri, 'jwks_uri'),
-        contacts: OAuthProviderImpl.validateStringArray(rawMetadata.contacts, 'contacts'),
-        grantTypes: OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
-          'authorization_code',
-        ],
-        responseTypes: OAuthProviderImpl.validateStringArray(rawMetadata.response_types, 'response_types') || ['code'],
-        tokenEndpointAuthMethod: tokenEndpointAuthMethod || 'none',
+        clientName: OAuthProviderImpl.validateStringField(rawMetadata.client_name, "client_name"),
+        clientUri: OAuthProviderImpl.validateStringField(rawMetadata.client_uri, "client_uri"),
+        logoUri: OAuthProviderImpl.validateStringField(rawMetadata.logo_uri, "logo_uri"),
+        policyUri: OAuthProviderImpl.validateStringField(rawMetadata.policy_uri, "policy_uri"),
+        tosUri: OAuthProviderImpl.validateStringField(rawMetadata.tos_uri, "tos_uri"),
+        jwksUri: OAuthProviderImpl.validateStringField(rawMetadata.jwks_uri, "jwks_uri"),
+        contacts: OAuthProviderImpl.validateStringArray(rawMetadata.contacts, "contacts"),
+        grantTypes: OAuthProviderImpl.validateStringArray(
+          rawMetadata.grant_types,
+          "grant_types",
+        ) || ["authorization_code"],
+        responseTypes: OAuthProviderImpl.validateStringArray(
+          rawMetadata.response_types,
+          "response_types",
+        ) || ["code"],
+        tokenEndpointAuthMethod: tokenEndpointAuthMethod || "none",
       };
     } finally {
       clearTimeout(timeoutId);
@@ -3125,10 +3309,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @returns Parsed JSON object
    * @throws Error if response body is null, size exceeded, or JSON parse failed
    */
-  private async readJsonWithSizeLimit(response: Response, maxBytes: number): Promise<Record<string, unknown>> {
+  private async readJsonWithSizeLimit(
+    response: Response,
+    maxBytes: number,
+  ): Promise<Record<string, unknown>> {
     const reader = response.body?.getReader();
     if (!reader) {
-      throw new Error('Response body is null');
+      throw new Error("Response body is null");
     }
 
     const chunks: Uint8Array[] = [];
@@ -3167,7 +3354,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   /**
    * Builds a WWW-Authenticate header value with resource_metadata per RFC 9728 §5.1
    */
-  private buildWwwAuthenticateHeader(resourceMetadataUrl: string, error: string, errorDescription?: string): string {
+  private buildWwwAuthenticateHeader(
+    resourceMetadataUrl: string,
+    error: string,
+    errorDescription?: string,
+  ): string {
     let header = `Bearer realm="OAuth", resource_metadata="${resourceMetadataUrl}", error="${error}"`;
     if (errorDescription) {
       header += `, error_description="${errorDescription}"`;
@@ -3187,7 +3378,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     code: string,
     description: string,
     status: number = 400,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
   ): Response {
     // Notify the user of the error and allow them to override the response
     const customErrorResponse = this.options.onError?.({ code, description, status, headers });
@@ -3201,7 +3392,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     return new Response(body, {
       status,
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         ...headers,
       },
     });
@@ -3216,10 +3407,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 class OAuthError extends Error {
   constructor(
     public code: string,
-    message: string
+    message: string,
   ) {
     super(message);
-    this.name = 'OAuthError';
+    this.name = "OAuthError";
   }
 }
 
@@ -3240,7 +3431,7 @@ const TOKEN_LENGTH = 32;
  * @returns true if valid, false otherwise
  */
 function validateResourceUri(uri: string): boolean {
-  if (!uri || typeof uri !== 'string') {
+  if (!uri || typeof uri !== "string") {
     return false;
   }
 
@@ -3258,7 +3449,7 @@ function validateResourceUri(uri: string): boolean {
     }
 
     // Must be http or https for security
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false;
     }
 
@@ -3288,14 +3479,17 @@ function audienceMatches(resourceServerUrl: string, audienceValue: string): bool
     }
 
     // Origin-only audience matches any path (backward compatibility)
-    if (audience.pathname === '/' || audience.pathname === '') {
+    if (audience.pathname === "/" || audience.pathname === "") {
       return true;
     }
 
     // Path-aware audience: prefix match on path boundary (RFC 8707)
     // e.g. audience "/api" matches request "/api", "/api/", "/api/users"
     // but does NOT match "/api-v2" or "/apiary"
-    return resource.pathname === audience.pathname || resource.pathname.startsWith(audience.pathname + '/');
+    return (
+      resource.pathname === audience.pathname ||
+      resource.pathname.startsWith(audience.pathname + "/")
+    );
   } catch {
     return false;
   }
@@ -3307,7 +3501,9 @@ function audienceMatches(resourceServerUrl: string, audienceValue: string): bool
  * @param value - The resource parameter value from the request body
  * @returns The validated value as string, string array, or undefined if validation fails
  */
-function parseResourceParameter(value: string | string[] | undefined): string | string[] | undefined {
+function parseResourceParameter(
+  value: string | string[] | undefined,
+): string | string[] | undefined {
   if (!value) {
     return undefined;
   }
@@ -3315,7 +3511,7 @@ function parseResourceParameter(value: string | string[] | undefined): string | 
   // Validate all URIs (RFC 8707 Section 2)
   const uris = Array.isArray(value) ? value : [value];
   for (const uri of uris) {
-    if (typeof uri !== 'string' || !validateResourceUri(uri)) {
+    if (typeof uri !== "string" || !validateResourceUri(uri)) {
       // Invalid resource URI - return undefined to trigger error
       return undefined;
     }
@@ -3340,8 +3536,8 @@ async function hashSecret(secret: string): Promise<string> {
  * @returns A random string of the specified length
  */
 function generateRandomString(length: number): string {
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
-  let result = '';
+  const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  let result = "";
   const values = new Uint8Array(length);
   crypto.getRandomValues(values);
   for (let i = 0; i < length; i++) {
@@ -3361,11 +3557,11 @@ async function generateTokenId(token: string): Promise<string> {
   const data = encoder.encode(token);
 
   // Use the WebCrypto API to create a SHA-256 hash
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
 
   // Convert the hash to a hex string
   const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 
   return hashHex;
 }
@@ -3381,7 +3577,7 @@ async function generateTokenId(token: string): Promise<string> {
  */
 function validateRedirectUriScheme(redirectUri: string): void {
   // List of dangerous pseudo-schemes that should not be allowed
-  const dangerousSchemes = ['javascript:', 'data:', 'vbscript:', 'file:', 'mailto:', 'blob:'];
+  const dangerousSchemes = ["javascript:", "data:", "vbscript:", "file:", "mailto:", "blob:"];
 
   // 1. Trim leading and trailing whitespace (allowed per RFC 3986 preprocessing)
   const normalized = redirectUri.trim();
@@ -3392,15 +3588,15 @@ function validateRedirectUriScheme(redirectUri: string): void {
   for (let i = 0; i < normalized.length; i++) {
     const code = normalized.charCodeAt(i);
     if ((code >= 0x00 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f)) {
-      throw new Error('Invalid redirect URI');
+      throw new Error("Invalid redirect URI");
     }
   }
 
   // 3. Extract the scheme by finding everything before the first ':'
-  const colonIndex = normalized.indexOf(':');
+  const colonIndex = normalized.indexOf(":");
   if (colonIndex === -1) {
     // No scheme present - reject relative URIs
-    throw new Error('Invalid redirect URI');
+    throw new Error("Invalid redirect URI");
   }
 
   // Get the scheme and convert to lowercase for case-insensitive comparison
@@ -3409,7 +3605,7 @@ function validateRedirectUriScheme(redirectUri: string): void {
   // Check against blacklist
   for (const dangerousScheme of dangerousSchemes) {
     if (scheme === dangerousScheme) {
-      throw new Error('Invalid redirect URI');
+      throw new Error("Invalid redirect URI");
     }
   }
 }
@@ -3427,7 +3623,7 @@ function isLoopbackUri(uri: string): boolean {
       return true;
     }
     // Check for IPv6 loopback (::1 or [::1])
-    if (host === '::1' || host === '[::1]') {
+    if (host === "::1" || host === "[::1]") {
       return true;
     }
     return false;
@@ -3470,7 +3666,7 @@ function isValidRedirectUri(requestUri: string, registeredUris: string[]): boole
  * @returns The base64url encoded string
  */
 function base64UrlEncode(str: string): string {
-  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
 
 /**
@@ -3506,11 +3702,11 @@ async function encryptProps(data: any): Promise<{ encryptedData: string; key: Cr
   // @ts-ignore
   const key: CryptoKey = await crypto.subtle.generateKey(
     {
-      name: 'AES-GCM',
+      name: "AES-GCM",
       length: 256,
     },
     true, // extractable
-    ['encrypt', 'decrypt']
+    ["encrypt", "decrypt"],
   );
 
   // Use a constant IV (all zeros) since each key is used only once
@@ -3524,11 +3720,11 @@ async function encryptProps(data: any): Promise<{ encryptedData: string; key: Cr
   // Encrypt the data
   const encryptedBuffer = await crypto.subtle.encrypt(
     {
-      name: 'AES-GCM',
+      name: "AES-GCM",
       iv,
     },
     key,
-    encodedData
+    encodedData,
   );
 
   // Convert to base64 for storage
@@ -3554,11 +3750,11 @@ async function decryptProps(key: CryptoKey, encryptedData: string): Promise<any>
   // Decrypt the data
   const decryptedBuffer = await crypto.subtle.decrypt(
     {
-      name: 'AES-GCM',
+      name: "AES-GCM",
       iv,
     },
     key,
-    encryptedBuffer
+    encryptedBuffer,
   );
 
   // Convert the decrypted buffer to a string, then parse as JSON
@@ -3571,8 +3767,8 @@ async function decryptProps(key: CryptoKey, encryptedData: string): Promise<any>
 // This ensures that even if someone has the token ID, they can't derive the wrapping key
 // We use a fixed array of 32 bytes for optimal performance
 const WRAPPING_KEY_HMAC_KEY = new Uint8Array([
-  0x22, 0x7e, 0x26, 0x86, 0x8d, 0xf1, 0xe1, 0x6d, 0x80, 0x70, 0xea, 0x17, 0x97, 0x5b, 0x47, 0xa6, 0x82, 0x18, 0xfa,
-  0x87, 0x28, 0xae, 0xde, 0x85, 0xb5, 0x1d, 0x4a, 0xd9, 0x96, 0xca, 0xca, 0x43,
+  0x22, 0x7e, 0x26, 0x86, 0x8d, 0xf1, 0xe1, 0x6d, 0x80, 0x70, 0xea, 0x17, 0x97, 0x5b, 0x47, 0xa6,
+  0x82, 0x18, 0xfa, 0x87, 0x28, 0xae, 0xde, 0x85, 0xb5, 0x1d, 0x4a, 0xd9, 0x96, 0xca, 0xca, 0x43,
 ]);
 
 /**
@@ -3587,23 +3783,23 @@ async function deriveKeyFromToken(tokenStr: string): Promise<CryptoKey> {
 
   // Import the pre-defined HMAC key (already 32 bytes)
   const hmacKey = await crypto.subtle.importKey(
-    'raw',
+    "raw",
     WRAPPING_KEY_HMAC_KEY,
-    { name: 'HMAC', hash: 'SHA-256' },
+    { name: "HMAC", hash: "SHA-256" },
     false,
-    ['sign']
+    ["sign"],
   );
 
   // Use HMAC-SHA256 to derive the wrapping key material
-  const hmacResult = await crypto.subtle.sign('HMAC', hmacKey, encoder.encode(tokenStr));
+  const hmacResult = await crypto.subtle.sign("HMAC", hmacKey, encoder.encode(tokenStr));
 
   // Import the HMAC result as the wrapping key
   return await crypto.subtle.importKey(
-    'raw',
+    "raw",
     hmacResult,
-    { name: 'AES-KW' },
+    { name: "AES-KW" },
     false, // not extractable
-    ['wrapKey', 'unwrapKey']
+    ["wrapKey", "unwrapKey"],
   );
 }
 
@@ -3618,7 +3814,9 @@ async function wrapKeyWithToken(tokenStr: string, keyToWrap: CryptoKey): Promise
   const wrappingKey = await deriveKeyFromToken(tokenStr);
 
   // Wrap the encryption key
-  const wrappedKeyBuffer = await crypto.subtle.wrapKey('raw', keyToWrap, wrappingKey, { name: 'AES-KW' });
+  const wrappedKeyBuffer = await crypto.subtle.wrapKey("raw", keyToWrap, wrappingKey, {
+    name: "AES-KW",
+  });
 
   // Convert to base64 for storage
   return arrayBufferToBase64(wrappedKeyBuffer);
@@ -3639,13 +3837,13 @@ async function unwrapKeyWithToken(tokenStr: string, wrappedKeyBase64: string): P
 
   // Unwrap the key
   return await crypto.subtle.unwrapKey(
-    'raw',
+    "raw",
     wrappedKeyBuffer,
     wrappingKey,
-    { name: 'AES-KW' },
-    { name: 'AES-GCM' },
+    { name: "AES-KW" },
+    { name: "AES-GCM" },
     true, // extractable
-    ['encrypt', 'decrypt']
+    ["encrypt", "decrypt"],
   );
 }
 
@@ -3674,17 +3872,21 @@ class OAuthHelpersImpl implements OAuthHelpers {
    */
   async parseAuthRequest(request: Request): Promise<AuthRequest> {
     const url = new URL(request.url);
-    const responseType = url.searchParams.get('response_type') || '';
-    const clientId = url.searchParams.get('client_id') || '';
-    const redirectUri = url.searchParams.get('redirect_uri') || '';
-    const scope = (url.searchParams.get('scope') || '').split(' ').filter(Boolean);
-    const state = url.searchParams.get('state') || '';
-    const codeChallenge = url.searchParams.get('code_challenge') || undefined;
-    const codeChallengeMethod = url.searchParams.get('code_challenge_method') || 'plain';
+    const responseType = url.searchParams.get("response_type") || "";
+    const clientId = url.searchParams.get("client_id") || "";
+    const redirectUri = url.searchParams.get("redirect_uri") || "";
+    const scope = (url.searchParams.get("scope") || "").split(" ").filter(Boolean);
+    const state = url.searchParams.get("state") || "";
+    const codeChallenge = url.searchParams.get("code_challenge") || undefined;
+    const codeChallengeMethod = url.searchParams.get("code_challenge_method") || "plain";
     // RFC 8707 Section 2.1: Multiple resource parameters MAY be used
-    const resourceParams = url.searchParams.getAll('resource');
+    const resourceParams = url.searchParams.getAll("resource");
     const resourceParam =
-      resourceParams.length > 0 ? (resourceParams.length === 1 ? resourceParams[0] : resourceParams) : undefined;
+      resourceParams.length > 0
+        ? resourceParams.length === 1
+          ? resourceParams[0]
+          : resourceParams
+        : undefined;
 
     // Validate redirect URI to prevent javascript: URIs / XSS attacks
     // Using helper function that normalizes and checks in a case-insensitive manner
@@ -3693,17 +3895,17 @@ class OAuthHelpersImpl implements OAuthHelpers {
     // Parse and validate resource parameter (RFC 8707)
     const resource = parseResourceParameter(resourceParam);
     if (resourceParam && !resource) {
-      throw new Error('The resource parameter must be a valid absolute URI without a fragment');
+      throw new Error("The resource parameter must be a valid absolute URI without a fragment");
     }
 
     // Check if implicit flow is requested but not allowed
-    if (responseType === 'token' && !this.provider.options.allowImplicitFlow) {
-      throw new Error('The implicit grant flow is not enabled for this provider');
+    if (responseType === "token" && !this.provider.options.allowImplicitFlow) {
+      throw new Error("The implicit grant flow is not enabled for this provider");
     }
 
     // Check if plain PKCE method is used but not allowed (OAuth 2.1 recommends S256 only)
-    if (codeChallengeMethod === 'plain' && this.provider.options.allowPlainPKCE === false) {
-      throw new Error('The plain PKCE method is not allowed. Use S256 instead.');
+    if (codeChallengeMethod === "plain" && this.provider.options.allowPlainPKCE === false) {
+      throw new Error("The plain PKCE method is not allowed. Use S256 instead.");
     }
 
     // Validate the client ID and redirect URI
@@ -3717,7 +3919,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       if (clientInfo && redirectUri) {
         if (!isValidRedirectUri(redirectUri, clientInfo.redirectUris)) {
           throw new Error(
-            `Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.`
+            `Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.`,
           );
         }
       }
@@ -3751,18 +3953,20 @@ class OAuthHelpersImpl implements OAuthHelpers {
    * @param options - Options specifying the grant details
    * @returns A Promise resolving to an object containing the redirect URL
    */
-  async completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }> {
+  async completeAuthorization(
+    options: CompleteAuthorizationOptions,
+  ): Promise<{ redirectTo: string }> {
     const { clientId, redirectUri } = options.request;
 
     if (!clientId || !redirectUri) {
-      throw new Error('Client ID and Redirect URI are required in the authorization request.');
+      throw new Error("Client ID and Redirect URI are required in the authorization request.");
     }
 
     // Re-validate the redirectUri to prevent open redirect vulnerabilities
     const clientInfo = await this.lookupClient(clientId);
     if (!clientInfo || !isValidRedirectUri(redirectUri, clientInfo.redirectUris)) {
       throw new Error(
-        'Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.'
+        "Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.",
       );
     }
 
@@ -3776,7 +3980,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     const now = Math.floor(Date.now() / 1000);
 
     // Check if this is an implicit flow request (response_type=token)
-    if (options.request.responseType === 'token') {
+    if (options.request.responseType === "token") {
       // For implicit flow, we skip the authorization code and directly issue an access token
       const accessTokenSecret = generateRandomString(TOKEN_LENGTH);
       const accessToken = `${options.userId}:${grantId}:${accessTokenSecret}`;
@@ -3794,7 +3998,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       // Parse and validate resource parameter (RFC 8707) for implicit flow
       const audience = parseResourceParameter(options.request.resource);
       if (options.request.resource && !audience) {
-        throw new Error('The resource parameter must be a valid absolute URI without a fragment');
+        throw new Error("The resource parameter must be a valid absolute URI without a fragment");
       }
 
       // Store the grant without an auth code (will be referenced by the access token)
@@ -3834,19 +4038,19 @@ class OAuthHelpersImpl implements OAuthHelpers {
       await this.env.OAUTH_KV.put(
         `token:${options.userId}:${grantId}:${accessTokenId}`,
         JSON.stringify(accessTokenData),
-        { expirationTtl: accessTokenTTL }
+        { expirationTtl: accessTokenTTL },
       );
 
       // Build the redirect URL for implicit flow (token in fragment, not query params)
       const redirectUrl = new URL(options.request.redirectUri);
       const fragment = new URLSearchParams();
-      fragment.set('access_token', accessToken);
-      fragment.set('token_type', 'bearer');
-      fragment.set('expires_in', accessTokenTTL.toString());
-      fragment.set('scope', options.scope.join(' '));
+      fragment.set("access_token", accessToken);
+      fragment.set("token_type", "bearer");
+      fragment.set("expires_in", accessTokenTTL.toString());
+      fragment.set("scope", options.scope.join(" "));
 
       if (options.request.state) {
-        fragment.set('state', options.request.state);
+        fragment.set("state", options.request.state);
       }
 
       // Set the fragment (hash) part of the URL
@@ -3887,13 +4091,15 @@ class OAuthHelpersImpl implements OAuthHelpers {
 
       // Set 10-minute TTL for the grant (will be extended when code is exchanged)
       const codeExpiresIn = 600; // 10 minutes
-      await this.env.OAUTH_KV.put(grantKey, JSON.stringify(grant), { expirationTtl: codeExpiresIn });
+      await this.env.OAUTH_KV.put(grantKey, JSON.stringify(grant), {
+        expirationTtl: codeExpiresIn,
+      });
 
       // Build the redirect URL for authorization code flow
       const redirectUrl = new URL(options.request.redirectUri);
-      redirectUrl.searchParams.set('code', authCode);
+      redirectUrl.searchParams.set("code", authCode);
       if (options.request.state) {
-        redirectUrl.searchParams.set('state', options.request.state);
+        redirectUrl.searchParams.set("state", options.request.state);
       }
 
       return { redirectTo: redirectUrl.toString() };
@@ -3909,8 +4115,8 @@ class OAuthHelpersImpl implements OAuthHelpers {
     const clientId = generateRandomString(16);
 
     // Determine token endpoint auth method
-    const tokenEndpointAuthMethod = clientInfo.tokenEndpointAuthMethod || 'client_secret_basic';
-    const isPublicClient = tokenEndpointAuthMethod === 'none';
+    const tokenEndpointAuthMethod = clientInfo.tokenEndpointAuthMethod || "client_secret_basic";
+    const isPublicClient = tokenEndpointAuthMethod === "none";
 
     // Create a new client object
     const newClient: ClientInfo = {
@@ -3928,7 +4134,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         GrantType.REFRESH_TOKEN,
         ...(this.provider.options.allowTokenExchangeGrant ? [GrantType.TOKEN_EXCHANGE] : []),
       ],
-      responseTypes: clientInfo.responseTypes || ['code'],
+      responseTypes: clientInfo.responseTypes || ["code"],
       registrationDate: Math.floor(Date.now() / 1000),
       tokenEndpointAuthMethod,
     };
@@ -3967,7 +4173,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
   async listClients(options?: ListOptions): Promise<ListResult<ClientInfo>> {
     // Prepare list options for KV
     const listOptions: { limit?: number; cursor?: string; prefix: string } = {
-      prefix: 'client:',
+      prefix: "client:",
     };
 
     if (options?.limit !== undefined) {
@@ -3984,7 +4190,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     // Fetch all clients in parallel
     const clients: ClientInfo[] = [];
     const promises = response.keys.map(async (key: { name: string }) => {
-      const clientId = key.name.substring('client:'.length);
+      const clientId = key.name.substring("client:".length);
       const client = await this.provider.getClient(this.env, clientId);
       if (client) {
         clients.push(client);
@@ -4013,8 +4219,9 @@ class OAuthHelpersImpl implements OAuthHelpers {
     }
 
     // Determine token endpoint auth method
-    let authMethod = updates.tokenEndpointAuthMethod || client.tokenEndpointAuthMethod || 'client_secret_basic';
-    const isPublicClient = authMethod === 'none';
+    let authMethod =
+      updates.tokenEndpointAuthMethod || client.tokenEndpointAuthMethod || "client_secret_basic";
+    const isPublicClient = authMethod === "none";
 
     // Handle changes in auth method
     let secretToStore = client.clientSecret;
@@ -4093,7 +4300,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     // Fetch all grants in parallel and convert to grant summaries
     const grantSummaries: GrantSummary[] = [];
     const promises = response.keys.map(async (key: { name: string }) => {
-      const grantData: Grant | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+      const grantData: Grant | null = await this.env.OAUTH_KV.get(key.name, { type: "json" });
       if (grantData) {
         // Create a summary with only the public fields
         const summary: GrantSummary = {
@@ -4152,7 +4359,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         await Promise.all(
           result.keys.map((key: { name: string }) => {
             return this.env.OAUTH_KV.delete(key.name);
-          })
+          }),
         );
       }
 
@@ -4187,12 +4394,12 @@ class OAuthHelpersImpl implements OAuthHelpers {
     // Validate subject token first to get client info
     const tokenSummary = await this.unwrapToken(options.subjectToken);
     if (!tokenSummary) {
-      throw new Error('Invalid or expired subject token');
+      throw new Error("Invalid or expired subject token");
     }
 
     const clientInfo = await this.lookupClient(tokenSummary.grant.clientId);
     if (!clientInfo) {
-      throw new Error('Client not found');
+      throw new Error("Client not found");
     }
 
     // Perform the token exchange using the shared method
@@ -4203,7 +4410,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       options.aud,
       options.expiresIn,
       clientInfo,
-      this.env
+      this.env,
     );
   }
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ['src/oauth-provider.ts'],
-  format: ['esm'],
+  entry: ["src/oauth-provider.ts"],
+  format: ["esm"],
   dts: true,
   clean: true,
-  outDir: 'dist',
-  external: ['cloudflare:workers'],
+  outDir: "dist",
+  external: ["cloudflare:workers"],
   fixedExtension: false,
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'node',
-    setupFiles: ['./__tests__/setup.ts'],
+    environment: "node",
+    setupFiles: ["./__tests__/setup.ts"],
   },
 });


### PR DESCRIPTION
Following on from this #69 

- Replace prettier with oxfmt for formatting (default settings)
- Add oxlint for linting (default settings)
- Apply type improvements: replace ~30 `any` types with proper types
- Make OAuthProvider, OAuthProviderImpl, OAuthHelpersImpl generic over Env
- Add RequiredEnv and DefaultEnv exported types
- Update CI workflow to use oxlint + oxfmt