### PR TITLE
Prevent unbounded KV namespace growth with TTL defaults, cascade deletes, and garbage collection

### DIFF
--- a/.changeset/kv-namespace-cleanup.md
+++ b/.changeset/kv-namespace-cleanup.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/workers-oauth-provider": minor
+'@cloudflare/workers-oauth-provider': minor
 ---
 
 Prevent unbounded KV namespace growth with TTL defaults, cascade deletes, and garbage collection.

--- a/.changeset/kv-namespace-cleanup.md
+++ b/.changeset/kv-namespace-cleanup.md
@@ -1,0 +1,20 @@
+---
+"@cloudflare/workers-oauth-provider": minor
+---
+
+Prevent unbounded KV namespace growth with TTL defaults, cascade deletes, and garbage collection.
+
+**Default TTLs to prevent unbounded storage growth:**
+
+- `refreshTokenTTL` now defaults to 30 days (previously infinite). Grants auto-expire via KV TTL. Set to `undefined` explicitly to restore the previous behavior of never expiring.
+- `clientRegistrationTTL` (new option) defaults to 90 days. Dynamically registered clients (DCR) auto-expire. Clients created via `OAuthHelpers.createClient()` are not affected. Set to `undefined` for clients that never expire.
+
+**`deleteClient()` now cascades to grants and tokens:**
+
+Previously, deleting a client only removed the `client:{id}` record, leaving all associated grants and tokens orphaned in KV. Now `deleteClient()` scans all grants, revokes those belonging to the deleted client (which also deletes their tokens), and then deletes the client record.
+
+**New `purgeExpiredData()` method for scheduled garbage collection:**
+
+Defense-in-depth cleanup method designed to be called from a Cron Trigger. Processes records in configurable batches (default: 50) to stay within Cloudflare's subrequest limits. Performs two sweep phases: (1) grant sweep removes orphaned grants (client deleted) and expired grants, (2) token sweep removes orphaned tokens (grant deleted). Safe for CIMD clients — grants with URL-based client IDs are never incorrectly treated as orphaned. Available on both `OAuthHelpers` (via `env.OAUTH_PROVIDER.purgeExpiredData()`) and directly on `OAuthProvider` (via `oauthProvider.purgeExpiredData(env)`) for use in scheduled handlers without a request context.
+
+**New exports:** `PurgeOptions`, `PurgeResult`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,9 @@ When in doubt about OAuth behavior, the MCP specification takes precedence for M
 ```
 workers-oauth-provider/
 ├── src/
-│   └── oauth-provider.ts      # Single source file (~4,100 lines)
+│   └── oauth-provider.ts      # Single source file (~4,600 lines)
 ├── __tests__/
-│   ├── oauth-provider.test.ts # Comprehensive test suite (~6,400 lines)
+│   ├── oauth-provider.test.ts # Comprehensive test suite (~9,400 lines)
 │   ├── setup.ts               # Vitest setup and mocking
 │   └── mocks/
 │       └── cloudflare-workers.ts

--- a/README.md
+++ b/README.md
@@ -96,14 +96,20 @@ export default new OAuthProvider({
   disallowPublicClientRegistration: false,
 
   // Optional: Time-to-live for refresh tokens in seconds.
-  // If not specified, refresh tokens do not expire.
+  // Defaults to 30 days (2,592,000 seconds).
   // Set to 0 to disable refresh tokens (only access tokens will be issued).
-  // For example: 3600 = 1 hour, 86400 = 1 day, 2592000 = 30 days
-  refreshTokenTTL: 2592000, // 30 days
+  // Set to `undefined` explicitly for refresh tokens that never expire.
+  refreshTokenTTL: 2592000, // 30 days (the default)
 
   // Optional: Time-to-live for access tokens in seconds.
   // Defaults to 1 hour (3600 seconds) if not specified.
   accessTokenTTL: 3600,
+
+  // Optional: Time-to-live for dynamically registered clients in seconds.
+  // Defaults to 90 days (7,776,000 seconds).
+  // Clients created via OAuthHelpers.createClient() are not affected.
+  // Set to `undefined` explicitly for clients that never expire.
+  clientRegistrationTTL: 7776000, // 90 days (the default)
 
   // Optional: Controls whether OAuth 2.0 Token Exchange (RFC 8693) is allowed.
   // When false, the token exchange grant type will not be advertised in metadata
@@ -226,6 +232,9 @@ The `env.OAUTH_PROVIDER` object available to the fetch handlers provides some me
 - Create, list, modify, and delete client_id registrations (in addition to `lookupClient()`, already shown in the example code).
 - List all active authorization grants for a particular user.
 - Revoke (delete) an authorization grant.
+- Purge expired and orphaned data from the KV namespace.
+
+Note that `deleteClient()` cascades: it revokes all grants (and their associated tokens) for the deleted client across all users.
 
 See the `OAuthHelpers` interface definition for full API details.
 
@@ -325,6 +334,33 @@ new OAuthProvider({
 ```
 
 By default, the `onError` callback is set to ``({ status, code, description }) => console.warn(`OAuth error response: ${status} ${code} - ${description}`)``.
