### PR TITLE
fix: verify client ownership and honor token_type_hint in revocation (RFC 7009)

### DIFF
--- a/.changeset/revocation-client-check.md
+++ b/.changeset/revocation-client-check.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Verify client ownership on token revocation (RFC 7009 §2.1) and honor `token_type_hint` for lookup ordering. Previously any client could revoke any other client's tokens.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -6274,6 +6274,70 @@ describe('OAuthProvider', () => {
       expect(newTokens.access_token).toBeDefined();
       expect(newTokens.refresh_token).toBeDefined();
     });
+
+    it('should not revoke tokens belonging to a different client (RFC 7009 §2.1)', async () => {
+      // Get tokens via full auth flow for client A
+      const authUrl = new URL('https://example.com/authorize');
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', clientId);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('scope', 'read');
+      const authRequest = createMockRequest(authUrl.toString());
+      const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        `grant_type=authorization_code&code=${encodeURIComponent(code)}&redirect_uri=${encodeURIComponent(redirectUri)}`
+      );
+      const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
+      expect(tokenResponse.status).toBe(200);
+      const tokens = await tokenResponse.json<any>();
+      const accessToken = tokens.access_token;
+
+      // Register a DIFFERENT client (client B)
+      const otherClientRes = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://other.example.com/callback'],
+            client_name: 'Other Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const otherClient = await otherClientRes.json<any>();
+
+      // Client B tries to revoke client A's token — should silently succeed
+      // per RFC 7009 §2.2 (200 OK, but token NOT actually revoked)
+      const revokeRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${otherClient.client_id}:${otherClient.client_secret}`)}`,
+        },
+        `token=${encodeURIComponent(accessToken)}`
+      );
+      const revokeResponse = await oauthProvider.fetch(revokeRequest, mockEnv, mockCtx);
+      expect(revokeResponse.status).toBe(200);
+
+      // Verify client A's token is still valid (was NOT revoked by client B)
+      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: `Bearer ${accessToken}`,
+      });
+      const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
+      expect(apiResponse.status).toBe(200);
+    });
   });
 
   describe('Client ID Metadata Document (CIMD)', () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { OAuthError, OAuthProvider, type OAuthHelpers } from '../src/oauth-provider';
+import { OAuthError, OAuthProvider, type OAuthHelpers, type Token } from '../src/oauth-provider';
 import type { ExecutionContext } from '@cloudflare/workers-types';
 // We're importing WorkerEntrypoint from our mock implementation
 // The actual import is mocked in setup.ts
@@ -8518,7 +8518,6 @@ describe('OAuthProvider', () => {
     beforeEach(async () => {
       redirectUri = 'https://client.example.com/callback';
 
-      // Create a test client
       const clientResponse = await oauthProvider.fetch(
         createMockRequest(
           'https://example.com/oauth/register',
@@ -8542,67 +8541,192 @@ describe('OAuthProvider', () => {
       clientSecret = client.client_secret;
     });
 
-    it('should connect revokeGrant to token endpoint ', async () => {
-      // Step 1: Get tokens through normal OAuth flow
-      const authRequest = createMockRequest(
-        `https://example.com/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read&state=test-state`
-      );
-      const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code');
+    async function issueTokens() {
+      const authUrl = new URL('https://example.com/authorize');
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', clientId);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('scope', 'read');
+      authUrl.searchParams.set('state', 'test-state');
 
-      const tokenRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-        },
-        `grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(redirectUri)}`
+      const authResponse = await oauthProvider.fetch(createMockRequest(authUrl.toString()), mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const tokenResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+          },
+          `grant_type=authorization_code&code=${encodeURIComponent(code)}&redirect_uri=${encodeURIComponent(redirectUri)}`
+        ),
+        mockEnv,
+        mockCtx
       );
 
-      const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
       expect(tokenResponse.status).toBe(200);
-      const tokens = await tokenResponse.json<any>();
+      return tokenResponse.json<any>();
+    }
 
-      // Step 2:this should successfully revoke the token
-      const revokeRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-        },
-        `token=${tokens.access_token}`
+    async function registerOtherClient() {
+      const otherClientRes = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://other.example.com/callback'],
+            client_name: 'Other Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
       );
 
-      const revokeResponse = await oauthProvider.fetch(revokeRequest, mockEnv, mockCtx);
-      // Verify response doesn't contain unsupported_grant_type error
-      const revokeResponseText = await revokeResponse.text();
-      expect(revokeResponseText).not.toContain('unsupported_grant_type');
+      expect(otherClientRes.status).toBe(201);
+      return otherClientRes.json<any>();
+    }
 
-      // Step 3: Verify the access token is actually revoked
-      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
-        Authorization: `Bearer ${tokens.access_token}`,
-      });
-      const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
-      expect(apiResponse.status).toBe(401); // Access token should no longer work
+    async function revokeAs(
+      token: string,
+      client: { client_id: string; client_secret: string },
+      tokenTypeHint?: string
+    ): Promise<Response> {
+      const body = new URLSearchParams({ token });
+      if (tokenTypeHint) {
+        body.set('token_type_hint', tokenTypeHint);
+      }
 
-      // Step 4: Verify refresh token still works
-      const refreshRequest = createMockRequest(
-        'https://example.com/oauth/token',
-        'POST',
-        {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-        },
-        `grant_type=refresh_token&refresh_token=${tokens.refresh_token}`
+      return oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+          },
+          body.toString()
+        ),
+        mockEnv,
+        mockCtx
       );
+    }
 
