### PR TITLE
feat: add clientRegistrationCallback for customizing DCR

### DIFF
--- a/.changeset/dcr-callback.md
+++ b/.changeset/dcr-callback.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Add `clientRegistrationCallback` for validating or rejecting dynamic client registrations before storage. Follows the same pattern as `tokenExchangeCallback`. Closes #162.

--- a/.changeset/dcr-callback.md
+++ b/.changeset/dcr-callback.md
@@ -3,3 +3,8 @@
 ---
 
 Add `clientRegistrationCallback` for validating or rejecting dynamic client registrations before storage. Follows the same pattern as `tokenExchangeCallback`. Closes #162.
+
+- Default rejection error follows RFC 7591 §3.2.2 (`invalid_client_metadata` / 400). Callbacks rejecting for non-metadata reasons (missing IAT, untrusted origin) should override `rejectCode` and `rejectStatus` explicitly.
+- The `request` passed to the callback is cloned before the library reads the body, so callbacks may consume the body (e.g. to verify a signature over the raw bytes).
+- Callback exceptions are caught and surfaced as `500 server_error`.
+- `software_statement` (RFC 7591 §3.1.1) JWTs are not processed by the library; callbacks wishing to honor them must verify the JWT and apply its claims themselves.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -705,7 +705,7 @@ describe('OAuthProvider', () => {
       );
     });
 