+
+## KV Namespace Cleanup
+
+The library uses KV TTLs to automatically expire access tokens, refresh tokens (grants), and dynamically registered clients. As defense-in-depth, the library also provides a `purgeExpiredData()` method that cleans up orphaned and expired records. This is designed to be called from a [Cron Trigger](https://developers.cloudflare.com/workers/configuration/cron-triggers/) (scheduled handler):
+
+```ts
+const oauthProvider = new OAuthProvider({
+  // ... options ...
+});
+
+export default {
+  fetch(request, env, ctx) {
+    return oauthProvider.fetch(request, env, ctx);
+  },
+  async scheduled(event, env, ctx) {
+    const result = await oauthProvider.purgeExpiredData(env, { batchSize: 100 });
+    console.log(`Checked ${result.grantsChecked} grants, purged ${result.grantsPurged}`);
+  },
+};
+```
+
+The method processes records in configurable batches (default: 50) to stay within Cloudflare's subrequest limits. It performs two sweep phases:
+
+1. **Grant sweep**: Removes orphaned grants (whose client no longer exists) and expired grants.
+2. **Token sweep**: Removes orphaned tokens (whose grant no longer exists).
+
+Call it repeatedly via a cron trigger — deleted records disappear from KV, so subsequent invocations naturally process fresh records without needing a persisted cursor. The `result.done` field indicates whether the full key space was scanned in this invocation.
 
 ## Protected Resource Metadata (RFC 9728)
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -11,11 +11,17 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 class MockKV {
   private storage: Map<string, { value: any; expiration?: number }> = new Map();
 
-  async put(key: string, value: string | ArrayBuffer, options?: { expirationTtl?: number }): Promise<void> {
+  async put(
+    key: string,
+    value: string | ArrayBuffer,
+    options?: { expirationTtl?: number; expiration?: number }
+  ): Promise<void> {
     let expirationTime: number | undefined = undefined;
 
     if (options?.expirationTtl) {
       expirationTime = Date.now() + options.expirationTtl * 1000;
+    } else if (options?.expiration) {
+      expirationTime = options.expiration * 1000;
     }
 
     this.storage.set(key, { value, expiration: expirationTime });
@@ -50,24 +56,28 @@ class MockKV {
     cursor?: string;
   }> {
     const { prefix, limit = 1000 } = options;
-    let keys: { name: string }[] = [];
+    const allKeys: string[] = [];
 
+    // Collect all matching, non-expired keys
     for (const key of this.storage.keys()) {
       if (key.startsWith(prefix)) {
         const item = this.storage.get(key);
         if (item && (!item.expiration || item.expiration >= Date.now())) {
-          keys.push({ name: key });
+          allKeys.push(key);
         }
-      }
-
-      if (keys.length >= limit) {
-        break;
       }
     }
 
+    // Handle cursor-based pagination: cursor is the index to start from
+    const startIndex = options.cursor ? parseInt(options.cursor, 10) : 0;
+    const pageKeys = allKeys.slice(startIndex, startIndex + limit);
+    const nextIndex = startIndex + pageKeys.length;
+    const listComplete = nextIndex >= allKeys.length;
+
     return {
-      keys,
-      list_complete: true,
+      keys: pageKeys.map((name) => ({ name })),
+      list_complete: listComplete,
+      cursor: listComplete ? undefined : String(nextIndex),
     };
   }
 
@@ -609,7 +619,7 @@ describe('OAuthProvider', () => {
       const registeredClient = await response.json<any>();
       expect(registeredClient.client_id).toBeDefined();
       expect(registeredClient.client_secret).toBeDefined();
-      expect(registeredClient.client_secret_expires_at).toBe(0);
+      expect(registeredClient.client_secret_expires_at).toBeGreaterThan(0);
       expect(registeredClient.client_secret_issued_at).toEqual(expect.any(Number));
       expect(registeredClient.redirect_uris).toEqual(['https://client.example.com/callback']);
       expect(registeredClient.client_name).toBe('Test Client');
@@ -2826,7 +2836,8 @@ describe('OAuthProvider', () => {
       expect(refreshResponse.status).toBe(400);
       const error = await refreshResponse.json<any>();
       expect(error.error).toBe('invalid_grant');
-      expect(error.error_description).toBe('Refresh token has expired');
+      // KV auto-deletes expired entries, so the grant is gone before the expiry check runs
+      expect(error.error_description).toBe('Grant not found');
     });
 
     it('should allow overriding refresh token TTL via callback', async () => {
@@ -8369,6 +8380,1053 @@ describe('OAuthProvider', () => {
         // Different path, should not match any registered URI
         await expect(makeAuthRequest('http://127.0.0.1:55555/callback')).rejects.toThrow('Invalid redirect URI');
       });
+    });
+  });
+
+  describe('Default Refresh Token TTL', () => {
+    let clientId: string;
+    let clientSecret: string;
+    const redirectUri = 'https://client.example.com/callback';
+
+    async function registerTestClient(provider: OAuthProvider<TestEnv>) {
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: [redirectUri],
+          client_name: 'TTL Test Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      const client = await response.json<any>();
+      clientId = client.client_id;
+      clientSecret = client.client_secret;
+    }
+
+    async function getAuthCodeAndExchange(provider: OAuthProvider<TestEnv>) {
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read%20write&state=xyz123`
+      );
+      const authResponse = await provider.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+      const tokenResponse = await provider.fetch(tokenRequest, mockEnv, mockCtx);
+      return tokenResponse.json<any>();
+    }
+
+    it('should apply 30-day default refresh token TTL when not specified', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+      });
+      await registerTestClient(provider);
+      const tokens = await getAuthCodeAndExchange(provider);
+
+      expect(tokens.refresh_token).toBeDefined();
+
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grant = await mockEnv.OAUTH_KV.get(grantEntries.keys[0].name, { type: 'json' });
+      const now = Math.floor(Date.now() / 1000);
+      const thirtyDays = 30 * 24 * 60 * 60;
+
+      expect(grant.expiresAt).toBeDefined();
+      expect(grant.expiresAt).toBeGreaterThan(now);
+      expect(grant.expiresAt).toBeLessThanOrEqual(now + thirtyDays);
+    });
+
+    it('should allow opting into infinite TTL by explicitly passing undefined', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        refreshTokenTTL: undefined,
+      });
+      await registerTestClient(provider);
+      const tokens = await getAuthCodeAndExchange(provider);
+
+      expect(tokens.refresh_token).toBeDefined();
+
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grant = await mockEnv.OAUTH_KV.get(grantEntries.keys[0].name, { type: 'json' });
+
+      expect(grant.expiresAt).toBeUndefined();
+    });
+
+    it('should allow overriding the default TTL with a custom value', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        refreshTokenTTL: 86400,
+      });
+      await registerTestClient(provider);
+      const tokens = await getAuthCodeAndExchange(provider);
+
+      expect(tokens.refresh_token).toBeDefined();
+
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grant = await mockEnv.OAUTH_KV.get(grantEntries.keys[0].name, { type: 'json' });
+      const now = Math.floor(Date.now() / 1000);
+
+      expect(grant.expiresAt).toBeDefined();
+      expect(grant.expiresAt).toBeLessThanOrEqual(now + 86400);
+      expect(grant.expiresAt).toBeGreaterThan(now + 86300);
+    });
+
+    it('should clamp access token TTL during refresh when remaining lifetime is shorter', async () => {
+      const shortRefreshTTL = 1800;
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        accessTokenTTL: 3600,
+        refreshTokenTTL: shortRefreshTTL,
+      });
+      await registerTestClient(provider);
+      const tokens = await getAuthCodeAndExchange(provider);
+
+      // Initial access token is not clamped (full refresh TTL remaining)
+      expect(tokens.access_token).toBeDefined();
+      expect(tokens.refresh_token).toBeDefined();
+
+      // Use the refresh token to get a new access token
+      const refreshParams = new URLSearchParams();
+      refreshParams.append('grant_type', 'refresh_token');
+      refreshParams.append('refresh_token', tokens.refresh_token);
+      refreshParams.append('client_id', clientId);
+      refreshParams.append('client_secret', clientSecret);
+
+      const refreshRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        refreshParams.toString()
+      );
+      const refreshResponse = await provider.fetch(refreshRequest, mockEnv, mockCtx);
+      const refreshedTokens = await refreshResponse.json<any>();
+
+      // Refreshed access token TTL should be clamped to remaining refresh token lifetime
+      expect(refreshedTokens.expires_in).toBeLessThanOrEqual(shortRefreshTTL);
+    });
+  });
+
+  describe('Client Registration TTL', () => {
+    it('should store DCR clients with TTL when clientRegistrationTTL is set', async () => {
+      const ttl = 7776000; // 90 days
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationTTL: ttl,
+      });
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://app.example.com/callback'],
+          client_name: 'TTL Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      expect(response.status).toBe(201);
+
+      const client = await response.json<any>();
+      const now = Math.floor(Date.now() / 1000);
+
+      // client_secret_expires_at should reflect the TTL
+      expect(client.client_secret_expires_at).toBeGreaterThan(now);
+      expect(client.client_secret_expires_at).toBeLessThanOrEqual(now + ttl);
+
+      // Verify the client exists in KV
+      const stored = await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' });
+      expect(stored).not.toBeNull();
+    });
+
+    it('should auto-expire DCR clients after TTL elapses', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationTTL: 1, // 1 second
+      });
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://app.example.com/callback'],
+          client_name: 'Short-lived Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      const client = await response.json<any>();
+
+      // Client should exist immediately
+      expect(await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' })).not.toBeNull();
+
+      // Wait for expiry
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      // Client should be auto-deleted by KV TTL
+      expect(await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' })).toBeNull();
+    });
+
+    it('should return client_secret_expires_at = 0 when clientRegistrationTTL is explicitly undefined', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationTTL: undefined,
+      });
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://app.example.com/callback'],
+          client_name: 'Permanent Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      const client = await response.json<any>();
+
+      expect(client.client_secret_expires_at).toBe(0);
+    });
+
+    it('should not include client_secret_expires_at for public clients', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationTTL: 7776000,
+      });
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://spa.example.com/callback'],
+          client_name: 'SPA',
+          token_endpoint_auth_method: 'none',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      const client = await response.json<any>();
+
+      expect(client.client_secret).toBeUndefined();
+      expect(client.client_secret_expires_at).toBeUndefined();
+    });
+
+    it('should not apply clientRegistrationTTL to clients created via OAuthHelpers.createClient', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationTTL: 1, // 1 second
+      });
+
+      // Use the default handler to trigger a request that populates OAUTH_PROVIDER
+      const initRequest = createMockRequest('https://example.com/');
+      await provider.fetch(initRequest, mockEnv, mockCtx);
+
+      // Create a client via OAuthHelpers (programmatic, not DCR)
+      const client = await mockEnv.OAUTH_PROVIDER!.createClient({
+        redirectUris: ['https://app.example.com/callback'],
+        clientName: 'Manual Client',
+      });
+
+      // Wait for the DCR TTL to elapse
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      // Client created via createClient should still exist (not affected by clientRegistrationTTL)
+      const stored = await mockEnv.OAUTH_KV.get(`client:${client.clientId}`, { type: 'json' });
+      expect(stored).not.toBeNull();
+    });
+
+    it('should preserve TTL when updating a DCR client via updateClient', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationTTL: 1, // 1 second
+      });
+
+      // Register a DCR client
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://app.example.com/callback'],
+          client_name: 'Update TTL Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      const client = await response.json<any>();
+
+      // Initialize OAUTH_PROVIDER
+      const initRequest = createMockRequest('https://example.com/');
+      await provider.fetch(initRequest, mockEnv, mockCtx);
+
+      // Update the client (should re-apply TTL, not strip it)
+      await mockEnv.OAUTH_PROVIDER!.updateClient(client.client_id, {
+        clientName: 'Updated Name',
+      });
+
+      // Client should still exist immediately after update
+      const stored = await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' });
+      expect(stored).not.toBeNull();
+      expect(stored.clientName).toBe('Updated Name');
+
+      // Wait for TTL to expire
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      // Client should have expired (TTL was preserved on update)
+      const expired = await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' });
+      expect(expired).toBeNull();
+    });
+  });
+
+  describe('deleteClient cascading to grants', () => {
+    let provider: OAuthProvider<TestEnv>;
+    let clientId: string;
+    let clientSecret: string;
+    const redirectUri = 'https://client.example.com/callback';
+
+    beforeEach(async () => {
+      provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        refreshTokenTTL: undefined, // infinite, to avoid expiry during test
+      });
+
+      // Initialize OAUTH_PROVIDER
+      const initRequest = createMockRequest('https://example.com/');
+      await provider.fetch(initRequest, mockEnv, mockCtx);
+
+      // Register a client via DCR
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: [redirectUri],
+          client_name: 'Cascade Test Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      const client = await response.json<any>();
+      clientId = client.client_id;
+      clientSecret = client.client_secret;
+    });
+
+    async function authorizeAndGetTokens(userId: string) {
+      // Create a custom default handler for this specific userId
+      const customDefaultHandler = {
+        async fetch(request: Request, env: TestEnv, ctx: ExecutionContext) {
+          const url = new URL(request.url);
+          if (url.pathname === '/authorize') {
+            const oauthReqInfo = await env.OAUTH_PROVIDER!.parseAuthRequest(request);
+            const { redirectTo } = await env.OAUTH_PROVIDER!.completeAuthorization({
+              request: oauthReqInfo,
+              userId,
+              metadata: { test: true },
+              scope: oauthReqInfo.scope,
+              props: { userId },
+              revokeExistingGrants: false,
+            });
+            return Response.redirect(redirectTo, 302);
+          }
+          return new Response('Default handler', { status: 200 });
+        },
+      };
+
+      const customProvider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: customDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        refreshTokenTTL: undefined,
+      });
+
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read%20write&state=abc`
+      );
+      const authResponse = await customProvider.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+      const tokenResponse = await customProvider.fetch(tokenRequest, mockEnv, mockCtx);
+      return tokenResponse.json<any>();
+    }
+
+    it('should delete all grants and tokens when a client is deleted', async () => {
+      // Create grants for two different users
+      const tokens1 = await authorizeAndGetTokens('user-1');
+      const tokens2 = await authorizeAndGetTokens('user-2');
+
+      // Verify grants and tokens exist
+      const grantsBefore = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const tokensBefore = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(grantsBefore.keys.length).toBe(2);
+      expect(tokensBefore.keys.length).toBe(2);
+
+      // Verify access tokens work
+      const apiRequest1 = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: `Bearer ${tokens1.access_token}`,
+      });
+      const apiResponse1 = await provider.fetch(apiRequest1, mockEnv, mockCtx);
+      expect(apiResponse1.status).toBe(200);
+
+      // Delete the client
+      await mockEnv.OAUTH_PROVIDER!.deleteClient(clientId);
+
+      // Verify all grants are gone
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(0);
+
+      // Verify all tokens are gone
+      const tokensAfter = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensAfter.keys.length).toBe(0);
+
+      // Verify the client itself is gone
+      const clientData = await mockEnv.OAUTH_KV.get(`client:${clientId}`, { type: 'json' });
+      expect(clientData).toBeNull();
+
+      // Verify access tokens no longer work
+      const apiRequest2 = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: `Bearer ${tokens1.access_token}`,
+      });
+      const apiResponse2 = await provider.fetch(apiRequest2, mockEnv, mockCtx);
+      expect(apiResponse2.status).toBe(401);
+    });
+
+    it('should only delete grants belonging to the specified client', async () => {
+      // Create a second client
+      const request2 = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://other.example.com/callback'],
+          client_name: 'Other Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response2 = await provider.fetch(request2, mockEnv, mockCtx);
+      const otherClient = await response2.json<any>();
+
+      // Authorize the first client
+      await authorizeAndGetTokens('user-1');
+
+      // Authorize the second client manually using the default handler
+      const authRequest2 = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${otherClient.client_id}` +
+          `&redirect_uri=${encodeURIComponent('https://other.example.com/callback')}&scope=read&state=abc`
+      );
+      const authResponse2 = await provider.fetch(authRequest2, mockEnv, mockCtx);
+      const code2 = new URL(authResponse2.headers.get('Location')!).searchParams.get('code')!;
+
+      const params2 = new URLSearchParams();
+      params2.append('grant_type', 'authorization_code');
+      params2.append('code', code2);
+      params2.append('redirect_uri', 'https://other.example.com/callback');
+      params2.append('client_id', otherClient.client_id);
+      params2.append('client_secret', otherClient.client_secret);
+      const tokenRequest2 = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params2.toString()
+      );
+      await provider.fetch(tokenRequest2, mockEnv, mockCtx);
+
+      // Verify we have 2 grants total
+      const grantsBefore = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsBefore.keys.length).toBe(2);
+
+      // Delete only the first client
+      await mockEnv.OAUTH_PROVIDER!.deleteClient(clientId);
+
+      // Only the second client's grant should remain
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(1);
+      const remainingGrant = await mockEnv.OAUTH_KV.get(grantsAfter.keys[0].name, { type: 'json' });
+      expect(remainingGrant.clientId).toBe(otherClient.client_id);
+
+      // Second client should still exist
+      const otherClientData = await mockEnv.OAUTH_KV.get(`client:${otherClient.client_id}`, { type: 'json' });
+      expect(otherClientData).not.toBeNull();
+    });
+
+    it('should handle deleting a client with no grants', async () => {
+      // Delete the client that has no grants yet
+      await mockEnv.OAUTH_PROVIDER!.deleteClient(clientId);
+
+      const clientData = await mockEnv.OAUTH_KV.get(`client:${clientId}`, { type: 'json' });
+      expect(clientData).toBeNull();
+    });
+
+    it('should handle deleting a non-existent client gracefully', async () => {
+      // Should not throw
+      await mockEnv.OAUTH_PROVIDER!.deleteClient('non-existent-client-id');
+    });
+  });
+
+  describe('purgeExpiredData', () => {
+    let provider: OAuthProvider<TestEnv>;
+    const redirectUri = 'https://client.example.com/callback';
+
+    beforeEach(() => {
+      provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        refreshTokenTTL: undefined,
+      });
+    });
+
+    async function initHelpers() {
+      const initRequest = createMockRequest('https://example.com/');
+      await provider.fetch(initRequest, mockEnv, mockCtx);
+    }
+
+    async function registerClient(): Promise<{ clientId: string; clientSecret: string }> {
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: [redirectUri],
+          client_name: 'Purge Test Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+      const client = await response.json<any>();
+      return { clientId: client.client_id, clientSecret: client.client_secret };
+    }
+
+    async function authorizeClient(clientId: string, clientSecret: string, userId: string = 'test-user-123') {
+      const customHandler = {
+        async fetch(request: Request, env: TestEnv, ctx: ExecutionContext) {
+          const url = new URL(request.url);
+          if (url.pathname === '/authorize') {
+            const oauthReqInfo = await env.OAUTH_PROVIDER!.parseAuthRequest(request);
+            const { redirectTo } = await env.OAUTH_PROVIDER!.completeAuthorization({
+              request: oauthReqInfo,
+              userId,
+              metadata: { test: true },
+              scope: oauthReqInfo.scope,
+              props: { userId },
+              revokeExistingGrants: false,
+            });
+            return Response.redirect(redirectTo, 302);
+          }
+          return new Response('Default handler', { status: 200 });
+        },
+      };
+
+      const customProvider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: customHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        refreshTokenTTL: undefined,
+      });
+
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read%20write&state=abc`
+      );
+      const authResponse = await customProvider.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+      const tokenResponse = await customProvider.fetch(tokenRequest, mockEnv, mockCtx);
+      return tokenResponse.json<any>();
+    }
+
+    it('should return done:true and zero counts when namespace is empty', async () => {
+      await initHelpers();
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsChecked).toBe(0);
+      expect(result.grantsPurged).toBe(0);
+      expect(result.tokensChecked).toBe(0);
+      expect(result.tokensPurged).toBe(0);
+      expect(result.done).toBe(true);
+    });
+
+    it('should not purge healthy grants', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+      await authorizeClient(clientId, clientSecret);
+
+      const grantsBefore = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsBefore.keys.length).toBe(1);
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsChecked).toBe(1);
+      expect(result.grantsPurged).toBe(0);
+      expect(result.done).toBe(true);
+
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(1);
+    });
+
+    it('should purge orphaned grants when client is deleted directly from KV', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+      await authorizeClient(clientId, clientSecret, 'user-1');
+      await authorizeClient(clientId, clientSecret, 'user-2');
+
+      // Delete the client directly from KV (bypassing deleteClient cascade)
+      await mockEnv.OAUTH_KV.delete(`client:${clientId}`);
+
+      const grantsBefore = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsBefore.keys.length).toBe(2);
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsChecked).toBe(2);
+      expect(result.grantsPurged).toBe(2);
+      expect(result.done).toBe(true);
+
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(0);
+    });
+
+    it('should also clean up tokens when purging orphaned grants', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+      await authorizeClient(clientId, clientSecret);
+
+      const tokensBefore = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensBefore.keys.length).toBe(1);
+
+      // Delete client directly from KV
+      await mockEnv.OAUTH_KV.delete(`client:${clientId}`);
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsPurged).toBe(1);
+
+      const tokensAfter = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensAfter.keys.length).toBe(0);
+    });
+
+    it('should purge expired grants as defense-in-depth', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+      await authorizeClient(clientId, clientSecret);
+
+      // Manually set grant expiresAt to the past (simulating KV TTL not firing)
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantKey = grantEntries.keys[0].name;
+      const grantData = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      grantData.expiresAt = Math.floor(Date.now() / 1000) - 100;
+      await mockEnv.OAUTH_KV.put(grantKey, JSON.stringify(grantData));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsChecked).toBe(1);
+      expect(result.grantsPurged).toBe(1);
+      expect(result.done).toBe(true);
+    });
+
+    it('should not purge grants whose expiresAt is in the future', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+      await authorizeClient(clientId, clientSecret);
+
+      // Set expiresAt to the future
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantKey = grantEntries.keys[0].name;
+      const grantData = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      grantData.expiresAt = Math.floor(Date.now() / 1000) + 86400;
+      await mockEnv.OAUTH_KV.put(grantKey, JSON.stringify(grantData));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsPurged).toBe(0);
+    });
+
+    it('should only purge grants for the deleted client, not others', async () => {
+      await initHelpers();
+      const client1 = await registerClient();
+      const client2 = await registerClient();
+      await authorizeClient(client1.clientId, client1.clientSecret);
+      await authorizeClient(client2.clientId, client2.clientSecret);
+
+      // Delete only client1 directly from KV
+      await mockEnv.OAUTH_KV.delete(`client:${client1.clientId}`);
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsPurged).toBe(1);
+
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(1);
+      const remainingGrant = await mockEnv.OAUTH_KV.get(grantsAfter.keys[0].name, { type: 'json' });
+      expect(remainingGrant.clientId).toBe(client2.clientId);
+    });
+
+    it('should not purge grants for CIMD clients', async () => {
+      await initHelpers();
+
+      // Manually insert a grant with a CIMD-style client ID (HTTPS URL)
+      const cimdGrant = {
+        id: 'cimd-grant-1',
+        clientId: 'https://app.example.com/.well-known/oauth-client',
+        userId: 'cimd-user',
+        scope: ['read'],
+        metadata: {},
+        encryptedProps: 'encrypted',
+        createdAt: Math.floor(Date.now() / 1000),
+      };
+      await mockEnv.OAUTH_KV.put(`grant:cimd-user:cimd-grant-1`, JSON.stringify(cimdGrant));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      // Grant should be checked but NOT purged (CIMD client not in KV is normal)
+      expect(result.grantsChecked).toBe(1);
+      expect(result.grantsPurged).toBe(0);
+
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(1);
+    });
+
+    it('should purge CIMD client grants if they are expired', async () => {
+      await initHelpers();
+
+      const cimdGrant = {
+        id: 'cimd-grant-expired',
+        clientId: 'https://app.example.com/.well-known/oauth-client',
+        userId: 'cimd-user',
+        scope: ['read'],
+        metadata: {},
+        encryptedProps: 'encrypted',
+        createdAt: Math.floor(Date.now() / 1000) - 200,
+        expiresAt: Math.floor(Date.now() / 1000) - 100,
+      };
+      await mockEnv.OAUTH_KV.put(`grant:cimd-user:cimd-grant-expired`, JSON.stringify(cimdGrant));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.grantsPurged).toBe(1);
+    });
+
+    it('should respect batchSize and return done:false when budget is exhausted', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+
+      // Create 5 grants
+      for (let i = 0; i < 5; i++) {
+        await authorizeClient(clientId, clientSecret, `user-${i}`);
+      }
+
+      // Delete the client to make all grants orphaned
+      await mockEnv.OAUTH_KV.delete(`client:${clientId}`);
+
+      // Purge with batchSize of 2
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData({ batchSize: 2 });
+
+      expect(result.grantsChecked).toBe(2);
+      expect(result.grantsPurged).toBe(2);
+      expect(result.done).toBe(false);
+
+      // 3 grants should remain
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(3);
+    });
+
+    it('should converge to done:true over multiple invocations', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+
+      for (let i = 0; i < 5; i++) {
+        await authorizeClient(clientId, clientSecret, `user-${i}`);
+      }
+      await mockEnv.OAUTH_KV.delete(`client:${clientId}`);
+
+      // First batch: purge 3
+      const result1 = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData({ batchSize: 3 });
+      expect(result1.grantsPurged).toBe(3);
+      expect(result1.done).toBe(false);
+
+      // Second batch: purge remaining 2
+      const result2 = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData({ batchSize: 3 });
+      expect(result2.grantsPurged).toBe(2);
+      expect(result2.done).toBe(true);
+
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(0);
+    });
+
+    it('should purge orphaned tokens whose grant no longer exists', async () => {
+      await initHelpers();
+
+      // Manually insert an orphaned token (no corresponding grant)
+      const orphanedToken = {
+        id: 'orphan-token-id',
+        grantId: 'deleted-grant',
+        userId: 'some-user',
+        createdAt: Math.floor(Date.now() / 1000),
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        wrappedEncryptionKey: 'key',
+        scope: ['read'],
+        grant: { clientId: 'deleted-client', scope: ['read'], encryptedProps: 'data' },
+      };
+      await mockEnv.OAUTH_KV.put(`token:some-user:deleted-grant:orphan-token-id`, JSON.stringify(orphanedToken));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.tokensChecked).toBe(1);
+      expect(result.tokensPurged).toBe(1);
+      expect(result.done).toBe(true);
+
+      const tokensAfter = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensAfter.keys.length).toBe(0);
+    });
+
+    it('should not purge tokens whose grant still exists', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+      await authorizeClient(clientId, clientSecret);
+
+      const tokensBefore = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensBefore.keys.length).toBe(1);
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      expect(result.tokensChecked).toBe(1);
+      expect(result.tokensPurged).toBe(0);
+
+      const tokensAfter = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensAfter.keys.length).toBe(1);
+    });
+
+    it('should skip grant sweep when purgeOrphanedGrants and purgeExpiredGrants are false', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+      await authorizeClient(clientId, clientSecret);
+      await mockEnv.OAUTH_KV.delete(`client:${clientId}`);
+
+      // Insert an orphaned token
+      const orphanedToken = {
+        id: 'orphan-id',
+        grantId: 'no-grant',
+        userId: 'some-user',
+        createdAt: Math.floor(Date.now() / 1000),
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        wrappedEncryptionKey: 'key',
+        scope: ['read'],
+        grant: { clientId: 'x', scope: ['read'], encryptedProps: 'data' },
+      };
+      await mockEnv.OAUTH_KV.put(`token:some-user:no-grant:orphan-id`, JSON.stringify(orphanedToken));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData({
+        purgeOrphanedGrants: false,
+        purgeExpiredGrants: false,
+      });
+
+      // Grant sweep should be skipped entirely
+      expect(result.grantsChecked).toBe(0);
+      expect(result.grantsPurged).toBe(0);
+      // Token sweep should still run
+      expect(result.tokensChecked).toBe(2); // 1 real token + 1 orphaned
+      expect(result.tokensPurged).toBe(1); // only orphaned one
+    });
+
+    it('should skip token sweep when purgeOrphanedTokens is false', async () => {
+      await initHelpers();
+
+      // Insert an orphaned token
+      const orphanedToken = {
+        id: 'orphan-id',
+        grantId: 'no-grant',
+        userId: 'some-user',
+        createdAt: Math.floor(Date.now() / 1000),
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        wrappedEncryptionKey: 'key',
+        scope: ['read'],
+        grant: { clientId: 'x', scope: ['read'], encryptedProps: 'data' },
+      };
+      await mockEnv.OAUTH_KV.put(`token:some-user:no-grant:orphan-id`, JSON.stringify(orphanedToken));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData({
+        purgeOrphanedTokens: false,
+      });
+
+      expect(result.tokensChecked).toBe(0);
+      expect(result.tokensPurged).toBe(0);
+      expect(result.done).toBe(true);
+
+      // Orphaned token should still be there
+      const tokensAfter = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensAfter.keys.length).toBe(1);
+    });
+
+    it('should cache client lookups across multiple grants for the same client', async () => {
+      await initHelpers();
+      const { clientId, clientSecret } = await registerClient();
+
+      // Create multiple grants for the same client
+      await authorizeClient(clientId, clientSecret, 'user-1');
+      await authorizeClient(clientId, clientSecret, 'user-2');
+      await authorizeClient(clientId, clientSecret, 'user-3');
+
+      // Spy on KV get to count client lookups
+      const originalGet = mockEnv.OAUTH_KV.get.bind(mockEnv.OAUTH_KV);
+      let clientLookups = 0;
+      mockEnv.OAUTH_KV.get = async (key: string, options?: any) => {
+        if (key.startsWith('client:')) clientLookups++;
+        return originalGet(key, options);
+      };
+
+      await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      // Should only look up the client once (cached for subsequent grants)
+      expect(clientLookups).toBe(1);
+    });
+
+    it('should work when called via OAuthProvider.purgeExpiredData', async () => {
+      await initHelpers();
+
+      // Insert an orphaned grant
+      const orphanedGrant = {
+        id: 'orphan-grant',
+        clientId: 'deleted-client',
+        userId: 'some-user',
+        scope: ['read'],
+        metadata: {},
+        encryptedProps: 'encrypted',
+        createdAt: Math.floor(Date.now() / 1000),
+      };
+      await mockEnv.OAUTH_KV.put(`grant:some-user:orphan-grant`, JSON.stringify(orphanedGrant));
+
+      // Call via OAuthProvider class (not OAuthHelpers)
+      const result = await provider.purgeExpiredData(mockEnv);
+
+      expect(result.grantsPurged).toBe(1);
+      expect(result.done).toBe(true);
+    });
+
+    it('should handle grants with colons in userId', async () => {
+      await initHelpers();
+
+      // Insert a grant with colons in the userId
+      const grant = {
+        id: 'grant-with-colons',
+        clientId: 'deleted-client',
+        userId: 'oauth2|provider|12345',
+        scope: ['read'],
+        metadata: {},
+        encryptedProps: 'encrypted',
+        createdAt: Math.floor(Date.now() / 1000),
+      };
+      await mockEnv.OAUTH_KV.put(`grant:oauth2|provider|12345:grant-with-colons`, JSON.stringify(grant));
+
+      const result = await mockEnv.OAUTH_PROVIDER!.purgeExpiredData();
+
+      // Should purge the orphaned grant using grantData.id and grantData.userId
+      expect(result.grantsPurged).toBe(1);
+      expect(result.done).toBe(true);
     });
   });
 });

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -247,10 +247,21 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
 
   /**
    * Time-to-live for refresh tokens in seconds.
-   * If not specified, refresh tokens do not expire.
+   * Defaults to 30 days (2,592,000 seconds).
+   * Set to 0 to disable refresh tokens entirely.
+   * Set to `undefined` explicitly for refresh tokens that never expire.
    * For example: 3600 = 1 hour, 2592000 = 30 days
    */
   refreshTokenTTL?: number;