-      const refreshResponse = await oauthProvider.fetch(refreshRequest, mockEnv, mockCtx);
-      expect(refreshResponse.status).toBe(200); // Refresh token should still work
+    async function callApi(accessToken: string): Promise<Response> {
+      return oauthProvider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: `Bearer ${accessToken}`,
+        }),
+        mockEnv,
+        mockCtx
+      );
+    }
+
+    async function refreshWith(refreshToken: string): Promise<Response> {
+      return oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+          },
+          `grant_type=refresh_token&refresh_token=${encodeURIComponent(refreshToken)}`
+        ),
+        mockEnv,
+        mockCtx
+      );
+    }
+
+    it('should connect revokeGrant to token endpoint', async () => {
+      const tokens = await issueTokens();
+
+      const revokeResponse = await revokeAs(tokens.access_token, { client_id: clientId, client_secret: clientSecret });
+      expect(revokeResponse.status).toBe(200);
+      expect(await revokeResponse.text()).not.toContain('unsupported_grant_type');
+
+      expect((await callApi(tokens.access_token)).status).toBe(401);
+
+      const refreshResponse = await refreshWith(tokens.refresh_token);
+      expect(refreshResponse.status).toBe(200);
       const newTokens = await refreshResponse.json<any>();
       expect(newTokens.access_token).toBeDefined();
       expect(newTokens.refresh_token).toBeDefined();
+    });
+
+    it('should not revoke access tokens belonging to a different client (RFC 7009 §2.1)', async () => {
+      const tokens = await issueTokens();
+      const otherClient = await registerOtherClient();
+
+      const revokeResponse = await revokeAs(tokens.access_token, otherClient);
+      expect(revokeResponse.status).toBe(200);
+
+      expect((await callApi(tokens.access_token)).status).toBe(200);
+    });
+
+    it('should verify legacy access-token ownership from the backing grant', async () => {
+      const tokens = await issueTokens();
+      const [userId, grantId] = tokens.access_token.split(':');
+      const tokenList = await mockEnv.OAUTH_KV.list({ prefix: `token:${userId}:${grantId}:` });
+      expect(tokenList.keys.length).toBe(1);
+
+      const tokenKey = tokenList.keys[0].name;
+      const tokenData = (await mockEnv.OAUTH_KV.get(tokenKey, { type: 'json' })) as Token | null;
+      expect(tokenData).not.toBeNull();
+      delete (tokenData as Partial<Token>).grant;
+      await mockEnv.OAUTH_KV.put(tokenKey, JSON.stringify(tokenData));
+
+      const otherClient = await registerOtherClient();
+      const wrongClientRevokeResponse = await revokeAs(tokens.access_token, otherClient);
+      expect(wrongClientRevokeResponse.status).toBe(200);
+      expect(await mockEnv.OAUTH_KV.get(tokenKey, { type: 'json' })).not.toBeNull();
+
+      const revokeResponse = await revokeAs(tokens.access_token, { client_id: clientId, client_secret: clientSecret });
+      expect(revokeResponse.status).toBe(200);
+
+      expect(await mockEnv.OAUTH_KV.get(tokenKey, { type: 'json' })).toBeNull();
+    });
+
+    it('should revoke a refresh token grant when token_type_hint is refresh_token', async () => {
+      const tokens = await issueTokens();
+
+      const revokeResponse = await revokeAs(
+        tokens.refresh_token,
+        { client_id: clientId, client_secret: clientSecret },
+        'refresh_token'
+      );
+      expect(revokeResponse.status).toBe(200);
+
+      expect((await callApi(tokens.access_token)).status).toBe(401);
+      expect((await refreshWith(tokens.refresh_token)).status).toBe(400);
+    });
+
+    it('should still find a refresh token when token_type_hint is wrong', async () => {
+      const tokens = await issueTokens();
+
+      const revokeResponse = await revokeAs(
+        tokens.refresh_token,
+        { client_id: clientId, client_secret: clientSecret },
+        'access_token'
+      );
+      expect(revokeResponse.status).toBe(200);
+
+      expect((await callApi(tokens.access_token)).status).toBe(401);
+      expect((await refreshWith(tokens.refresh_token)).status).toBe(400);
+    });
+
+    it('should not revoke refresh tokens belonging to a different client (RFC 7009 §2.1)', async () => {
+      const tokens = await issueTokens();
+      const otherClient = await registerOtherClient();
+
+      const revokeResponse = await revokeAs(tokens.refresh_token, otherClient, 'refresh_token');
+      expect(revokeResponse.status).toBe(200);
+
+      expect((await callApi(tokens.access_token)).status).toBe(200);
+      expect((await refreshWith(tokens.refresh_token)).status).toBe(200);
     });
   });
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1232,7 +1232,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
       let response: Response;
       if (parsed.isRevocationRequest) {
-        response = await this.handleRevocationRequest(parsed.body, env);
+        response = await this.handleRevocationRequest(parsed.body, parsed.clientInfo, env);
       } else {
         response = await this.handleTokenRequest(parsed.body, parsed.clientInfo, env);
       }
