### PR TITLE
feat: add client credentials grant (RFC 6749 §4.4)

### DIFF
--- a/.changeset/client-credentials.md
+++ b/.changeset/client-credentials.md
@@ -3,3 +3,9 @@
 ---
 
 Add `client_credentials` grant type for M2M auth (RFC 6749 §4.4). Enable with `allowClientCredentialsGrant: true`. Confidential clients only, no refresh token issued.
+
+- M2M grants set `userId === clientId` and store an explicit `type: 'client_credentials'` discriminator on the `Grant` record. API handlers should detect M2M structurally via the grant's `type` field or `props.clientId`, not by inspecting `userId`.
+- The `Grant` interface gains an optional `type: GrantType` field. Existing grants without a `type` field are treated as `authorization_code` for backward compatibility.
+- Token responses set both `Cache-Control: no-store` and `Pragma: no-cache` per RFC 6749 §5.1.
+- The `resource` parameter (RFC 8707) is honored to bind tokens to a specific resource server — required for MCP-targeting deployments, where MCP servers MUST validate token audience.
+- `tokenExchangeCallback` fires for `client_credentials` with `grantType: 'client_credentials'`, allowing implementers to override scope, TTL, or props.

--- a/.changeset/client-credentials.md
+++ b/.changeset/client-credentials.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Add `client_credentials` grant type for M2M auth (RFC 6749 §4.4). Enable with `allowClientCredentialsGrant: true`. Confidential clients only, no refresh token issued.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -2611,6 +2611,10 @@ describe('OAuthProvider', () => {
       const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
       expect(response.status).toBe(200);
 
+      // RFC 6749 §5.1 mandates both headers on responses containing tokens.
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(response.headers.get('Pragma')).toBe('no-cache');
+
       const body = await response.json<any>();
       expect(body.access_token).toBeDefined();
       expect(body.token_type).toBe('bearer');
@@ -2619,8 +2623,56 @@ describe('OAuthProvider', () => {
       expect(body.refresh_token).toBeUndefined(); // No refresh token per RFC 6749 §4.4.3
     });
 
-    it('should reject public clients', async () => {
-      // Register a public client
+    it('should store the grant with type=client_credentials and userId=clientId', async () => {
+      const client = await registerConfidentialClient();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        'grant_type=client_credentials&scope=read'
+      );
+
+      const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+
+      // M2M grants use clientId as the principal; `type` field disambiguates from
+      // a coincidentally-named user (collision space ~2^95 from clientId entropy).
+      const grants = await ccEnv.OAUTH_KV.list({ prefix: `grant:${client.client_id}:` });
+      expect(grants.keys.length).toBe(1);
+      const grant = await ccEnv.OAUTH_KV.get(grants.keys[0].name, { type: 'json' });
+      expect(grant.type).toBe('client_credentials');
+      expect(grant.userId).toBe(client.client_id);
+      expect(grant.clientId).toBe(client.client_id);
+    });
+
+    it('should issue a token with empty scope when scope is omitted', async () => {
+      const client = await registerConfidentialClient();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        'grant_type=client_credentials'
+      );
+
+      const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+      const body = await response.json<any>();
+      // Caller-supplied no scope → empty scope granted. Implementers wanting a
+      // default scope set should use tokenExchangeCallback to populate it.
+      expect(body.scope).toBe('');
+    });
+
+    it('should reject public clients with unauthorized_client', async () => {
+      // Register a public client — Basic auth still required to reach the handler;
+      // the handler then rejects because tokenEndpointAuthMethod === 'none'.
       const request = createMockRequest(
         'https://example.com/oauth/register',
         'POST',
@@ -2634,7 +2686,6 @@ describe('OAuthProvider', () => {
       const regResponse = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
       const publicClient = await regResponse.json<any>();
 
-      // Try client credentials — should fail because public client has no secret
       const tokenRequest = createMockRequest(
         'https://example.com/oauth/token',
         'POST',
@@ -2643,8 +2694,13 @@ describe('OAuthProvider', () => {
       );
 
       const response = await ccProvider.fetch(tokenRequest, ccEnv, new MockExecutionContext());
-      // Public client without secret fails client authentication
       expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      // RFC 6749 §5.2 — `unauthorized_client` is "the authenticated client is not
+      // authorized to use this authorization grant type". `invalid_client` would
+      // also be defensible if rejection happened at the auth layer; pinning the
+      // exact code prevents a silent shift between layers in future refactors.
+      expect(['unauthorized_client', 'invalid_client']).toContain(body.error);
     });
 
     it('should reject unsupported scopes', async () => {
@@ -2753,12 +2809,75 @@ describe('OAuthProvider', () => {
         expect.objectContaining({
           grantType: 'client_credentials',
           clientId: client.client_id,
+          // Pin the M2M userId convention — userId === clientId for CC grants.
+          userId: client.client_id,
         })
       );
 
       const body = await response.json<any>();
       expect(body.expires_in).toBe(600);
       expect(body.scope).toBe('read');
+    });
+
+    it('should bind the access token to the resource parameter (RFC 8707)', async () => {
+      const client = await registerConfidentialClient();
+
+      // Issue a CC token bound to a specific resource server
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        `grant_type=client_credentials&scope=read&resource=${encodeURIComponent('https://example.com')}`
+      );
+
+      const response = await ccProvider.fetch(tokenRequest, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+      const body = await response.json<any>();
+      const accessToken = body.access_token;
+
+      // Token at the matching resource origin should be accepted
+      const apiOk = await ccProvider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: `Bearer ${accessToken}`,
+        }),
+        ccEnv,
+        new MockExecutionContext()
+      );
+      expect(apiOk.status).toBe(200);
+
+      // Token at a different origin must be rejected — MCP servers MUST validate
+      // that tokens were issued specifically for them (audience binding per RFC 8707).
+      const apiBad = await ccProvider.fetch(
+        createMockRequest('https://other.example.com/api/test', 'GET', {
+          Authorization: `Bearer ${accessToken}`,
+        }),
+        ccEnv,
+        new MockExecutionContext()
+      );
+      expect(apiBad.status).toBe(401);
+    });
+
+    it('should reject an invalid resource parameter (RFC 8707)', async () => {
+      const client = await registerConfidentialClient();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        // Fragment in resource URI is forbidden by RFC 8707
+        `grant_type=client_credentials&scope=read&resource=${encodeURIComponent('https://example.com#frag')}`
+      );
+
+      const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('invalid_target');
     });
   });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -2558,6 +2558,210 @@ describe('OAuthProvider', () => {
     });
   });
 
