### PR TITLE
fix: include client_secret_expires_at and client_secret_issued_at per RFC 7591

### DIFF
--- a/.changeset/client-registration-rfc7591.md
+++ b/.changeset/client-registration-rfc7591.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Include `client_secret_expires_at` and `client_secret_issued_at` in dynamic client registration responses when a `client_secret` is issued, per RFC 7591 §3.2.1.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -551,6 +551,8 @@ describe('OAuthProvider', () => {
       const registeredClient = await response.json<any>();
       expect(registeredClient.client_id).toBeDefined();
       expect(registeredClient.client_secret).toBeDefined();
+      expect(registeredClient.client_secret_expires_at).toBe(0);
+      expect(registeredClient.client_secret_issued_at).toEqual(expect.any(Number));
       expect(registeredClient.redirect_uris).toEqual(['https://client.example.com/callback']);
       expect(registeredClient.client_name).toBe('Test Client');
 
@@ -583,6 +585,8 @@ describe('OAuthProvider', () => {
       const registeredClient = await response.json<any>();
       expect(registeredClient.client_id).toBeDefined();
       expect(registeredClient.client_secret).toBeUndefined(); // Public client should not have a secret
+      expect(registeredClient.client_secret_expires_at).toBeUndefined();
+      expect(registeredClient.client_secret_issued_at).toBeUndefined();
       expect(registeredClient.token_endpoint_auth_method).toBe('none');
 
       // Verify the client was saved to KV

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2706,9 +2706,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       client_id_issued_at: clientInfo.registrationDate,
     };
 
-    // Only include client_secret for confidential clients
+    // Only include client_secret for confidential clients (RFC 7591 §3.2.1)
     if (clientSecret) {
       response.client_secret = clientSecret; // Return the original unhashed secret
+      response.client_secret_expires_at = 0; // Secret does not expire
+      response.client_secret_issued_at = clientInfo.registrationDate;
     }
 
     return new Response(JSON.stringify(response), {


### PR DESCRIPTION
Closes #163
Supersedes #164

Per RFC 7591 §3.2.1, `client_secret_expires_at` is **REQUIRED** when a `client_secret` is issued. This PR adds it (set to `0` — secret does not expire) along with the OPTIONAL `client_secret_issued_at` field.

## Changes
- `src/oauth-provider.ts`: Add `client_secret_expires_at: 0` and `client_secret_issued_at` to the registration response when a `client_secret` is present
- `__tests__/oauth-provider.test.ts`: Assert both fields are present for confidential clients and absent for public clients
- `.changeset/client-registration-rfc7591.md`: Patch bump

## RFC 7591 §3.2.1

> **`client_secret_expires_at`** — REQUIRED if `client_secret` is issued. Time at which the client secret will expire or 0 if it will not expire.
>
> **`client_secret_issued_at`** — OPTIONAL. Time at which the client secret was issued.

## Test plan
- [x] Confidential client: `client_secret_expires_at` is `0`, `client_secret_issued_at` is a number
- [x] Public client: both fields are absent
- [x] All 270 tests pass
- [x] TypeScript typecheck passes