### PR TITLE
fix: advertise fragment response mode when implicit flow is enabled

### DIFF
--- a/.changeset/response-modes-fragment.md
+++ b/.changeset/response-modes-fragment.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Include `fragment` in `response_modes_supported` when `allowImplicitFlow` is true (RFC 6749 §4.2.2).

--- a/.changeset/response-modes-fragment.md
+++ b/.changeset/response-modes-fragment.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': patch
 ---
 
-Include `fragment` in `response_modes_supported` when `allowImplicitFlow` is true (RFC 6749 §4.2.2).
+Advertise `fragment` in `response_modes_supported` when `allowImplicitFlow` enables the implicit `token` response type. RFC 8414 §2 requires authorization server metadata to list supported response modes; RFC 6749 §4.2.2 delivers implicit-flow access tokens through the redirect URI fragment.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -351,6 +351,24 @@ describe('OAuthProvider', () => {
       expect(metadata.response_types_supported).toContain('token'); // Implicit flow enabled
       expect(metadata.grant_types_supported).toContain('authorization_code');
       expect(metadata.code_challenge_methods_supported).toContain('S256');
+      // Implicit flow is enabled in the default test provider, so fragment mode should be advertised
+      expect(metadata.response_modes_supported).toContain('query');
+      expect(metadata.response_modes_supported).toContain('fragment');
+    });
+
+    it('should not include fragment response mode when implicit flow is disabled', async () => {
+      const providerNoImplicit = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        allowImplicitFlow: false,
+      });
+      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const response = await providerNoImplicit.fetch(request, mockEnv, mockCtx);
+      const metadata = await response.json<any>();
+      expect(metadata.response_modes_supported).toEqual(['query']);
     });
 
     it('should not include token response type when implicit flow is disabled', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1630,7 +1630,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       registration_endpoint: registrationEndpoint,
       scopes_supported: this.options.scopesSupported,
       response_types_supported: responseTypesSupported,
-      response_modes_supported: ['query'],
+      response_modes_supported: this.options.allowImplicitFlow ? ['query', 'fragment'] : ['query'],
       grant_types_supported: grantTypesSupported,
       // Support "none" auth method for public clients
       token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],


### PR DESCRIPTION
`response_modes_supported` now includes `fragment` when `allowImplicitFlow` is true. Implicit flow uses fragment redirect per RFC 6749 §4.2.2.