+
+  /**
+   * Time-to-live for dynamically registered clients in seconds.
+   * Defaults to 90 days (7,776,000 seconds).
+   * Clients created via the DCR endpoint will automatically expire after this duration.
+   * Clients created via `OAuthHelpers.createClient()` are not affected by this setting.
+   * Set to `undefined` explicitly for clients that never expire.
+   */
+  clientRegistrationTTL?: number;
 
   /**
    * List of scopes supported by this OAuth provider.
@@ -470,6 +481,23 @@ export interface OAuthHelpers {
    * @returns Promise resolving to token response with new access token
    */
   exchangeToken(options: ExchangeTokenOptions): Promise<TokenResponse>;
+
+  /**
+   * Purges expired and orphaned data from the KV namespace.
+   * Designed to be called from a scheduled handler (Cron Trigger) for periodic cleanup.
+   * Processes records in configurable batches to stay within Cloudflare's subrequest limits.
+   *
+   * Performs two sweep phases:
+   * 1. Grant sweep: removes orphaned grants (client deleted) and expired grants (defense-in-depth for KV TTL)
+   * 2. Token sweep: removes orphaned tokens (grant deleted) as defense-in-depth
+   *
+   * Safe to call repeatedly — deleted records disappear from KV, so subsequent invocations
+   * naturally process fresh records without needing a persisted cursor.
+   *
+   * @param options - Optional configuration for batch size and which purge types to enable
+   * @returns Statistics about what was checked and purged, and whether the full scan completed
+   */
+  purgeExpiredData(options?: PurgeOptions): Promise<PurgeResult>;
 }
 
 /**
@@ -907,6 +935,64 @@ export interface ListResult<T> {
 }
 
 /**
+ * Options for the purgeExpiredData garbage collection method
+ */
+export interface PurgeOptions {
+  /**
+   * Maximum number of KV keys to check per phase (grants and tokens) per invocation.
+   * Each phase (grant sweep, token sweep) gets its own budget of this size.
+   * Keep this conservative to stay within Cloudflare's 1000 subrequest limit per invocation,
+   * since each checked key requires at least one KV read, and orphaned grants trigger
+   * additional KV operations via revokeGrant().
+   * Defaults to 50.
+   */
+  batchSize?: number;
+
+  /**
+   * Whether to purge orphaned grants whose client no longer exists in KV.
+   * Grants for CIMD (Client ID Metadata Document) clients are always skipped
+   * since those clients are not stored in KV.
+   * Defaults to true.
+   */
+  purgeOrphanedGrants?: boolean;
+
+  /**
+   * Whether to purge expired grants as defense-in-depth for KV TTL.
+   * Normally KV auto-deletes expired entries, but this catches any stragglers.
+   * Defaults to true.
+   */
+  purgeExpiredGrants?: boolean;
+
+  /**
+   * Whether to purge orphaned tokens whose grant no longer exists.
+   * Tokens already auto-expire via KV TTL (default 1 hour), so this is
+   * defense-in-depth for partial revokeGrant() failures.
+   * Defaults to true.
+   */
+  purgeOrphanedTokens?: boolean;
+}
+
+/**
+ * Result of a purgeExpiredData garbage collection invocation
+ */
+export interface PurgeResult {
+  /** Number of grant records checked in this invocation */
+  grantsChecked: number;
+
+  /** Number of grant records purged (orphaned or expired) */
+  grantsPurged: number;
+
+  /** Number of token records checked in this invocation */
+  tokensChecked: number;
+
+  /** Number of token records purged (orphaned) */
+  tokensPurged: number;
+
+  /** True if the full key space was scanned in this invocation (both grants and tokens) */
+  done: boolean;
+}
+
+/**
  * Public representation of a grant, with sensitive data removed
  * Used for list operations where the complete grant data isn't needed
  */
