### PR TITLE
feat: include resource_metadata in WWW-Authenticate headers (RFC 9728 §5.1)

### DIFF
--- a/.changeset/www-authenticate-resource-metadata.md
+++ b/.changeset/www-authenticate-resource-metadata.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Include `resource_metadata` URL in `WWW-Authenticate` headers on 401 responses per RFC 9728 §5.1, enabling clients to discover the protected resource metadata endpoint directly from authentication challenges.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -2880,6 +2880,19 @@ describe('OAuthProvider', () => {
       expect(error.error).toBe('invalid_token');
     });
 
+    it('should include resource_metadata in WWW-Authenticate header on 401 (RFC 9728)', async () => {
+      const apiRequest = createMockRequest('https://example.com/api/test');
+
+      const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
+
+      expect(apiResponse.status).toBe(401);
+
+      const wwwAuth = apiResponse.headers.get('WWW-Authenticate');
+      expect(wwwAuth).toBe(
+        'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token"'
+      );
+    });
+
     it('should reject API requests with an invalid token', async () => {
       const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
         Authorization: 'Bearer invalid-token',
@@ -3058,6 +3071,7 @@ describe('OAuthProvider', () => {
 
       const wwwAuth = apiResponse.headers.get('WWW-Authenticate');
       expect(wwwAuth).toContain('Bearer');
+      expect(wwwAuth).toContain('resource_metadata="https://example.com/.well-known/oauth-protected-resource"');
       expect(wwwAuth).toContain('error="invalid_token"');
       expect(wwwAuth).toContain('Invalid audience');
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2689,13 +2689,19 @@ class OAuthProviderImpl {
    * @returns Response from the API handler or error
    */
   private async handleApiRequest(request: Request, env: any, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    const resourceMetadataUrl = `${url.origin}/.well-known/oauth-protected-resource`;
+
     // Get access token from Authorization header
     const authHeader = request.headers.get('Authorization');
 
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return this.createErrorResponse('invalid_token', 'Missing or invalid access token', 401, {
-        'WWW-Authenticate':
-          'Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"',
+        'WWW-Authenticate': this.buildWwwAuthenticateHeader(
+          resourceMetadataUrl,
+          'invalid_token',
+          'Missing or invalid access token'
+        ),
       });
     }
 
@@ -2717,7 +2723,7 @@ class OAuthProviderImpl {
     // No internal token found in KV and no external token validator provided
     if (!tokenData && !this.options.resolveExternalToken) {
       return this.createErrorResponse('invalid_token', 'Invalid access token', 401, {
-        'WWW-Authenticate': 'Bearer realm="OAuth", error="invalid_token"',
+        'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
       });
     }
 
@@ -2727,7 +2733,7 @@ class OAuthProviderImpl {
       const now = Math.floor(Date.now() / 1000);
       if (tokenData.expiresAt < now) {
         return this.createErrorResponse('invalid_token', 'Access token expired', 401, {
-          'WWW-Authenticate': 'Bearer realm="OAuth", error="invalid_token"',
+          'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
         });
       }
 
@@ -2743,7 +2749,11 @@ class OAuthProviderImpl {
         const matches = audiences.some((aud) => audienceMatches(resourceServer, aud));
         if (!matches) {
           return this.createErrorResponse('invalid_token', 'Token audience does not match resource server', 401, {
-            'WWW-Authenticate': 'Bearer realm="OAuth", error="invalid_token", error_description="Invalid audience"',
+            'WWW-Authenticate': this.buildWwwAuthenticateHeader(
+              resourceMetadataUrl,
+              'invalid_token',
+              'Invalid audience'
+            ),
           });
         }
       }
@@ -2764,7 +2774,7 @@ class OAuthProviderImpl {
       // Failed external validation
       if (!ext) {
         return this.createErrorResponse('invalid_token', 'Invalid access token', 401, {
-          'WWW-Authenticate': 'Bearer realm="OAuth", error="invalid_token"',
+          'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
         });
       }
 
@@ -2778,7 +2788,11 @@ class OAuthProviderImpl {
         const matches = audiences.some((aud) => audienceMatches(resourceServer, aud));
         if (!matches) {
           return this.createErrorResponse('invalid_token', 'Token audience does not match resource server', 401, {
-            'WWW-Authenticate': 'Bearer realm="OAuth", error="invalid_token", error_description="Invalid audience"',
+            'WWW-Authenticate': this.buildWwwAuthenticateHeader(
+              resourceMetadataUrl,
+              'invalid_token',
+              'Invalid audience'
+            ),
           });
         }
       }
@@ -2794,7 +2808,6 @@ class OAuthProviderImpl {
     }
 
     // Find the appropriate API handler for this URL
-    const url = new URL(request.url);
     const apiHandler = this.findApiHandlerForUrl(url);
 
     if (!apiHandler) {
@@ -3131,6 +3144,17 @@ class OAuthProviderImpl {
 
     const text = new TextDecoder().decode(allChunks);
     return JSON.parse(text);
+  }
+
+  /**
+   * Builds a WWW-Authenticate header value with resource_metadata per RFC 9728 §5.1
+   */
+  private buildWwwAuthenticateHeader(resourceMetadataUrl: string, error: string, errorDescription?: string): string {
+    let header = `Bearer realm="OAuth", resource_metadata="${resourceMetadataUrl}", error="${error}"`;
+    if (errorDescription) {
+      header += `, error_description="${errorDescription}"`;
+    }
+    return header;
   }
 
   /**


### PR DESCRIPTION
Closes #138

## Context

[RFC 9728 §5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1) and the [MCP authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization) specify that protected resources **MUST** implement at least one of two discovery mechanisms:

1. Serve metadata at `/.well-known/oauth-protected-resource` (added in #136)
2. Include a `resource_metadata` URL in the `WWW-Authenticate` header on `401 Unauthorized` responses

This PR adds mechanism 2, complementing #136 for full RFC 9728 compliance.

## What changed

All 6 `WWW-Authenticate: Bearer` headers in `handleApiRequest()` now include the `resource_metadata` parameter:

```
WWW-Authenticate: Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token"
```

### Implementation details

- **`buildWwwAuthenticateHeader()` helper** — constructs the header value with `resource_metadata`, `error`, and optional `error_description` parameters
- **`resourceMetadataUrl` computed once** at the top of `handleApiRequest` from `request.url`'s origin
- **All 6 sites updated**: missing token, invalid token, expired token, internal audience mismatch, external validation failure, external audience mismatch
- **No new config needed** — the `resource_metadata` URL is deterministic (`{origin}/.well-known/oauth-protected-resource`)

### Not changed

- Token endpoint 401s (`invalid_client`) — these are not resource access errors and should not include `resource_metadata`
- `createErrorResponse` — headers are still passed from call sites
- `OAuthProviderOptions` — no new configuration surface

## Test plan

- [x] All 216 tests pass (1 new)
- [x] New test: verifies exact `WWW-Authenticate` header value including `resource_metadata` URL
- [x] Updated test: audience mismatch now also asserts `resource_metadata` presence
- [x] Build succeeds cleanly