### PR TITLE
fix: add Cache-Control: no-store to token and error responses (RFC 6749 §5.1)

### DIFF
--- a/.changeset/cache-control-no-store.md
+++ b/.changeset/cache-control-no-store.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Add `Cache-Control: no-store` to token responses, DCR responses, and error responses per RFC 6749 §5.1.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -4207,6 +4207,67 @@ describe('OAuthProvider', () => {
     });
   });
 
+  describe('Cache-Control Headers (RFC 6749 §5.1)', () => {
+    it('should include Cache-Control: no-store on token responses', async () => {
+      // Register a client and do a full auth code flow to get a token response
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Cache Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+      const regRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+      const regResponse = await oauthProvider.fetch(regRequest, mockEnv, mockCtx);
+      const client = await regResponse.json<any>();
+
+      // Registration response should also have no-store (contains client_secret)
+      expect(regResponse.headers.get('Cache-Control')).toBe('no-store');
+
+      // Do authorization
+      const authUrl = new URL('https://example.com/authorize');
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', client.client_id);
+      authUrl.searchParams.set('redirect_uri', 'https://client.example.com/callback');
+      authUrl.searchParams.set('scope', 'read');
+      const authRequest = createMockRequest(authUrl.toString());
+      const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+      const redirectUrl = new URL(authResponse.headers.get('Location')!);
+      const code = redirectUrl.searchParams.get('code')!;
+
+      // Exchange code for token
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+        },
+        `grant_type=authorization_code&code=${encodeURIComponent(code)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}`
+      );
+      const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
+
+      expect(tokenResponse.status).toBe(200);
+      expect(tokenResponse.headers.get('Cache-Control')).toBe('no-store');
+    });
+
+    it('should include Cache-Control: no-store on token error responses', async () => {
+      const request = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        'grant_type=authorization_code&code=invalid'
+      );
+      const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+    });
+  });
+
   describe('CORS Support', () => {
     it('should handle CORS preflight for API requests', async () => {
       const preflightRequest = createMockRequest('https://example.com/api/test', 'OPTIONS', {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1993,9 +1993,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       tokenResponse.resource = audience;
     }
 
-    // Return the tokens
+    // Return the tokens (RFC 6749 §5.1 requires Cache-Control: no-store)
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
     });
   }
 
@@ -2276,9 +2276,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       tokenResponse.resource = audience;
     }
 
-    // Return the tokens
+    // Return the tokens (RFC 6749 §5.1 requires Cache-Control: no-store)
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
     });
   }
 
@@ -2527,9 +2527,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         env
       );
 
-      // Return the token
+      // Return the token (RFC 6749 §5.1 requires Cache-Control: no-store)
       return new Response(JSON.stringify(tokenResponse), {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
       });
     } catch (error) {
       // Convert OAuthError to HTTP error response
@@ -2767,9 +2767,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       response.client_secret_issued_at = clientInfo.registrationDate;
     }
 
+    // RFC 7591 §3.2.1: response may contain client_secret — prevent caching
     return new Response(JSON.stringify(response), {
       status: 201,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
     });
   }
 
@@ -3281,10 +3282,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       error_description: description,
     });
 
+    // RFC 6749 §5.2 requires Cache-Control: no-store for token endpoint error responses.
+    // Applied to all error responses since it's harmless on non-token errors and ensures
+    // no error response containing sensitive info (e.g. client auth failures) is cached.
     return new Response(body, {
       status,
       headers: {
         'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
         ...headers,
       },
     });


### PR DESCRIPTION
Adds `Cache-Control: no-store` to token responses, DCR responses, and error responses per RFC 6749 §5.1. Prevents intermediary caching of tokens and credentials.