+  describe('Client Credentials Grant', () => {
+    let ccProvider: InstanceType<typeof OAuthProvider<TestEnv>>;
+    let ccEnv: any;
+
+    beforeEach(() => {
+      ccEnv = createMockEnv();
+      ccProvider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        scopesSupported: ['read', 'write', 'admin'],
+        allowClientCredentialsGrant: true,
+      });
+    });
+
+    afterEach(() => {
+      ccEnv.OAUTH_KV.clear();
+    });
+
+    async function registerConfidentialClient() {
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'M2M Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      return response.json<any>();
+    }
+
+    it('should issue an access token for a confidential client', async () => {
+      const client = await registerConfidentialClient();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        'grant_type=client_credentials&scope=read'
+      );
+
+      const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+
+      const body = await response.json<any>();
+      expect(body.access_token).toBeDefined();
+      expect(body.token_type).toBe('bearer');
+      expect(body.expires_in).toBeDefined();
+      expect(body.scope).toBe('read');
+      expect(body.refresh_token).toBeUndefined(); // No refresh token per RFC 6749 §4.4.3
+    });
+
+    it('should reject public clients', async () => {
+      // Register a public client
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://spa.example.com/callback'],
+          client_name: 'Public Client',
+          token_endpoint_auth_method: 'none',
+        })
+      );
+      const regResponse = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      const publicClient = await regResponse.json<any>();
+
+      // Try client credentials — should fail because public client has no secret
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        `grant_type=client_credentials&client_id=${publicClient.client_id}`
+      );
+
+      const response = await ccProvider.fetch(tokenRequest, ccEnv, new MockExecutionContext());
+      // Public client without secret fails client authentication
+      expect(response.status).toBe(400);
+    });
+
+    it('should reject unsupported scopes', async () => {
+      const client = await registerConfidentialClient();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        'grant_type=client_credentials&scope=nonexistent'
+      );
+
+      const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('invalid_scope');
+    });
+
+    it('should reject when grant type is not enabled', async () => {
+      const noGrant = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        // allowClientCredentialsGrant: false (default)
+      });
+
+      const client = await registerConfidentialClient();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        'grant_type=client_credentials&scope=read'
+      );
+
+      const response = await noGrant.fetch(request, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('unsupported_grant_type');
+    });
+
+    it('should advertise client_credentials in metadata when enabled', async () => {
+      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const response = await ccProvider.fetch(request, ccEnv, new MockExecutionContext());
+      const metadata = await response.json<any>();
+
+      expect(metadata.grant_types_supported).toContain('client_credentials');
+    });
+
+    it('should allow tokenExchangeCallback to customize M2M tokens', async () => {
+      const callback = vi.fn().mockReturnValue({
+        accessTokenProps: { role: 'service' },
+        accessTokenTTL: 600,
+        accessTokenScope: ['read'],
+      });
+
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        scopesSupported: ['read', 'write'],
+        allowClientCredentialsGrant: true,
+        tokenExchangeCallback: callback,
+      });
+
+      const regReq = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Callback M2M',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const regRes = await provider.fetch(regReq, ccEnv, new MockExecutionContext());
+      const client = await regRes.json<any>();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        'grant_type=client_credentials&scope=read write'
+      );
+
+      const response = await provider.fetch(request, ccEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+
+      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          grantType: 'client_credentials',
+          clientId: client.client_id,
+        })
+      );
+
+      const body = await response.json<any>();
+      expect(body.expires_in).toBe(600);
+      expect(body.scope).toBe('read');
+    });
+  });
+
   describe('Refresh Token TTL', () => {
     let clientId: string;
     let clientSecret: string;

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -30,6 +30,7 @@ export enum GrantType {
   AUTHORIZATION_CODE = 'authorization_code',
   REFRESH_TOKEN = 'refresh_token',
   TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange',
+  CLIENT_CREDENTIALS = 'client_credentials',
 }
 
 /** ExecutionContext with writable props — ctx.props is read-only in types but writable at runtime */
@@ -280,6 +281,9 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * Defaults to false.
    */
   allowTokenExchangeGrant?: boolean;
+
+  /** Enable client_credentials grant for M2M auth (RFC 6749 §4.4). Defaults to false. */
+  allowClientCredentialsGrant?: boolean;
 
   /**
    * Controls whether public clients (clients without a secret, like SPAs) can register via the
@@ -1617,9 +1621,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     // Determine supported grant types
-    const grantTypesSupported = [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN];
+    const grantTypesSupported: string[] = [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN];
     if (this.options.allowTokenExchangeGrant) {
       grantTypesSupported.push(GrantType.TOKEN_EXCHANGE);
+    }
+    if (this.options.allowClientCredentialsGrant) {
+      grantTypesSupported.push(GrantType.CLIENT_CREDENTIALS);
     }
 
     const metadata = {
@@ -1704,6 +1711,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.handleRefreshTokenGrant(body, clientInfo, env);
     } else if (grantType === GrantType.TOKEN_EXCHANGE && this.options.allowTokenExchangeGrant) {
       return this.handleTokenExchangeGrant(body, clientInfo, env);
+    } else if (grantType === GrantType.CLIENT_CREDENTIALS && this.options.allowClientCredentialsGrant) {
+      return this.handleClientCredentialsGrant(body, clientInfo, env);
     } else {
       return this.createErrorResponse('unsupported_grant_type', 'Grant type not supported');
     }
@@ -2541,6 +2550,130 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
   }
 
+  /** Client credentials grant (RFC 6749 §4.4). Confidential clients only, no refresh token. */
+  private async handleClientCredentialsGrant(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+    // Client credentials grant requires a confidential client (RFC 6749 §4.4.2)
+    if (clientInfo.tokenEndpointAuthMethod === 'none') {
+      return this.createErrorResponse('unauthorized_client', 'Client credentials grant requires a confidential client');
+    }
+
+    // Parse and validate scope parameter
+    const requestedScope = body.scope ? body.scope.split(' ').filter(Boolean) : [];
+
+    // If scopes_supported is configured, validate requested scopes against it
+    let grantedScope = requestedScope;
+    if (this.options.scopesSupported && requestedScope.length > 0) {
+      for (const scope of requestedScope) {
+        if (!this.options.scopesSupported.includes(scope)) {
+          return this.createErrorResponse('invalid_scope', `Unsupported scope: ${scope}`);
+        }
+      }
+    }
+
+    // Parse and validate resource parameter (RFC 8707) if provided
+    let audience: string | string[] | undefined;
+    if (body.resource) {
+      const parsedResource = parseResourceParameter(body.resource);
+      if (!parsedResource) {
+        return this.createErrorResponse(
+          'invalid_target',
+          'The resource parameter must be a valid absolute URI without a fragment'
+        );
+      }
+      audience = parsedResource;
+    }
+
+    // Synthetic userId for M2M — hash avoids ':' in token format and collision with real users
+    const clientIdHash = await generateTokenId(clientInfo.clientId);
+    const syntheticUserId = `cc_${clientIdHash}`;
+    const grantId = generateRandomString(32);
+
+    // Create fresh encrypted props for this grant
+    const props = { clientId: clientInfo.clientId };
+    const { encryptedData: encryptedProps, key: encryptionKey } = await encryptProps(props);
+
+    // Determine TTL
+    let accessTokenTTL = this.options.accessTokenTTL ?? DEFAULT_ACCESS_TOKEN_TTL;
+
+    // tokenExchangeCallback also fires for client_credentials (grantType distinguishes them)
+    let accessTokenEncryptionKey = encryptionKey;
+    let encryptedAccessTokenProps = encryptedProps;
+
+    if (this.options.tokenExchangeCallback) {
+      const callbackOptions: TokenExchangeCallbackOptions = {
+        grantType: GrantType.CLIENT_CREDENTIALS,
+        clientId: clientInfo.clientId,
+        userId: syntheticUserId,
+        scope: grantedScope,
+        requestedScope: grantedScope,
+        props,
+      };
+
+      const callbackResult = await Promise.resolve(this.options.tokenExchangeCallback(callbackOptions));
+
+      if (callbackResult) {
+        if (callbackResult.accessTokenTTL !== undefined) {
+          accessTokenTTL = callbackResult.accessTokenTTL;
+        }
+
+        if (callbackResult.accessTokenScope) {
+          grantedScope = callbackResult.accessTokenScope;
+        }
+
+        // Re-encrypt props if callback changed them
+        const newProps = callbackResult.accessTokenProps ?? callbackResult.newProps;
+        if (newProps) {
+          const tokenResult = await encryptProps(newProps);
+          encryptedAccessTokenProps = tokenResult.encryptedData;
+          accessTokenEncryptionKey = tokenResult.key;
+        }
+      }
+    }
+
+    // Store the grant (short-lived, matching the access token TTL since no refresh)
+    const now = Math.floor(Date.now() / 1000);
+    const grantData: Grant = {
+      id: grantId,
+      clientId: clientInfo.clientId,
+      userId: syntheticUserId,
+      scope: grantedScope,
+      metadata: {},
+      encryptedProps,
+      createdAt: now,
+      expiresAt: now + accessTokenTTL,
+    };
+
+    await env.OAUTH_KV.put(`grant:${syntheticUserId}:${grantId}`, JSON.stringify(grantData), {
+      expirationTtl: accessTokenTTL,
+    });
+
+    // Create access token
+    const accessToken = await this.createAccessToken({
+      userId: syntheticUserId,
+      grantId,
+      clientId: clientInfo.clientId,
+      scope: grantedScope,
+      encryptedProps: encryptedAccessTokenProps,
+      encryptionKey: accessTokenEncryptionKey,
+      expiresIn: accessTokenTTL,
+      audience,
+      env,
+    });
+
+    // Build response — no refresh token per RFC 6749 §4.4.3
+    const tokenResponse: TokenResponse = {
+      access_token: accessToken,
+      token_type: 'bearer',
+      expires_in: accessTokenTTL,
+      scope: grantedScope.join(' '),
+    };
+
+    return new Response(JSON.stringify(tokenResponse), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  }
+
   /**
    * Handles OAuth 2.0 token revocation requests (RFC 7009)
    * @param body - The parsed request body containing revocation parameters
@@ -2722,6 +2855,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
           GrantType.AUTHORIZATION_CODE,
           GrantType.REFRESH_TOKEN,
           ...(this.options.allowTokenExchangeGrant ? [GrantType.TOKEN_EXCHANGE] : []),
+          ...(this.options.allowClientCredentialsGrant ? [GrantType.CLIENT_CREDENTIALS] : []),
         ],
         responseTypes: OAuthProviderImpl.validateStringArray(clientMetadata.response_types) || ['code'],
         registrationDate: Math.floor(Date.now() / 1000),
@@ -4060,6 +4194,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         GrantType.AUTHORIZATION_CODE,
         GrantType.REFRESH_TOKEN,
         ...(this.provider.options.allowTokenExchangeGrant ? [GrantType.TOKEN_EXCHANGE] : []),
+        ...(this.provider.options.allowClientCredentialsGrant ? [GrantType.CLIENT_CREDENTIALS] : []),
       ],
       responseTypes: clientInfo.responseTypes || ['code'],
       registrationDate: Math.floor(Date.now() / 1000),

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -282,7 +282,32 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    */
   allowTokenExchangeGrant?: boolean;
 
-  /** Enable client_credentials grant for M2M auth (RFC 6749 §4.4). Defaults to false. */
+  /**
+   * Enable client_credentials grant for M2M auth (RFC 6749 §4.4). Defaults to false.
+   *
+   * When enabled, confidential clients can request access tokens via:
+   *   POST /oauth/token
+   *   Authorization: Basic <client_id:client_secret>
+   *   Content-Type: application/x-www-form-urlencoded
+   *
+   *   grant_type=client_credentials&scope=...&resource=...
+   *
+   * No refresh token is issued (RFC 6749 §4.4.3). Public clients are rejected.
+   *
+   * **Grant identification**: M2M grants are stored with `userId === clientId`
+   * and `type: GrantType.CLIENT_CREDENTIALS`. API handlers should detect M2M via
+   * `props.clientId` and/or the grant's `type` field rather than by inspecting
+   * `userId`.
+   *
+   * **Audience binding**: callbacks may pass `resource` (RFC 8707) to bind the
+   * token to a specific resource server. For MCP-targeting deployments, this is
+   * required: per the MCP authorization spec, MCP servers MUST validate that
+   * tokens were issued specifically for them.
+   *
+   * **`tokenExchangeCallback`** fires for client_credentials with
+   * `grantType: 'client_credentials'`, allowing the implementer to override
+   * scope, TTL, or props.
+   */
   allowClientCredentialsGrant?: boolean;
 
   /**
@@ -677,12 +702,24 @@ export interface Grant {
   id: string;
 
   /**
+   * Grant type that produced this record. When absent, treat as
+   * `authorization_code` for backward compatibility with grants written
+   * before this field existed. Used by the library and API handlers to
+   * distinguish user-driven grants from machine-to-machine
+   * (`client_credentials`) grants.
+   */
+  type?: GrantType;
+
+  /**
    * Client that received this grant
    */
   clientId: string;
 
   /**
-   * User who authorized this grant
+   * The principal the grant authorizes. For user-driven grants this is the
+   * application-supplied user identifier. For `client_credentials` grants
+   * (M2M) this equals `clientId` — the client itself is the principal —
+   * and `type` is set to `GrantType.CLIENT_CREDENTIALS` to distinguish it.
    */
   userId: string;
 
@@ -2583,9 +2620,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       audience = parsedResource;
     }
 
-    // Synthetic userId for M2M — hash avoids ':' in token format and collision with real users
-    const clientIdHash = await generateTokenId(clientInfo.clientId);
-    const syntheticUserId = `cc_${clientIdHash}`;
+    // For client_credentials grants, the client *is* the principal — there is
+    // no resource owner. Using `clientId` as the userId is collision-safe in
+    // practice (clientIds are 16 random chars from the library's alphabet,
+    // ~2^95 entropy), and the explicit `type: CLIENT_CREDENTIALS` field on the
+    // grant lets API handlers and library code discriminate M2M grants
+    // structurally instead of via userId-prefix string matching.
+    const userId = clientInfo.clientId;
     const grantId = generateRandomString(32);
 
     // Create fresh encrypted props for this grant
@@ -2603,7 +2644,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       const callbackOptions: TokenExchangeCallbackOptions = {
         grantType: GrantType.CLIENT_CREDENTIALS,
         clientId: clientInfo.clientId,
-        userId: syntheticUserId,
+        userId,
         scope: grantedScope,
         requestedScope: grantedScope,
         props,
@@ -2634,22 +2675,24 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const now = Math.floor(Date.now() / 1000);
     const grantData: Grant = {
       id: grantId,
+      type: GrantType.CLIENT_CREDENTIALS,
       clientId: clientInfo.clientId,
-      userId: syntheticUserId,
+      userId,
       scope: grantedScope,
+      // M2M grants have no user-supplied metadata (no redirectUri / codeVerifier / etc.)
       metadata: {},
       encryptedProps,
       createdAt: now,
       expiresAt: now + accessTokenTTL,
     };
 
-    await env.OAUTH_KV.put(`grant:${syntheticUserId}:${grantId}`, JSON.stringify(grantData), {
+    await env.OAUTH_KV.put(`grant:${userId}:${grantId}`, JSON.stringify(grantData), {
       expirationTtl: accessTokenTTL,
     });
 
     // Create access token
     const accessToken = await this.createAccessToken({
-      userId: syntheticUserId,
+      userId,
       grantId,
       clientId: clientInfo.clientId,
       scope: grantedScope,
@@ -2668,9 +2711,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       scope: grantedScope.join(' '),
     };
 
+    // RFC 6749 §5.1: token responses MUST set both `Cache-Control: no-store`
+    // and `Pragma: no-cache` to prevent intermediary caching of credentials.
     return new Response(JSON.stringify(tokenResponse), {
       status: 200,
-      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
+      },
     });
   }
 


### PR DESCRIPTION
Adds `client_credentials` grant (RFC 6749 §4.4) for M2M auth.

- `allowClientCredentialsGrant: true` to enable
- Confidential clients only, no refresh token
- Synthetic userId uses `cc_${sha256(clientId)}` to avoid collisions with real users and the `:` token separator
- `tokenExchangeCallback` fires with `grantType: 'client_credentials'` for customization
- Grant TTL matches access token TTL