@@ -1024,6 +1110,18 @@ export class OAuthProvider<Env = Cloudflare.Env> {
   fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     return this.#impl.fetch(request, env, ctx);
   }
+
+  /**
+   * Purges expired and orphaned data from the KV namespace.
+   * Can be called directly from a scheduled handler without needing a request context.
+   *
+   * @param env - Cloudflare Worker environment variables (must include OAUTH_KV binding)
+   * @param options - Optional configuration for batch size and which purge types to enable
+   * @returns Statistics about what was checked and purged
+   */
+  purgeExpiredData(env: Env, options?: PurgeOptions): Promise<PurgeResult> {
+    return this.#impl.createOAuthHelpers(env).purgeExpiredData(options);
+  }
 }
 
 /**
@@ -1123,6 +1221,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     this.options = {
       accessTokenTTL: DEFAULT_ACCESS_TOKEN_TTL,
+      refreshTokenTTL: DEFAULT_REFRESH_TOKEN_TTL,
+      clientRegistrationTTL: DEFAULT_CLIENT_REGISTRATION_TTL,
       onError: ({ status, code, description }) =>
         console.warn(`OAuth error response: ${status} ${code} - ${description}`),
       ...options,
@@ -2739,8 +2839,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       );
     }
 
-    // Store client info
-    await env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(clientInfo));
+    // Store client info with optional TTL for DCR clients
+    const clientKvOptions: { expirationTtl?: number } = {};
+    if (this.options.clientRegistrationTTL !== undefined) {
+      clientKvOptions.expirationTtl = this.options.clientRegistrationTTL;
+    }
+    await env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(clientInfo), clientKvOptions);
 
     // Return client information with the original unhashed secret
     const response: Record<string, any> = {
@@ -2763,7 +2867,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Only include client_secret for confidential clients (RFC 7591 §3.2.1)
     if (clientSecret) {
       response.client_secret = clientSecret; // Return the original unhashed secret
-      response.client_secret_expires_at = 0; // Secret does not expire
+      response.client_secret_expires_at =
+        this.options.clientRegistrationTTL && clientInfo.registrationDate
+          ? clientInfo.registrationDate + this.options.clientRegistrationTTL
+          : 0;
       response.client_secret_issued_at = clientInfo.registrationDate;
     }
 
@@ -3053,9 +3160,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
-   * Checks if a client_id is a CIMD URL (HTTPS with non-root path)
+   * Checks if a client_id is a CIMD URL (HTTPS with non-root path).
+   * Not private because OAuthHelpersImpl needs access for purgeExpiredData.
    */