@@ -2547,20 +2547,23 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Response confirming revocation or error
    */
-  private async handleRevocationRequest(body: any, env: any): Promise<Response> {
-    // Handle the revocation request
-    return this.revokeToken(body, env);
+  private async handleRevocationRequest(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+    // Handle the revocation request with client ownership verification
+    return this.revokeToken(body, clientInfo, env);
   }
 
   /**
    * - Access tokens: Revokes only the specific token
    * - Refresh tokens: Revokes the entire grant (access + refresh tokens)
+   * Per RFC 7009 §2.1, the server MUST verify the token was issued to the client making the request.
    * @param body - The parsed request body containing token parameter
+   * @param clientInfo - The authenticated client information
    * @param env - Cloudflare Worker environment variables
    * @returns Response confirming revocation or error
    */
-  private async revokeToken(body: any, env: any): Promise<Response> {
+  private async revokeToken(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
     const token = body.token;
+    const tokenTypeHint = body.token_type_hint;
 
     if (!token) {
       return this.createErrorResponse('invalid_request', 'Token parameter is required');
@@ -2573,15 +2576,57 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const [userId, grantId, _] = tokenParts;
     const tokenId = await generateTokenId(token);
 
-    const isAccessToken = await this.validateAccessToken(tokenId, userId, grantId, env);
-    const isRefreshToken = await this.validateRefreshToken(tokenId, userId, grantId, env);
-
-    if (isAccessToken) {
-      await this.revokeSpecificAccessToken(tokenId, userId, grantId, env);
-    } else if (isRefreshToken) {
-      await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
+    // Use token_type_hint to check the hinted type first (RFC 7009 §2.1).
+    // Both paths verify client ownership before revoking (RFC 7009 §2.1).
+    if (tokenTypeHint === 'refresh_token') {
+      if (await this.revokeRefreshIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
+      if (await this.revokeAccessIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
+    } else {
+      // Default: access token first (matches hint=access_token or no hint)
+      if (await this.revokeAccessIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
+      if (await this.revokeRefreshIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
     }
     return new Response('', { status: 200 });
+  }
+
+  /** Revoke an access token if it exists and belongs to the requesting client. */
+  private async revokeAccessIfOwned(
+    tokenId: string,
+    userId: string,
+    grantId: string,
+    clientInfo: ClientInfo,
+    env: any
+  ): Promise<boolean> {
+    const tokenData: Token | null = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${tokenId}`, { type: 'json' });
+    if (!tokenData) return false;
+    if (tokenData.grant.clientId !== clientInfo.clientId) return false;
+    await this.revokeSpecificAccessToken(tokenId, userId, grantId, env);
+    return true;
+  }
+
+  /** Revoke a refresh token (and its grant) if it exists and belongs to the requesting client. */
+  private async revokeRefreshIfOwned(
+    tokenId: string,
+    userId: string,
+    grantId: string,
+    clientInfo: ClientInfo,
+    env: any
+  ): Promise<boolean> {
+    const grantData: Grant | null = await env.OAUTH_KV.get(`grant:${userId}:${grantId}`, { type: 'json' });
+    if (!grantData) return false;
+    const isRefreshToken = grantData.refreshTokenId === tokenId || grantData.previousRefreshTokenId === tokenId;
+    if (!isRefreshToken) return false;
+    if (grantData.clientId !== clientInfo.clientId) return false;
+    await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
+    return true;
   }
 
   /**

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1541,7 +1541,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
       let response: Response;
       if (parsed.isRevocationRequest) {
-        response = await this.handleRevocationRequest(parsed.body, env);
+        response = await this.handleRevocationRequest(parsed.body, parsed.clientInfo, env);
       } else {
         response = await this.handleTokenRequest(parsed.body, parsed.clientInfo, env, url, request);
       }
@@ -3240,20 +3240,23 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Response confirming revocation or error
    */
-  private async handleRevocationRequest(body: any, env: any): Promise<Response> {
-    // Handle the revocation request
-    return this.revokeToken(body, env);
+  private async handleRevocationRequest(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+    // Handle the revocation request with client ownership verification
+    return this.revokeToken(body, clientInfo, env);
   }
 
   /**
    * - Access tokens: Revokes only the specific token
    * - Refresh tokens: Revokes the entire grant (access + refresh tokens)
+   * Per RFC 7009 §2.1, the server MUST verify the token was issued to the client making the request.
    * @param body - The parsed request body containing token parameter
+   * @param clientInfo - The authenticated client information
    * @param env - Cloudflare Worker environment variables
    * @returns Response confirming revocation or error
    */
-  private async revokeToken(body: any, env: any): Promise<Response> {
+  private async revokeToken(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
     const token = body.token;
+    const tokenTypeHint = body.token_type_hint;
 
     if (!token) {
       return this.createErrorResponse('invalid_request', { description: 'Token parameter is required' });
@@ -3266,15 +3269,67 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const [userId, grantId, _] = tokenParts;
     const tokenId = await generateTokenId(token);
 
-    const isAccessToken = await this.validateAccessToken(tokenId, userId, grantId, env);
-    const isRefreshToken = await this.validateRefreshToken(tokenId, userId, grantId, env);
-
-    if (isAccessToken) {
-      await this.revokeSpecificAccessToken(tokenId, userId, grantId, env);
-    } else if (isRefreshToken) {
-      await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
+    // Use token_type_hint to check the hinted type first (RFC 7009 §2.1).
+    // Both paths verify client ownership before revoking (RFC 7009 §2.1).
+    if (tokenTypeHint === 'refresh_token') {
+      if (await this.revokeRefreshIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
+      if (await this.revokeAccessIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
+    } else {
+      // Default and unknown hints: access token first (matches hint=access_token or no hint).
+      if (await this.revokeAccessIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
+      if (await this.revokeRefreshIfOwned(tokenId, userId, grantId, clientInfo, env)) {
+        return new Response('', { status: 200 });
+      }
     }
     return new Response('', { status: 200 });
+  }
+
+  /** Revoke an access token if it exists and belongs to the requesting client. */
+  private async revokeAccessIfOwned(
+    tokenId: string,
+    userId: string,
+    grantId: string,
+    clientInfo: ClientInfo,
+    env: any
+  ): Promise<boolean> {
+    const tokenData: Token | null = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${tokenId}`, { type: 'json' });
+    if (!tokenData) return false;
+
+    const tokenClientId = tokenData.grant?.clientId;
+    if (tokenClientId !== undefined) {
+      if (tokenClientId !== clientInfo.clientId) return false;
+    } else {
+      // Backward compatibility for token records written before access tokens
+      // denormalized grant.clientId. Verify ownership from the backing grant.
+      const grantData: Grant | null = await env.OAUTH_KV.get(`grant:${userId}:${grantId}`, { type: 'json' });
+      if (grantData?.clientId !== clientInfo.clientId) return false;
+    }
+
+    await this.revokeSpecificAccessToken(tokenId, userId, grantId, env);
+    return true;
+  }
+
+  /** Revoke a refresh token (and its grant) if it exists and belongs to the requesting client. */
+  private async revokeRefreshIfOwned(
+    tokenId: string,
+    userId: string,
+    grantId: string,
+    clientInfo: ClientInfo,
+    env: any
+  ): Promise<boolean> {
+    const grantData: Grant | null = await env.OAUTH_KV.get(`grant:${userId}:${grantId}`, { type: 'json' });
+    if (!grantData) return false;
+    const isRefreshToken = grantData.refreshTokenId === tokenId || grantData.previousRefreshTokenId === tokenId;
+    if (!isRefreshToken) return false;
+    if (grantData.clientId !== clientInfo.clientId) return false;
+    await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
+    return true;
   }
 
   /**
@@ -3287,47 +3342,6 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private async revokeSpecificAccessToken(tokenId: string, userId: string, grantId: string, env: any): Promise<void> {
     const tokenKey = `token:${userId}:${grantId}:${tokenId}`;
     await env.OAUTH_KV.delete(tokenKey);
-  }
-
-  /**
-   * Validates if a token is a valid access token
-   * @param tokenId - The hashed token ID
-   * @param userId - The user ID extracted from the token
-   * @param grantId - The grant ID extracted from the token
-   * @param env - Cloudflare Worker environment variables
-   * @returns Promise<boolean> indicating if the token is valid
-   */
-  private async validateAccessToken(tokenId: string, userId: string, grantId: string, env: any): Promise<boolean> {
-    const tokenKey = `token:${userId}:${grantId}:${tokenId}`;
-    const tokenData = await env.OAUTH_KV.get(tokenKey, { type: 'json' });
-
-    if (!tokenData) {
-      return false;
-    }
-
-    // Check if token is expired
-    const now = Math.floor(Date.now() / 1000);
-    return tokenData.expiresAt >= now;
-  }
-
-  /**
-   * Validates if a token is a valid refresh token
-   * @param tokenId - The hashed token ID
-   * @param userId - The user ID extracted from the token
-   * @param grantId - The grant ID extracted from the token
-   * @param env - Cloudflare Worker environment variables
-   * @returns Promise<boolean> indicating if the token is valid
-   */
-  private async validateRefreshToken(tokenId: string, userId: string, grantId: string, env: any): Promise<boolean> {
-    const grantKey = `grant:${userId}:${grantId}`;
-    const grantData = await env.OAUTH_KV.get(grantKey, { type: 'json' });
-
-    if (!grantData) {
-      return false;
-    }
-
-    // Check if this matches the current or previous refresh token
-    return grantData.refreshTokenId === tokenId || grantData.previousRefreshTokenId === tokenId;
   }
 
   /**


### PR DESCRIPTION
Two related revocation fixes in one PR since they both rewrite `revokeToken`:

**Client ownership (RFC 7009 §2.1):** Verifies the token belongs to the requesting client before revoking. Previously any authenticated client could revoke any other client's tokens.

**token_type_hint (RFC 7009 §2.1):** Checks the hinted type first, falls back to the other. Incorrect hints are handled gracefully.

- Access tokens: ownership checked from denormalized `grant.clientId`; legacy-style records without that denormalized field fall back to the backing grant before deletion
- Refresh tokens: single grant read validates both token identity and ownership
- Mismatches silently return 200 per RFC 7009 §2.2, but do not revoke
- Tests cover access-token ownership, refresh-token ownership, legacy access-token ownership fallback, refresh-token revocation, and incorrect-hint fallback
- Removes the now-unused private token validation helpers

## Verification

- `npm run check` ✅ — 501 tests passing
- `npm run build` ✅
- `npx prettier --check src/oauth-provider.ts __tests__/oauth-provider.test.ts .changeset/revocation-client-check.md` ✅
- `git diff --check origin/main...HEAD` ✅

## Note

Do not merge without Matt's explicit approval.
