### PR TITLE
feat: enforce strict refresh token rotation for public clients

### DIFF
--- a/.changeset/strict-rt-rotation-public-clients.md
+++ b/.changeset/strict-rt-rotation-public-clients.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Require strict single-use refresh tokens for public clients per OAuth 2.1 Section 4.3.1. Confidential clients retain the grace period for network resilience.


### PR DESCRIPTION
## Summary

- Enforces strict single-use refresh tokens for public clients per OAuth 2.1 Section 4.3.1
- Public clients (`tokenEndpointAuthMethod='none'`) now have immediate token invalidation with no grace period
- Confidential clients retain the previous token grace period for network resilience

This change addresses the OAuth 2.1 requirement that authorization servers MUST detect refresh token replay for public clients. Public clients are more vulnerable to token theft since they cannot securely store client credentials, making strict rotation essential for security.

## Background

OAuth 2.1 Section 4.3.1 states that authorization servers "MUST detect refresh token replay for public clients". The previous implementation allowed a grace period where both the current and previous refresh tokens were valid, which is acceptable for confidential clients but violates the spec for public clients.

## Changes

- Modified `handleRefreshTokenGrant()` to check if the client is a public client
- For public clients: `previousRefreshTokenId` is set to `undefined`, ensuring immediate invalidation
- For confidential clients: Behavior unchanged - previous token remains valid for network resilience

Fixes #43

## Test plan

- [x] All existing tests pass (215 tests)
- [x] Verified existing tests use confidential clients (`client_secret_basic`), so behavior is preserved
- [ ] Public client refresh token should be invalidated immediately after use
- [ ] Confidential client refresh token should still allow previous token reuse