-  private isClientMetadataUrl(clientId: string): boolean {
+  isClientMetadataUrl(clientId: string): boolean {
     try {
       const url = new URL(clientId);
       return url.protocol === 'https:' && url.pathname !== '/';
@@ -3310,6 +3418,22 @@ class OAuthError extends Error {
  * Default expiration time for access tokens (1 hour in seconds)
  */
 const DEFAULT_ACCESS_TOKEN_TTL = 60 * 60;
+
+/**
+ * Default expiration time for refresh tokens (30 days in seconds)
+ */
+const DEFAULT_REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60;
+
+/**
+ * Default expiration time for dynamically registered clients (90 days in seconds)
+ */
+const DEFAULT_CLIENT_REGISTRATION_TTL = 90 * 24 * 60 * 60;
+
+/**
+ * Default batch size for purgeExpiredData. Conservative to stay within
+ * Cloudflare's 1000 subrequest limit per invocation.
+ */
+const DEFAULT_PURGE_BATCH_SIZE = 50;
 
 /**
  * Length of generated token strings
@@ -4176,7 +4300,12 @@ class OAuthHelpersImpl implements OAuthHelpers {
       delete updatedClient.clientSecret;
     }
 
-    await this.env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(updatedClient));
+    // Preserve TTL for DCR clients: re-apply clientRegistrationTTL if configured
+    const clientKvOptions: { expirationTtl?: number } = {};
+    if (this.provider.options.clientRegistrationTTL !== undefined) {
+      clientKvOptions.expirationTtl = this.provider.options.clientRegistrationTTL;
+    }
+    await this.env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(updatedClient), clientKvOptions);
 
     // Create a response object
     const response = { ...updatedClient };
@@ -4190,12 +4319,40 @@ class OAuthHelpersImpl implements OAuthHelpers {
   }
 
   /**
-   * Deletes an OAuth client
+   * Deletes an OAuth client and revokes all associated grants across all users.
    * @param clientId - The ID of the client to delete
    * @returns A Promise resolving when the deletion is confirmed.
    */
   async deleteClient(clientId: string): Promise<void> {
-    // Delete client
+    // Revoke all grants associated with this client across all users.
+    // Grants are keyed as grant:{userId}:{grantId}, so we scan all grants
+    // and check the clientId stored in each one.
+    let cursor: string | undefined;
+    let allProcessed = false;
+
+    while (!allProcessed) {
+      const listOptions: { prefix: string; cursor?: string } = { prefix: 'grant:' };
+      if (cursor) {
+        listOptions.cursor = cursor;
+      }
+
+      const result = await this.env.OAUTH_KV.list(listOptions);
+
+      for (const key of result.keys) {
+        const grantData: Grant | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+        if (grantData && grantData.clientId === clientId) {
+          await this.revokeGrant(grantData.id, grantData.userId);
+        }
+      }
+
+      if (result.list_complete) {
+        allProcessed = true;
+      } else {
+        cursor = result.cursor;
+      }
+    }
+
+    // Delete the client record
     await this.env.OAUTH_KV.delete(`client:${clientId}`);
   }
 
@@ -4338,6 +4495,145 @@ class OAuthHelpersImpl implements OAuthHelpers {
       clientInfo,
       this.env
     );
+  }
+
+  async purgeExpiredData(options?: PurgeOptions): Promise<PurgeResult> {
+    const batchSize = options?.batchSize ?? DEFAULT_PURGE_BATCH_SIZE;
+    const purgeOrphanedGrants = options?.purgeOrphanedGrants !== false;
+    const purgeExpiredGrants = options?.purgeExpiredGrants !== false;
+    const purgeOrphanedTokens = options?.purgeOrphanedTokens !== false;
+    const now = Math.floor(Date.now() / 1000);
+
+    const result: PurgeResult = {
+      grantsChecked: 0,
+      grantsPurged: 0,
+      tokensChecked: 0,
+      tokensPurged: 0,
+      done: false,
+    };
+
+    // Phase 1: Grant sweep
+    if (purgeOrphanedGrants || purgeExpiredGrants) {
+      const knownGoodClients = new Set<string>();
+      const knownMissingClients = new Set<string>();
+      let grantCursor: string | undefined;
+      let grantsDone = false;
+
+      while (!grantsDone && result.grantsChecked < batchSize) {
+        const listOptions: { prefix: string; cursor?: string; limit?: number } = {
+          prefix: 'grant:',
+          limit: Math.min(1000, batchSize - result.grantsChecked),
+        };
+        if (grantCursor) {
+          listOptions.cursor = grantCursor;
+        }
+
+        const page = await this.env.OAUTH_KV.list(listOptions);
+
+        for (const key of page.keys) {
+          if (result.grantsChecked >= batchSize) break;
+          result.grantsChecked++;
+
+          const grantData: Grant | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+          if (!grantData) continue;
+
+          let shouldPurge = false;
+
+          // Expiry check (defense-in-depth for KV TTL)
+          if (purgeExpiredGrants && grantData.expiresAt !== undefined && now >= grantData.expiresAt) {
+            shouldPurge = true;
+          }
+
+          // Orphan check: skip CIMD clients (URL-based client IDs not stored in KV)
+          if (!shouldPurge && purgeOrphanedGrants && !this.provider.isClientMetadataUrl(grantData.clientId)) {
+            if (knownMissingClients.has(grantData.clientId)) {
+              shouldPurge = true;
+            } else if (!knownGoodClients.has(grantData.clientId)) {
+              const client = await this.env.OAUTH_KV.get(`client:${grantData.clientId}`, { type: 'json' });
+              if (client) {
+                knownGoodClients.add(grantData.clientId);
+              } else {
+                knownMissingClients.add(grantData.clientId);
+                shouldPurge = true;
+              }
+            }
+          }
+
+          if (shouldPurge) {
+            await this.revokeGrant(grantData.id, grantData.userId);
+            result.grantsPurged++;
+          }
+        }
+
+        if (page.list_complete) {
+          grantsDone = true;
+        } else {
+          grantCursor = page.cursor;
+        }
+      }
+
+      // If grant sweep didn't finish, skip token sweep
+      if (!grantsDone) {
+        return result;
+      }
+    }
+
+    // Phase 2: Token sweep
+    if (purgeOrphanedTokens) {
+      const knownGoodGrants = new Set<string>();
+      const knownMissingGrants = new Set<string>();
+      let tokenCursor: string | undefined;
+      let tokensDone = false;
+
+      while (!tokensDone && result.tokensChecked < batchSize) {
+        const listOptions: { prefix: string; cursor?: string; limit?: number } = {
+          prefix: 'token:',
+          limit: Math.min(1000, batchSize - result.tokensChecked),
+        };
+        if (tokenCursor) {
+          listOptions.cursor = tokenCursor;
+        }
+
+        const page = await this.env.OAUTH_KV.list(listOptions);
+
+        for (const key of page.keys) {
+          if (result.tokensChecked >= batchSize) break;
+          result.tokensChecked++;
+
+          const tokenData: Token | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+          if (!tokenData) continue;
+
+          const grantKey = `grant:${tokenData.userId}:${tokenData.grantId}`;
+
+          if (knownMissingGrants.has(grantKey)) {
+            await this.env.OAUTH_KV.delete(key.name);
+            result.tokensPurged++;
+          } else if (!knownGoodGrants.has(grantKey)) {
+            const grantExists = await this.env.OAUTH_KV.get(grantKey);
+            if (grantExists) {
+              knownGoodGrants.add(grantKey);
+            } else {
+              knownMissingGrants.add(grantKey);
+              await this.env.OAUTH_KV.delete(key.name);
+              result.tokensPurged++;
+            }
+          }
+        }
+
+        if (page.list_complete) {
+          tokensDone = true;
+        } else {
+          tokenCursor = page.cursor;
+        }
+      }
+
+      if (!tokensDone) {
+        return result;
+      }
+    }
+
+    result.done = true;
+    return result;
   }
 }
 

--- a/storage-schema.md
+++ b/storage-schema.md
@@ -48,7 +48,7 @@ Client records store OAuth client application information.
 
 > **Note:** The `clientSecret` is stored as a SHA-256 hash, not in plaintext. The actual secret is only returned to the client when initially created or updated, and never stored.
 
-**TTL:** No expiration (persistent storage)
+**TTL:** Dynamically registered clients (DCR) default to 90 days. Clients created via `OAuthHelpers.createClient()` have no expiration. Configurable via the `clientRegistrationTTL` option.
 
 ### Authorization Grants
 
@@ -120,9 +120,9 @@ Grant records store information about permissions a user has granted to an appli
 **TTL:**
 
 - Initially 10 minutes (during authorization process)
-- No expiration after the authorization code is exchanged for tokens
+- After code exchange, TTL matches the refresh token expiration (defaults to 30 days, configurable via `refreshTokenTTL`)
 
-> **Note:** The grant record includes the hash of the authorization code initially, which is replaced by the hash of the refresh token after the code is exchanged. The record also has a TTL during the authorization process, which is removed when the code is exchanged for tokens to make the grant permanent.
+> **Note:** The grant record includes the hash of the authorization code initially, which is replaced by the hash of the refresh token after the code is exchanged. The record has a 10-minute TTL during authorization, which is replaced by the refresh token TTL when the code is exchanged.
 
 ### Tokens
 
@@ -232,12 +232,12 @@ Token records store metadata about issued access tokens, including denormalized 
 
 5. Access tokens expire automatically after their TTL.
 
-6. Refresh tokens do not expire and are stored directly in the grant; they remain valid until the grant is revoked.
+6. Refresh tokens expire based on the configured `refreshTokenTTL` (default: 30 days) and are stored directly in the grant.
    - For security, the provider issues a new refresh token with each refresh operation
    - It keeps track of both the current and previous tokens, along with their wrapped keys
    - When the new token is used, the previous token is invalidated, but can still be used until replaced
 
-7. When a grant is revoked:
+7. When a grant is revoked (or when `deleteClient()` is called, which cascades to all grants for that client):
    - All associated access tokens are found using the key prefix `token:{userId}:{grantId}:` and deleted
    - The grant record is deleted, which also effectively revokes the refresh token and all encrypted data
 
@@ -246,4 +246,5 @@ Token records store metadata about issued access tokens, including denormalized 
 - For high-traffic applications, consider using a caching layer in front of KV to reduce read operations on frequently accessed data.
 - Monitor KV usage metrics to ensure you stay within Cloudflare's limits for your plan.
 - The design uses KV's `list()` capability with key prefixes to efficiently query related data like all grants for a user, eliminating the need for separate list indexes.
-- If a grant is revoked, associated tokens are not immediately deleted from KV, but rely on TTL expiration. Add a cleanup process if immediate revocation is required.
+- When a grant is revoked via `revokeGrant()`, associated tokens are immediately deleted. When a client is deleted via `deleteClient()`, all grants and tokens for that client are also deleted.
+- The `purgeExpiredData()` method provides defense-in-depth garbage collection for orphaned grants and tokens. It is designed to be called from a scheduled handler (Cron Trigger).


### PR DESCRIPTION
## Problem

The OAUTH_KV namespace can grow unboundedly. Three categories of data accumulate without cleanup:

1. **Grants** — When `refreshTokenTTL` is not configured (the previous default), grants persist forever after code exchange. Users who authorize once and never return still have their grants stored permanently.
2. **DCR clients** — Dynamically registered clients have no expiration at all. In MCP contexts where many clients register, this is particularly problematic.
3. **Orphaned data** — When a client is deleted, its grants and tokens are left behind. There is no background cleanup mechanism.

## Solution

Four complementary changes, each addressing a layer of the growth problem:

### A. Default `refreshTokenTTL` to 30 days

Grants now auto-expire via KV TTL. Previously, the default was `undefined` (infinite).

- New constant: `DEFAULT_REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60`
- Set as constructor default via spread: `{ refreshTokenTTL: DEFAULT_REFRESH_TOKEN_TTL, ...options }`
- Opt-out: pass `refreshTokenTTL: undefined` explicitly for infinite TTL
- `refreshTokenTTL: 0` still disables refresh tokens entirely

**Reviewer note — existing data safety:** Existing grants in KV have `expiresAt: undefined` and no KV TTL. They are NOT affected by this change — only newly issued grants get the default. The GC's expiry check (`grantData.expiresAt !== undefined && now >= grantData.expiresAt`) skips grants without `expiresAt`.

### B. Default `clientRegistrationTTL` to 90 days

DCR-created clients now auto-expire. Previously, they persisted forever.

- New constant: `DEFAULT_CLIENT_REGISTRATION_TTL = 90 * 24 * 60 * 60`
- Applied as `expirationTtl` on `KV.put()` in the DCR endpoint
- `client_secret_expires_at` in DCR response now reflects the TTL (per RFC 7591)
- `OAuthHelpers.createClient()` (programmatic) is NOT affected — no TTL applied
- `updateClient()` re-applies the TTL (resets from now) to prevent TTL stripping on update
- Opt-out: pass `clientRegistrationTTL: undefined` explicitly

### C. `deleteClient` cascades to grants and tokens

Previously, `deleteClient()` only deleted the `client:{id}` record, leaving all grants and tokens orphaned.

Now it scans all `grant:*` keys, checks each grant's `clientId`, and calls `revokeGrant()` for matches (which also deletes associated tokens). The client record is deleted last.

**Reviewer note — key parsing safety:** Uses `grantData.id` and `grantData.userId` from the fetched Grant object instead of parsing key strings. This is safe for userIds containing colons (e.g., `oauth2|provider|12345`).

### D. `purgeExpiredData()` garbage collection

New method on both `OAuthHelpers` and `OAuthProvider` for scheduled cleanup:

```typescript
// From a scheduled handler (no request context needed)
const result = await oauthProvider.purgeExpiredData(env, { batchSize: 100 });

// Or from OAuthHelpers
const result = await env.OAUTH_PROVIDER.purgeExpiredData({ batchSize: 100 });
```

**Two-phase sweep:**

1. **Grant sweep** — Removes orphaned grants (client deleted) and expired grants (defense-in-depth for KV TTL)
2. **Token sweep** — Removes orphaned tokens (grant deleted) as defense-in-depth

**Batch processing:** Each phase gets its own `batchSize` budget (default: 50). If grants exhaust the budget, token sweep is skipped and `done: false` is returned. Designed for repeated invocation via Cron Trigger — deleted records disappear from KV, so subsequent calls naturally process fresh records without a persisted cursor.

**Safeguards against accidental deletion:**

| Scenario | Protection |
|---|---|
| CIMD clients (URL-based client IDs not in KV) | `isClientMetadataUrl()` check skips orphan detection — these clients are fetched live, not stored in KV |
| Grants mid-authorization (10-min auth code TTL) | No `expiresAt` field set during authorization, so expiry check doesn't fire. Client exists, so orphan check doesn't fire. |
| Healthy grants with active clients | Client existence cached in `Set<string>` — only purges when `client:{id}` is genuinely missing |
| Concurrent GC invocations | Harmless — KV deletes are idempotent, `revokeGrant` handles missing data gracefully |
| Subrequest limits (1000/invocation) | Default batch size of 50. Worst case: 50 orphaned grants x ~13 ops each = ~650 subrequests |

## MockKV improvements

Two fixes to the test mock to match real Cloudflare KV behavior:

1. **`put()` now supports `expiration`** (absolute timestamp in seconds), not just `expirationTtl` (relative). Needed because `saveGrantWithTTL` uses `{ expiration: grantData.expiresAt }`.
2. **`list()` now properly paginates** with `limit` and `cursor`, returning `list_complete: false` when there are more records. Previously always returned `list_complete: true`.

## Breaking changes

This is a **minor version bump** (per AGENTS.md: "changes that invalidate tokens or refresh tokens must be minor"):

- `refreshTokenTTL` now defaults to 30 days instead of infinite. Newly issued grants will expire. Existing grants are unaffected.
- `clientRegistrationTTL` now defaults to 90 days. Newly registered DCR clients will expire. Existing clients are unaffected.
- `deleteClient()` now cascades to grants and tokens. Previously it only deleted the client record.
- `client_secret_expires_at` in DCR responses now reflects the TTL instead of always being `0`.

**Migration for existing users who want the old behavior:**
```typescript
new OAuthProvider({
  refreshTokenTTL: undefined,        // infinite refresh tokens
  clientRegistrationTTL: undefined,   // permanent DCR clients
  // ...
});
```

## New exports

- `PurgeOptions` — Configuration for `purgeExpiredData()`
- `PurgeResult` — Return type with `grantsChecked`, `grantsPurged`, `tokensChecked`, `tokensPurged`, `done`

## Test coverage

32 new tests (305 to 337 total), covering:

- Default TTL application (refresh tokens, client registrations)
- Explicit `undefined` opt-out for infinite TTL
- Custom TTL values
- DCR client auto-expiry
- `createClient()` not affected by `clientRegistrationTTL`
- `updateClient()` preserving TTL
- `deleteClient` cascading to grants and tokens across multiple users
- Selective cascade (only target client's grants)
- Orphaned grant purging
- Expired grant purging (defense-in-depth)
- CIMD client grants NOT being purged (data loss prevention)
- Expired CIMD grants still being purged
- Batch size limiting with `done: false`
- Multi-invocation convergence to `done: true`
- Orphaned token purging
- Healthy token/grant preservation
- Selective disable (`purgeOrphanedGrants: false`, etc.)
- Client lookup caching verification
- `OAuthProvider.purgeExpiredData()` (scheduled handler path)
- Colons in userId (key parsing safety)
- No-op on clean namespace

## Docs updated

- **README.md** — Updated `refreshTokenTTL` description, added `clientRegistrationTTL`, added "KV Namespace Cleanup" section with scheduled handler example, noted `deleteClient` cascade behavior
- **storage-schema.md** — Updated client TTL (90 days default for DCR), grant TTL (30 days default), refresh token expiry, cascade delete behavior, `purgeExpiredData` mention
- **AGENTS.md** — Updated file size estimates
