### PR TITLE
fix: include client_secret_expires_at in client registration response

### DIFF
--- a/.changeset/client-registration-rfc7591.md
+++ b/.changeset/client-registration-rfc7591.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Include `client_secret_expires_at` and `client_secret_issued_at` in dynamic client registration responses when a `client_secret` is issued, per RFC 7591 §3.2.1.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -552,6 +552,7 @@ describe('OAuthProvider', () => {
       expect(registeredClient.client_id).toBeDefined();
       expect(registeredClient.client_secret).toBeDefined();
       expect(registeredClient.client_secret_expires_at).toBe(0);
+      expect(registeredClient.client_secret_issued_at).toEqual(expect.any(Number));
       expect(registeredClient.redirect_uris).toEqual(['https://client.example.com/callback']);
       expect(registeredClient.client_name).toBe('Test Client');
 
@@ -584,6 +585,8 @@ describe('OAuthProvider', () => {
       const registeredClient = await response.json<any>();
       expect(registeredClient.client_id).toBeDefined();
       expect(registeredClient.client_secret).toBeUndefined(); // Public client should not have a secret
+      expect(registeredClient.client_secret_expires_at).toBeUndefined();
+      expect(registeredClient.client_secret_issued_at).toBeUndefined();
       expect(registeredClient.token_endpoint_auth_method).toBe('none');
 
       // Verify the client was saved to KV

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2706,10 +2706,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       client_id_issued_at: clientInfo.registrationDate,
     };
 
-    // Only include client_secret for confidential clients
+    // Only include client_secret for confidential clients (RFC 7591 §3.2.1)
     if (clientSecret) {
       response.client_secret = clientSecret; // Return the original unhashed secret
-      response.client_secret_expires_at = 0; // Indicate that the secret does not expire
+      response.client_secret_expires_at = 0; // Secret does not expire
+      response.client_secret_issued_at = clientInfo.registrationDate;
     }
 
     return new Response(JSON.stringify(response), {


### PR DESCRIPTION
Fixes #163

When a confidential client is registered and a client_secret is returned, the response was missing the client_secret_expires_at field required by RFC 7591 (OAuth 2.0 Dynamic Client Registration).

This change adds client_secret_expires_at: 0 to the registration response, indicating the secret does not expire. Clients that strictly follow the spec may reject responses without this field.