-    it('should reject registration when callback returns reject: true', async () => {
+    it('should reject registration with RFC 7591 §3.2.2 defaults when callback returns reject: true', async () => {
       const provider = new OAuthProvider({
         apiRoute: '/api/',
         apiHandler: TestApiHandler,
@@ -734,9 +734,10 @@ describe('OAuthProvider', () => {
 
       const response = await provider.fetch(request, mockEnv, mockCtx);
 
-      expect(response.status).toBe(403);
+      // Defaults follow RFC 7591 §3.2.2: `invalid_client_metadata` / 400
+      expect(response.status).toBe(400);
       const body = await response.json<any>();
-      expect(body.error).toBe('access_denied');
+      expect(body.error).toBe('invalid_client_metadata');
       expect(body.error_description).toBe('Registration requires approval');
 
       // Verify no client was stored
@@ -814,10 +815,88 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(201);
       const registeredClient = await response.json<any>();
 
-      // Verify overrides were applied in KV
+      // Response body must reflect overrides — clients depend on this per
+      // RFC 7591 §3.2.1 to determine if registration is sufficient for use.
+      expect(registeredClient.client_name).toBe('Overridden Name');
+      expect(registeredClient.contacts).toEqual(['admin@example.com']);
+
+      // Verify overrides were also applied in KV
       const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
       expect(savedClient.clientName).toBe('Overridden Name');
       expect(savedClient.contacts).toEqual(['admin@example.com']);
+    });
+
+    it('should return 500 server_error when callback throws', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => {
+          throw new Error('upstream allowlist service unavailable');
+        },
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(500);
+      const body = await response.json<any>();
+      expect(body.error).toBe('server_error');
+      expect(body.error_description).toBe('upstream allowlist service unavailable');
+
+      // No client should have been stored
+      const keys = await mockEnv.OAUTH_KV.list({ prefix: 'client:' });
+      expect(keys.keys.length).toBe(0);
+    });
+
+    it('should expose request body to the callback (cloned before parsing)', async () => {
+      const seenBodies: string[] = [];
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: async ({ request }) => {
+          // Body should be readable here even though the library has already parsed it
+          seenBodies.push(await request.text());
+        },
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Body Reader Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const rawBody = JSON.stringify(clientData);
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        rawBody
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(201);
+      expect(seenBodies).toEqual([rawBody]);
     });
 
     it('should support async callback', async () => {
@@ -829,11 +908,15 @@ describe('OAuthProvider', () => {
         tokenEndpoint: '/oauth/token',
         clientRegistrationEndpoint: '/oauth/register',
         clientRegistrationCallback: async ({ request }) => {
-          // Simulate async validation (e.g. checking an initial access token)
+          // Simulate async validation (e.g. checking an initial access token).
+          // IAT failure is an auth problem, not a metadata problem, so we
+          // override the RFC 7591 §3.2.2 defaults to return 401/invalid_token.
           const authHeader = request.headers.get('Authorization');
           if (!authHeader || authHeader !== 'Bearer valid-initial-token') {
             return {
               reject: true,
+              rejectCode: 'invalid_token',
+              rejectStatus: 401,
               rejectDescription: 'Valid initial access token required',
             };
           }
@@ -855,7 +938,9 @@ describe('OAuthProvider', () => {
       );
 
       const rejectedResponse = await provider.fetch(rejectedRequest, mockEnv, mockCtx);
-      expect(rejectedResponse.status).toBe(403);
+      expect(rejectedResponse.status).toBe(401);
+      const rejectedBody = await rejectedResponse.json<any>();
+      expect(rejectedBody.error).toBe('invalid_token');
 
       // With valid token — should succeed
       const approvedRequest = createMockRequest(

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -664,6 +664,212 @@ describe('OAuthProvider', () => {
     });
   });
 
+  describe('Client Registration Callback', () => {
+    it('should invoke callback and allow registration when callback returns void', async () => {
+      const callback = vi.fn();
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: callback,
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Callback Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(201);
+      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientMetadata: expect.objectContaining({
+            client_name: 'Callback Test Client',
+            redirect_uris: ['https://client.example.com/callback'],
+          }),
+          request: expect.any(Request),
+        })
+      );
+    });
+
+    it('should reject registration when callback returns reject: true', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => ({
+          reject: true,
+          rejectDescription: 'Registration requires approval',
+        }),
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Rejected Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(403);
+      const body = await response.json<any>();
+      expect(body.error).toBe('access_denied');
+      expect(body.error_description).toBe('Registration requires approval');
+
+      // Verify no client was stored
+      const keys = await mockEnv.OAUTH_KV.list({ prefix: 'client:' });
+      expect(keys.keys.length).toBe(0);
+    });
+
+    it('should reject with custom error code when callback provides one', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => ({
+          reject: true,
+          rejectCode: 'invalid_client_metadata',
+          rejectDescription: 'client_name is required by policy',
+          rejectStatus: 400,
+        }),
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('invalid_client_metadata');
+      expect(body.error_description).toBe('client_name is required by policy');
+    });
+
+    it('should apply clientMetadataOverrides before storing', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => ({
+          clientMetadataOverrides: {
+            clientName: 'Overridden Name',
+            contacts: ['admin@example.com'],
+          },
+        }),
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Original Name',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(201);
+      const registeredClient = await response.json<any>();
+
+      // Verify overrides were applied in KV
+      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+      expect(savedClient.clientName).toBe('Overridden Name');
+      expect(savedClient.contacts).toEqual(['admin@example.com']);
+    });
+
+    it('should support async callback', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: async ({ request }) => {
+          // Simulate async validation (e.g. checking an initial access token)
+          const authHeader = request.headers.get('Authorization');
+          if (!authHeader || authHeader !== 'Bearer valid-initial-token') {
+            return {
+              reject: true,
+              rejectDescription: 'Valid initial access token required',
+            };
+          }
+        },
+      });
+
+      // Without token — should be rejected
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const rejectedRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const rejectedResponse = await provider.fetch(rejectedRequest, mockEnv, mockCtx);
+      expect(rejectedResponse.status).toBe(403);
+
+      // With valid token — should succeed
+      const approvedRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json', Authorization: 'Bearer valid-initial-token' },
+        JSON.stringify(clientData)
+      );
+
+      const approvedResponse = await provider.fetch(approvedRequest, mockEnv, mockCtx);
+      expect(approvedResponse.status).toBe(201);
+    });
+  });
+
   describe('Authorization Code Flow', () => {
     let clientId: string;
     let clientSecret: string;

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1040,7 +1040,7 @@ describe('OAuthProvider', () => {
       );
     });
 
-    it('should reject registration when callback returns reject: true', async () => {
+    it('should reject registration with RFC 7591 §3.2.2 defaults when callback returns reject: true', async () => {
       const provider = new OAuthProvider({
         apiRoute: '/api/',
         apiHandler: TestApiHandler,
@@ -1069,9 +1069,10 @@ describe('OAuthProvider', () => {
 
       const response = await provider.fetch(request, mockEnv, mockCtx);
 
-      expect(response.status).toBe(403);
+      // Defaults follow RFC 7591 §3.2.2: `invalid_client_metadata` / 400
+      expect(response.status).toBe(400);
       const body = await response.json<any>();
-      expect(body.error).toBe('access_denied');
+      expect(body.error).toBe('invalid_client_metadata');
       expect(body.error_description).toBe('Registration requires approval');
 
       // Verify no client was stored
@@ -1149,10 +1150,88 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(201);
       const registeredClient = await response.json<any>();
 
-      // Verify overrides were applied in KV
+      // Response body must reflect overrides — clients depend on this per
+      // RFC 7591 §3.2.1 to determine if registration is sufficient for use.
+      expect(registeredClient.client_name).toBe('Overridden Name');
+      expect(registeredClient.contacts).toEqual(['admin@example.com']);
+
+      // Verify overrides were also applied in KV
       const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
       expect(savedClient.clientName).toBe('Overridden Name');
       expect(savedClient.contacts).toEqual(['admin@example.com']);
+    });
+
+    it('should return 500 server_error when callback throws', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => {
+          throw new Error('upstream allowlist service unavailable');
+        },
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(500);
+      const body = await response.json<any>();
+      expect(body.error).toBe('server_error');
+      expect(body.error_description).toBe('upstream allowlist service unavailable');
+
+      // No client should have been stored
+      const keys = await mockEnv.OAUTH_KV.list({ prefix: 'client:' });
+      expect(keys.keys.length).toBe(0);
+    });
+
+    it('should expose request body to the callback (cloned before parsing)', async () => {
+      const seenBodies: string[] = [];
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: async ({ request }) => {
+          // Body should be readable here even though the library has already parsed it
+          seenBodies.push(await request.text());
+        },
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Body Reader Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const rawBody = JSON.stringify(clientData);
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        rawBody
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(201);
+      expect(seenBodies).toEqual([rawBody]);
     });
 
     it('should support async callback', async () => {
@@ -1164,11 +1243,15 @@ describe('OAuthProvider', () => {
         tokenEndpoint: '/oauth/token',
         clientRegistrationEndpoint: '/oauth/register',
         clientRegistrationCallback: async ({ request }) => {
-          // Simulate async validation (e.g. checking an initial access token)
+          // Simulate async validation (e.g. checking an initial access token).
+          // IAT failure is an auth problem, not a metadata problem, so we
+          // override the RFC 7591 §3.2.2 defaults to return 401/invalid_token.
           const authHeader = request.headers.get('Authorization');
           if (!authHeader || authHeader !== 'Bearer valid-initial-token') {
             return {
               reject: true,
+              rejectCode: 'invalid_token',
+              rejectStatus: 401,
               rejectDescription: 'Valid initial access token required',
             };
           }
@@ -1190,7 +1273,9 @@ describe('OAuthProvider', () => {
       );
 
       const rejectedResponse = await provider.fetch(rejectedRequest, mockEnv, mockCtx);
-      expect(rejectedResponse.status).toBe(403);
+      expect(rejectedResponse.status).toBe(401);
+      const rejectedBody = await rejectedResponse.json<any>();
+      expect(rejectedBody.error).toBe('invalid_token');
 
       // With valid token — should succeed
       const approvedRequest = createMockRequest(

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -999,6 +999,212 @@ describe('OAuthProvider', () => {
     });
   });
 
+  describe('Client Registration Callback', () => {
+    it('should invoke callback and allow registration when callback returns void', async () => {
+      const callback = vi.fn();
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: callback,
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Callback Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(201);
+      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientMetadata: expect.objectContaining({
+            client_name: 'Callback Test Client',
+            redirect_uris: ['https://client.example.com/callback'],
+          }),
+          request: expect.any(Request),
+        })
+      );
+    });
+
+    it('should reject registration when callback returns reject: true', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => ({
+          reject: true,
+          rejectDescription: 'Registration requires approval',
+        }),
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Rejected Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(403);
+      const body = await response.json<any>();
+      expect(body.error).toBe('access_denied');
+      expect(body.error_description).toBe('Registration requires approval');
+
+      // Verify no client was stored
+      const keys = await mockEnv.OAUTH_KV.list({ prefix: 'client:' });
+      expect(keys.keys.length).toBe(0);
+    });
+
+    it('should reject with custom error code when callback provides one', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => ({
+          reject: true,
+          rejectCode: 'invalid_client_metadata',
+          rejectDescription: 'client_name is required by policy',
+          rejectStatus: 400,
+        }),
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('invalid_client_metadata');
+      expect(body.error_description).toBe('client_name is required by policy');
+    });
+
+    it('should apply clientMetadataOverrides before storing', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => ({
+          clientMetadataOverrides: {
+            clientName: 'Overridden Name',
+            contacts: ['admin@example.com'],
+          },
+        }),
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Original Name',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(201);
+      const registeredClient = await response.json<any>();
+
+      // Verify overrides were applied in KV
+      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+      expect(savedClient.clientName).toBe('Overridden Name');
+      expect(savedClient.contacts).toEqual(['admin@example.com']);
+    });
+
+    it('should support async callback', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: async ({ request }) => {
+          // Simulate async validation (e.g. checking an initial access token)
+          const authHeader = request.headers.get('Authorization');
+          if (!authHeader || authHeader !== 'Bearer valid-initial-token') {
+            return {
+              reject: true,
+              rejectDescription: 'Valid initial access token required',
+            };
+          }
+        },
+      });
+
+      // Without token — should be rejected
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const rejectedRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const rejectedResponse = await provider.fetch(rejectedRequest, mockEnv, mockCtx);
+      expect(rejectedResponse.status).toBe(403);
+
+      // With valid token — should succeed
+      const approvedRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json', Authorization: 'Bearer valid-initial-token' },
+        JSON.stringify(clientData)
+      );
+
+      const approvedResponse = await provider.fetch(approvedRequest, mockEnv, mockCtx);
+      expect(approvedResponse.status).toBe(201);
+    });
+  });
+
   describe('Authorization Code Flow', () => {
     let clientId: string;
     let clientSecret: string;

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1161,6 +1161,45 @@ describe('OAuthProvider', () => {
       expect(savedClient.contacts).toEqual(['admin@example.com']);
     });
 
+    it('should reject invalid URI overrides before storing', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        clientRegistrationCallback: () => ({
+          clientMetadataOverrides: {
+            logoUri: 'javascript:alert(1)',
+          },
+        }),
+      });
+
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Original Name',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('invalid_client_metadata');
+      expect(body.error_description).toBe('Invalid logoUri: must be an absolute http: or https: URL');
+
+      const keys = await mockEnv.OAUTH_KV.list({ prefix: 'client:' });
+      expect(keys.keys.length).toBe(0);
+    });
+
     it('should return 500 server_error when callback throws', async () => {
       const provider = new OAuthProvider({
         apiRoute: '/api/',

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -140,6 +140,38 @@ export interface TokenExchangeCallbackOptions {
 }
 
 /**
+ * Options for the client registration callback (RFC 7591).
+ */
+export interface ClientRegistrationCallbackOptions {
+  /** Parsed client metadata from the registration request body. */
+  clientMetadata: Record<string, unknown>;
+  /** The original HTTP request (useful for reading auth headers). */
+  request: Request;
+}
+
+/**
+ * Result of the client registration callback.
+ */
+export interface ClientRegistrationCallbackResult {
+  /**
+   * Override non-security-critical client metadata fields (allowlist).
+   * Security fields (clientId, clientSecret, redirectUris, tokenEndpointAuthMethod,
+   * registrationDate, grantTypes, responseTypes) cannot be overridden.
+   */
+  clientMetadataOverrides?: Partial<
+    Pick<ClientInfo, 'clientName' | 'logoUri' | 'clientUri' | 'policyUri' | 'tosUri' | 'jwksUri' | 'contacts'>
+  >;
+  /** Set true to reject the registration. */
+  reject?: boolean;
+  /** OAuth error code when rejecting. Defaults to "access_denied". */
+  rejectCode?: string;
+  /** Error description when rejecting. */
+  rejectDescription?: string;
+  /** HTTP status code when rejecting. Defaults to 403. */
+  rejectStatus?: number;
+}
+
+/**
  * Input parameters for the resolveExternalToken callback function
  */
 export interface ResolveExternalTokenInput {
@@ -299,6 +331,14 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * Defaults to false.
    */
   disallowPublicClientRegistration?: boolean;
+
+  /**
+   * Called during DCR (RFC 7591) before the client is stored. Return `{ reject: true }` to
+   * deny, `{ clientMetadataOverrides }` to modify, or void to allow.
+   */
+  clientRegistrationCallback?: (
+    options: ClientRegistrationCallbackOptions
+  ) => Promise<ClientRegistrationCallbackResult | void> | ClientRegistrationCallbackResult | void;
 
   /**
    * Optional callback function that is called during token exchange.
@@ -2837,6 +2877,39 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         'invalid_client_metadata',
         error instanceof Error ? error.message : 'Invalid client metadata'
       );
+    }
+
+    if (this.options.clientRegistrationCallback) {
+      const callbackResult = await Promise.resolve(
+        this.options.clientRegistrationCallback({ clientMetadata, request })
+      );
+
+      if (callbackResult?.reject) {
+        return this.createErrorResponse(
+          callbackResult.rejectCode || 'access_denied',
+          callbackResult.rejectDescription || 'Client registration denied',
+          callbackResult.rejectStatus ?? 403
+        );
+      }
+
+      if (callbackResult?.clientMetadataOverrides) {
+        // Runtime allowlist (defense in depth — matches the Pick<> type constraint)
+        const ALLOWED_OVERRIDE_KEYS = [
+          'clientName',
+          'logoUri',
+          'clientUri',
+          'policyUri',
+          'tosUri',
+          'jwksUri',
+          'contacts',
+        ] as const;
+        const overrides = callbackResult.clientMetadataOverrides;
+        for (const key of ALLOWED_OVERRIDE_KEYS) {
+          if (key in overrides) {
+            (clientInfo as any)[key] = (overrides as any)[key];
+          }
+        }
+      }
     }
 
     // Store client info with optional TTL for DCR clients

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -143,9 +143,19 @@ export interface TokenExchangeCallbackOptions {
  * Options for the client registration callback (RFC 7591).
  */
 export interface ClientRegistrationCallbackOptions {
-  /** Parsed client metadata from the registration request body. */
+  /**
+   * Parsed client metadata from the registration request body.
+   *
+   * Note: This is the raw JSON body. RFC 7591 §3.1.1 `software_statement` claims
+   * are NOT currently merged in by the library — if `software_statement` is present
+   * the callback is responsible for verifying the JWT and applying its claims.
+   */
   clientMetadata: Record<string, unknown>;
-  /** The original HTTP request (useful for reading auth headers). */
+  /**
+   * A clone of the registration HTTP request. The body has not been consumed,
+   * so the callback may call `request.text()` / `request.json()` if needed
+   * (e.g. to validate a signature over the raw body).
+   */
   request: Request;
 }
 
@@ -163,11 +173,19 @@ export interface ClientRegistrationCallbackResult {
   >;
   /** Set true to reject the registration. */
   reject?: boolean;
-  /** OAuth error code when rejecting. Defaults to "access_denied". */
+  /**
+   * OAuth error code when rejecting. Defaults to `invalid_client_metadata`
+   * (RFC 7591 §3.2.2). For non-metadata rejections (e.g. missing initial access
+   * token, untrusted origin), set this to a more specific code such as
+   * `access_denied` or `invalid_token`.
+   */
   rejectCode?: string;
   /** Error description when rejecting. */
   rejectDescription?: string;
-  /** HTTP status code when rejecting. Defaults to 403. */
+  /**
+   * HTTP status code when rejecting. Defaults to 400 (RFC 7591 §3.2.2). Override
+   * for auth-style failures (e.g. 401 for missing IAT, 403 for policy denial).
+   */
   rejectStatus?: number;
 }
 
@@ -2800,6 +2818,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.createErrorResponse('invalid_request', 'Request payload too large, must be under 1 MiB', 413);
     }
 
+    // Clone before reading the body so a downstream clientRegistrationCallback
+    // can still consume it (e.g. to verify a signature over the raw bytes).
+    const callbackRequest = request.clone();
+
     // Parse client metadata with a size limitation
     let clientMetadata;
     try {
@@ -2880,15 +2902,31 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     if (this.options.clientRegistrationCallback) {
-      const callbackResult = await Promise.resolve(
-        this.options.clientRegistrationCallback({ clientMetadata, request })
-      );
+      // Note: RFC 7591 §3.1.1 `software_statement` claims are not processed by
+      // this library. If the request body includes a `software_statement` JWT,
+      // the callback is responsible for verifying its signature and applying
+      // its claims (which per §2 MUST take precedence over plain JSON values).
+      let callbackResult;
+      try {
+        callbackResult = await Promise.resolve(
+          this.options.clientRegistrationCallback({ clientMetadata, request: callbackRequest })
+        );
+      } catch (error) {
+        return this.createErrorResponse(
+          'server_error',
+          error instanceof Error ? error.message : 'Client registration callback failed',
+          500
+        );
+      }
 
       if (callbackResult?.reject) {
+        // Default to RFC 7591 §3.2.2 — `invalid_client_metadata` / 400. Callbacks
+        // rejecting for non-metadata reasons (missing IAT, policy denial) should
+        // override `rejectCode` / `rejectStatus` explicitly.
         return this.createErrorResponse(
-          callbackResult.rejectCode || 'access_denied',
+          callbackResult.rejectCode || 'invalid_client_metadata',
           callbackResult.rejectDescription || 'Client registration denied',
-          callbackResult.rejectStatus ?? 403
+          callbackResult.rejectStatus ?? 400
         );
       }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -212,9 +212,19 @@ export interface TokenExchangeCallbackOptions {
  * Options for the client registration callback (RFC 7591).
  */
 export interface ClientRegistrationCallbackOptions {
-  /** Parsed client metadata from the registration request body. */
+  /**
+   * Parsed client metadata from the registration request body.
+   *
+   * Note: This is the raw JSON body. RFC 7591 §3.1.1 `software_statement` claims
+   * are NOT currently merged in by the library — if `software_statement` is present
+   * the callback is responsible for verifying the JWT and applying its claims.
+   */
   clientMetadata: Record<string, unknown>;
-  /** The original HTTP request (useful for reading auth headers). */
+  /**
+   * A clone of the registration HTTP request. The body has not been consumed,
+   * so the callback may call `request.text()` / `request.json()` if needed
+   * (e.g. to validate a signature over the raw body).
+   */
   request: Request;
 }
 
@@ -232,11 +242,19 @@ export interface ClientRegistrationCallbackResult {
   >;
   /** Set true to reject the registration. */
   reject?: boolean;
-  /** OAuth error code when rejecting. Defaults to "access_denied". */
+  /**
+   * OAuth error code when rejecting. Defaults to `invalid_client_metadata`
+   * (RFC 7591 §3.2.2). For non-metadata rejections (e.g. missing initial access
+   * token, untrusted origin), set this to a more specific code such as
+   * `access_denied` or `invalid_token`.
+   */
   rejectCode?: string;
   /** Error description when rejecting. */
   rejectDescription?: string;
-  /** HTTP status code when rejecting. Defaults to 403. */
+  /**
+   * HTTP status code when rejecting. Defaults to 400 (RFC 7591 §3.2.2). Override
+   * for auth-style failures (e.g. 401 for missing IAT, 403 for policy denial).
+   */
   rejectStatus?: number;
 }
 
@@ -3347,6 +3365,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       });
     }
 
+    // Clone before reading the body so a downstream clientRegistrationCallback
+    // can still consume it (e.g. to verify a signature over the raw bytes).
+    const callbackRequest = request.clone();
+
     // Parse client metadata with a size limitation
     let clientMetadata;
     try {
@@ -3432,15 +3454,31 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     if (this.options.clientRegistrationCallback) {
-      const callbackResult = await Promise.resolve(
-        this.options.clientRegistrationCallback({ clientMetadata, request })
-      );
+      // Note: RFC 7591 §3.1.1 `software_statement` claims are not processed by
+      // this library. If the request body includes a `software_statement` JWT,
+      // the callback is responsible for verifying its signature and applying
+      // its claims (which per §2 MUST take precedence over plain JSON values).
+      let callbackResult;
+      try {
+        callbackResult = await Promise.resolve(
+          this.options.clientRegistrationCallback({ clientMetadata, request: callbackRequest })
+        );
+      } catch (error) {
+        return this.createErrorResponse(
+          'server_error',
+          error instanceof Error ? error.message : 'Client registration callback failed',
+          500
+        );
+      }
 
       if (callbackResult?.reject) {
+        // Default to RFC 7591 §3.2.2 — `invalid_client_metadata` / 400. Callbacks
+        // rejecting for non-metadata reasons (missing IAT, policy denial) should
+        // override `rejectCode` / `rejectStatus` explicitly.
         return this.createErrorResponse(
-          callbackResult.rejectCode || 'access_denied',
+          callbackResult.rejectCode || 'invalid_client_metadata',
           callbackResult.rejectDescription || 'Client registration denied',
-          callbackResult.rejectStatus ?? 403
+          callbackResult.rejectStatus ?? 400
         );
       }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -209,6 +209,38 @@ export interface TokenExchangeCallbackOptions {
 }
 
 /**
+ * Options for the client registration callback (RFC 7591).
+ */
+export interface ClientRegistrationCallbackOptions {
+  /** Parsed client metadata from the registration request body. */
+  clientMetadata: Record<string, unknown>;
+  /** The original HTTP request (useful for reading auth headers). */
+  request: Request;
+}
+
+/**
+ * Result of the client registration callback.
+ */
+export interface ClientRegistrationCallbackResult {
+  /**
+   * Override non-security-critical client metadata fields (allowlist).
+   * Security fields (clientId, clientSecret, redirectUris, tokenEndpointAuthMethod,
+   * registrationDate, grantTypes, responseTypes) cannot be overridden.
+   */
+  clientMetadataOverrides?: Partial<
+    Pick<ClientInfo, 'clientName' | 'logoUri' | 'clientUri' | 'policyUri' | 'tosUri' | 'jwksUri' | 'contacts'>
+  >;
+  /** Set true to reject the registration. */
+  reject?: boolean;
+  /** OAuth error code when rejecting. Defaults to "access_denied". */
+  rejectCode?: string;
+  /** Error description when rejecting. */
+  rejectDescription?: string;
+  /** HTTP status code when rejecting. Defaults to 403. */
+  rejectStatus?: number;
+}
+
+/**
  * Input parameters for the resolveExternalToken callback function
  */
 export interface ResolveExternalTokenInput {
@@ -378,6 +410,14 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * Defaults to false.
    */
   disallowPublicClientRegistration?: boolean;
+
+  /**
+   * Called during DCR (RFC 7591) before the client is stored. Return `{ reject: true }` to
+   * deny, `{ clientMetadataOverrides }` to modify, or void to allow.
+   */
+  clientRegistrationCallback?: (
+    options: ClientRegistrationCallbackOptions
+  ) => Promise<ClientRegistrationCallbackResult | void> | ClientRegistrationCallbackResult | void;
 
   /**
    * Optional callback function that is called during token exchange.
@@ -3389,6 +3429,39 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.createErrorResponse('invalid_client_metadata', {
         description: error instanceof Error ? error.message : 'Invalid client metadata',
       });
+    }
+
+    if (this.options.clientRegistrationCallback) {
+      const callbackResult = await Promise.resolve(
+        this.options.clientRegistrationCallback({ clientMetadata, request })
+      );
+
+      if (callbackResult?.reject) {
+        return this.createErrorResponse(
+          callbackResult.rejectCode || 'access_denied',
+          callbackResult.rejectDescription || 'Client registration denied',
+          callbackResult.rejectStatus ?? 403
+        );
+      }
+
+      if (callbackResult?.clientMetadataOverrides) {
+        // Runtime allowlist (defense in depth — matches the Pick<> type constraint)
+        const ALLOWED_OVERRIDE_KEYS = [
+          'clientName',
+          'logoUri',
+          'clientUri',
+          'policyUri',
+          'tosUri',
+          'jwksUri',
+          'contacts',
+        ] as const;
+        const overrides = callbackResult.clientMetadataOverrides;
+        for (const key of ALLOWED_OVERRIDE_KEYS) {
+          if (key in overrides) {
+            (clientInfo as any)[key] = (overrides as any)[key];
+          }
+        }
+      }
     }
 
     // Store client info with optional TTL for DCR clients

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -235,7 +235,8 @@ export interface ClientRegistrationCallbackResult {
   /**
    * Override non-security-critical client metadata fields (allowlist).
    * Security fields (clientId, clientSecret, redirectUris, tokenEndpointAuthMethod,
-   * registrationDate, grantTypes, responseTypes) cannot be overridden.
+   * registrationDate, grantTypes, responseTypes) cannot be overridden. Override
+   * values are revalidated before storage.
    */
   clientMetadataOverrides?: Partial<
     Pick<ClientInfo, 'clientName' | 'logoUri' | 'clientUri' | 'policyUri' | 'tosUri' | 'jwksUri' | 'contacts'>
@@ -3464,40 +3465,51 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
           this.options.clientRegistrationCallback({ clientMetadata, request: callbackRequest })
         );
       } catch (error) {
-        return this.createErrorResponse(
-          'server_error',
-          error instanceof Error ? error.message : 'Client registration callback failed',
-          500
-        );
+        return this.createErrorResponse('server_error', {
+          description: error instanceof Error ? error.message : 'Client registration callback failed',
+          statusCode: 500,
+        });
       }
 
       if (callbackResult?.reject) {
         // Default to RFC 7591 §3.2.2 — `invalid_client_metadata` / 400. Callbacks
         // rejecting for non-metadata reasons (missing IAT, policy denial) should
         // override `rejectCode` / `rejectStatus` explicitly.
-        return this.createErrorResponse(
-          callbackResult.rejectCode || 'invalid_client_metadata',
-          callbackResult.rejectDescription || 'Client registration denied',
-          callbackResult.rejectStatus ?? 400
-        );
+        return this.createErrorResponse(callbackResult.rejectCode || 'invalid_client_metadata', {
+          description: callbackResult.rejectDescription || 'Client registration denied',
+          statusCode: callbackResult.rejectStatus ?? 400,
+        });
       }
 
       if (callbackResult?.clientMetadataOverrides) {
-        // Runtime allowlist (defense in depth — matches the Pick<> type constraint)
-        const ALLOWED_OVERRIDE_KEYS = [
-          'clientName',
-          'logoUri',
-          'clientUri',
-          'policyUri',
-          'tosUri',
-          'jwksUri',
-          'contacts',
-        ] as const;
         const overrides = callbackResult.clientMetadataOverrides;
-        for (const key of ALLOWED_OVERRIDE_KEYS) {
-          if (key in overrides) {
-            (clientInfo as any)[key] = (overrides as any)[key];
+        try {
+          // Runtime allowlist and validation (defense in depth — matches the Pick<> type constraint).
+          if ('clientName' in overrides) {
+            clientInfo.clientName = OAuthProviderImpl.validateStringField(overrides.clientName, 'clientName');
           }
+          if ('logoUri' in overrides) {
+            clientInfo.logoUri = OAuthProviderImpl.validateOptionalUriField(overrides.logoUri, 'logoUri');
+          }
+          if ('clientUri' in overrides) {
+            clientInfo.clientUri = OAuthProviderImpl.validateOptionalUriField(overrides.clientUri, 'clientUri');
+          }
+          if ('policyUri' in overrides) {
+            clientInfo.policyUri = OAuthProviderImpl.validateOptionalUriField(overrides.policyUri, 'policyUri');
+          }
+          if ('tosUri' in overrides) {
+            clientInfo.tosUri = OAuthProviderImpl.validateOptionalUriField(overrides.tosUri, 'tosUri');
+          }
+          if ('jwksUri' in overrides) {
+            clientInfo.jwksUri = OAuthProviderImpl.validateOptionalUriField(overrides.jwksUri, 'jwksUri');
+          }
+          if ('contacts' in overrides) {
+            clientInfo.contacts = OAuthProviderImpl.validateStringArray(overrides.contacts, 'contacts');
+          }
+        } catch (error) {
+          return this.createErrorResponse('invalid_client_metadata', {
+            description: error instanceof Error ? error.message : 'Invalid client metadata override',
+          });
         }
       }
     }


### PR DESCRIPTION
Adds `clientRegistrationCallback` to `OAuthProviderOptions` — same pattern as `tokenExchangeCallback`, applied to DCR.

- Callback invoked after validation, before KV storage
- Can reject with custom error code/status, or override safe metadata fields
- Overrides use a Pick allowlist (clientName, contacts, URI metadata, etc.) — security fields like redirectUris/clientSecret/tokenEndpointAuthMethod can't be set
- Override values are revalidated before storage, including http(s)-only URI validation for URI metadata fields
- Runtime enforcement mirrors the type constraint

Closes #162.
