### PR TITLE
fix: use Promise.allSettled for best-effort grant revocation

### DIFF
--- a/.changeset/promise-allsettled.md
+++ b/.changeset/promise-allsettled.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Use `Promise.allSettled` instead of `Promise.all` for best-effort grant revocation in `completeAuthorization()`, ensuring all grants are attempted even if one fails.

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -3886,7 +3886,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
 
       // Revoke old grants AFTER the new grant is successfully stored
       try {
-        await Promise.all(grantsToRevoke.map((oldGrantId) => this.revokeGrant(oldGrantId, options.userId)));
+        await Promise.allSettled(grantsToRevoke.map((oldGrantId) => this.revokeGrant(oldGrantId, options.userId)));
       } catch {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }
@@ -3937,7 +3937,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
 
       // Revoke old grants AFTER the new grant is successfully stored
       try {
-        await Promise.all(grantsToRevoke.map((oldGrantId) => this.revokeGrant(oldGrantId, options.userId)));
+        await Promise.allSettled(grantsToRevoke.map((oldGrantId) => this.revokeGrant(oldGrantId, options.userId)));
       } catch {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }


### PR DESCRIPTION
Closes #160

`Promise.all` short-circuits on first rejection, leaving remaining grant revocations unattempted. `Promise.allSettled` ensures every revocation is attempted regardless of individual failures, matching the "best-effort" intent of the try/catch wrapper.

## Changes
- `src/oauth-provider.ts`: `Promise.all` → `Promise.allSettled` in both implicit and auth code flow revocation paths

## Test plan
- [x] Existing 270 tests pass
- [x] TypeScript typecheck passes