### PR TITLE
feat: add token introspection endpoint (RFC 7662)

### DIFF
--- a/.changeset/token-introspection.md
+++ b/.changeset/token-introspection.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Add token introspection endpoint (RFC 7662). Enable with `introspectionEndpoint`. Confidential clients only; returns `active: false` for tokens not owned by the requesting client.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -6276,6 +6276,212 @@ describe('OAuthProvider', () => {
     });
   });
 
+  describe('Token Introspection (RFC 7662)', () => {
+    let introProvider: InstanceType<typeof OAuthProvider<TestEnv>>;
+    let introEnv: any;
+    let clientId: string;
+    let clientSecret: string;
+    const redirectUri = 'https://client.example.com/callback';
+
+    beforeEach(async () => {
+      introEnv = createMockEnv();
+      introProvider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        introspectionEndpoint: '/oauth/introspect',
+        scopesSupported: ['read', 'write'],
+      });
+
+      // Register a confidential client
+      const regRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: [redirectUri],
+          client_name: 'Introspection Test Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const regResponse = await introProvider.fetch(regRequest, introEnv, new MockExecutionContext());
+      const client = await regResponse.json<any>();
+      clientId = client.client_id;
+      clientSecret = client.client_secret;
+    });
+
+    afterEach(() => {
+      introEnv.OAUTH_KV.clear();
+    });
+
+    async function getAccessToken(): Promise<string> {
+      // Authorize
+      const authUrl = new URL('https://example.com/authorize');
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', clientId);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('scope', 'read write');
+      const authResponse = await introProvider.fetch(
+        createMockRequest(authUrl.toString()),
+        introEnv,
+        new MockExecutionContext()
+      );
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      // Exchange
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        `grant_type=authorization_code&code=${encodeURIComponent(code)}&redirect_uri=${encodeURIComponent(redirectUri)}`
+      );
+      const tokenResponse = await introProvider.fetch(tokenRequest, introEnv, new MockExecutionContext());
+      const tokens = await tokenResponse.json<any>();
+      return tokens.access_token;
+    }
+
+    it('should return active:true for a valid token', async () => {
+      const accessToken = await getAccessToken();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        `token=${encodeURIComponent(accessToken)}`
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+
+      const body = await response.json<any>();
+      expect(body.active).toBe(true);
+      expect(body.iss).toBe('https://example.com');
+      expect(body.client_id).toBe(clientId);
+      expect(body.token_type).toBe('bearer');
+      expect(body.sub).toBeDefined();
+      expect(body.exp).toBeDefined();
+      expect(body.iat).toBeDefined();
+      expect(body.scope).toBe('read write');
+    });
+
+    it('should return active:false for an invalid token', async () => {
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        'token=invalid:token:value'
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+
+      const body = await response.json<any>();
+      expect(body.active).toBe(false);
+    });
+
+    it('should reject public clients', async () => {
+      // Register a public client
+      const pubRegReq = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://spa.example.com/callback'],
+          client_name: 'Public Client',
+          token_endpoint_auth_method: 'none',
+        })
+      );
+      const pubRegRes = await introProvider.fetch(pubRegReq, introEnv, new MockExecutionContext());
+      const pubClient = await pubRegRes.json<any>();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        `token=some:token:value&client_id=${pubClient.client_id}`
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(401);
+    });
+
+    it('should require the token parameter', async () => {
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        'not_a_token=foo'
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('invalid_request');
+    });
+
+    it('should return active:false when a different client introspects the token', async () => {
+      const accessToken = await getAccessToken();
+
+      // Register a different confidential client
+      const otherRegReq = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://other.example.com/callback'],
+          client_name: 'Other Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const otherRegRes = await introProvider.fetch(otherRegReq, introEnv, new MockExecutionContext());
+      const otherClient = await otherRegRes.json<any>();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${otherClient.client_id}:${otherClient.client_secret}`)}`,
+        },
+        `token=${encodeURIComponent(accessToken)}`
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+      const body = await response.json<any>();
+      // RFC 7662 §2.1: tokens not issued to the requesting client report as inactive
+      expect(body.active).toBe(false);
+    });
+
+    it('should advertise introspection_endpoint in metadata', async () => {
+      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      const metadata = await response.json<any>();
+
+      expect(metadata.introspection_endpoint).toBe('https://example.com/oauth/introspect');
+      expect(metadata.introspection_endpoint_auth_methods_supported).toEqual([
+        'client_secret_basic',
+        'client_secret_post',
+      ]);
+    });
+  });
+
   describe('Client ID Metadata Document (CIMD)', () => {
     let originalFetch: typeof globalThis.fetch;
     let originalCloudflare: Cloudflare | undefined;

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -8730,6 +8730,212 @@ describe('OAuthProvider', () => {
     });
   });
 
+  describe('Token Introspection (RFC 7662)', () => {
+    let introProvider: InstanceType<typeof OAuthProvider<TestEnv>>;
+    let introEnv: any;
+    let clientId: string;
+    let clientSecret: string;
+    const redirectUri = 'https://client.example.com/callback';
+
+    beforeEach(async () => {
+      introEnv = createMockEnv();
+      introProvider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        introspectionEndpoint: '/oauth/introspect',
+        scopesSupported: ['read', 'write'],
+      });
+
+      // Register a confidential client
+      const regRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: [redirectUri],
+          client_name: 'Introspection Test Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const regResponse = await introProvider.fetch(regRequest, introEnv, new MockExecutionContext());
+      const client = await regResponse.json<any>();
+      clientId = client.client_id;
+      clientSecret = client.client_secret;
+    });
+
+    afterEach(() => {
+      introEnv.OAUTH_KV.clear();
+    });
+
+    async function getAccessToken(): Promise<string> {
+      // Authorize
+      const authUrl = new URL('https://example.com/authorize');
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', clientId);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('scope', 'read write');
+      const authResponse = await introProvider.fetch(
+        createMockRequest(authUrl.toString()),
+        introEnv,
+        new MockExecutionContext()
+      );
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      // Exchange
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        `grant_type=authorization_code&code=${encodeURIComponent(code)}&redirect_uri=${encodeURIComponent(redirectUri)}`
+      );
+      const tokenResponse = await introProvider.fetch(tokenRequest, introEnv, new MockExecutionContext());
+      const tokens = await tokenResponse.json<any>();
+      return tokens.access_token;
+    }
+
+    it('should return active:true for a valid token', async () => {
+      const accessToken = await getAccessToken();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        `token=${encodeURIComponent(accessToken)}`
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+
+      const body = await response.json<any>();
+      expect(body.active).toBe(true);
+      expect(body.iss).toBe('https://example.com');
+      expect(body.client_id).toBe(clientId);
+      expect(body.token_type).toBe('bearer');
+      expect(body.sub).toBeDefined();
+      expect(body.exp).toBeDefined();
+      expect(body.iat).toBeDefined();
+      expect(body.scope).toBe('read write');
+    });
+
+    it('should return active:false for an invalid token', async () => {
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        'token=invalid:token:value'
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+
+      const body = await response.json<any>();
+      expect(body.active).toBe(false);
+    });
+
+    it('should reject public clients', async () => {
+      // Register a public client
+      const pubRegReq = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://spa.example.com/callback'],
+          client_name: 'Public Client',
+          token_endpoint_auth_method: 'none',
+        })
+      );
+      const pubRegRes = await introProvider.fetch(pubRegReq, introEnv, new MockExecutionContext());
+      const pubClient = await pubRegRes.json<any>();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        `token=some:token:value&client_id=${pubClient.client_id}`
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(401);
+    });
+
+    it('should require the token parameter', async () => {
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        'not_a_token=foo'
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(400);
+      const body = await response.json<any>();
+      expect(body.error).toBe('invalid_request');
+    });
+
+    it('should return active:false when a different client introspects the token', async () => {
+      const accessToken = await getAccessToken();
+
+      // Register a different confidential client
+      const otherRegReq = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://other.example.com/callback'],
+          client_name: 'Other Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+      const otherRegRes = await introProvider.fetch(otherRegReq, introEnv, new MockExecutionContext());
+      const otherClient = await otherRegRes.json<any>();
+
+      const request = createMockRequest(
+        'https://example.com/oauth/introspect',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${otherClient.client_id}:${otherClient.client_secret}`)}`,
+        },
+        `token=${encodeURIComponent(accessToken)}`
+      );
+
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      expect(response.status).toBe(200);
+      const body = await response.json<any>();
+      // RFC 7662 §2.1: tokens not issued to the requesting client report as inactive
+      expect(body.active).toBe(false);
+    });
+
+    it('should advertise introspection_endpoint in metadata', async () => {
+      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const response = await introProvider.fetch(request, introEnv, new MockExecutionContext());
+      const metadata = await response.json<any>();
+
+      expect(metadata.introspection_endpoint).toBe('https://example.com/oauth/introspect');
+      expect(metadata.introspection_endpoint_auth_methods_supported).toEqual([
+        'client_secret_basic',
+        'client_secret_post',
+      ]);
+    });
+  });
+
   describe('Client ID Metadata Document (CIMD)', () => {
     let originalFetch: typeof globalThis.fetch;
     let originalCloudflare: Cloudflare | undefined;

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -240,6 +240,14 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   clientRegistrationEndpoint?: string;
 
   /**
+   * Optional URL for the token introspection endpoint (RFC 7662).
+   * If provided, the provider will implement token introspection, allowing
+   * resource servers to query the authorization server about the state of
+   * an access token. Only confidential clients can introspect tokens.
+   */
+  introspectionEndpoint?: string;
+
+  /**
    * Time-to-live for access tokens in seconds.
    * Defaults to 1 hour (3600 seconds) if not specified.
    */
@@ -1193,7 +1201,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         url.pathname === '/.well-known/oauth-authorization-server' ||
         this.isProtectedResourceMetadataRequest(url) ||
         this.isTokenEndpoint(url) ||
-        (this.options.clientRegistrationEndpoint && this.isClientRegistrationEndpoint(url))
+        (this.options.clientRegistrationEndpoint && this.isClientRegistrationEndpoint(url)) ||
+        (this.options.introspectionEndpoint && this.matchEndpoint(url, this.options.introspectionEndpoint))
       ) {
         // Create an empty 204 No Content response with CORS headers
         return this.addCorsHeaders(
@@ -1243,6 +1252,19 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Handle client registration endpoint
     if (this.options.clientRegistrationEndpoint && this.isClientRegistrationEndpoint(url)) {
       const response = await this.handleClientRegistration(request, env);
+      return this.addCorsHeaders(response, request);
+    }
+
+    // Handle token introspection endpoint (RFC 7662)
+    // Note: This MUST be checked before the token endpoint because introspection requests
+    // (body has `token` and no `grant_type`) match the revocation detection heuristic in
+    // parseTokenEndpointRequest. Routing by URL first avoids ambiguity.
+    if (this.options.introspectionEndpoint && this.matchEndpoint(url, this.options.introspectionEndpoint)) {
+      const parsed = await this.parseTokenEndpointRequest(request, env);
+      if (parsed instanceof Response) {
+        return this.addCorsHeaders(parsed, request);
+      }
+      const response = await this.handleIntrospection(parsed.body, parsed.clientInfo, env, url);
       return this.addCorsHeaders(response, request);
     }
 
@@ -1608,6 +1630,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       registrationEndpoint = this.getFullEndpointUrl(this.options.clientRegistrationEndpoint, requestUrl);
     }
 
+    let introspectionEndpoint: string | undefined = undefined;
+    if (this.options.introspectionEndpoint) {
+      introspectionEndpoint = this.getFullEndpointUrl(this.options.introspectionEndpoint, requestUrl);
+    }
+
     // Determine supported response types
     const responseTypesSupported = ['code'];
 
@@ -1642,9 +1669,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       revocation_endpoint: tokenEndpoint, // Reusing token endpoint for revocation
       // not implemented: revocation_endpoint_auth_methods_supported
       // not implemented: revocation_endpoint_auth_signing_alg_values_supported
-      // not implemented: introspection_endpoint
-      // not implemented: introspection_endpoint_auth_methods_supported
-      // not implemented: introspection_endpoint_auth_signing_alg_values_supported
+      introspection_endpoint: introspectionEndpoint,
+      introspection_endpoint_auth_methods_supported: introspectionEndpoint
+        ? ['client_secret_basic', 'client_secret_post']
+        : undefined,
       code_challenge_methods_supported: this.options.allowPlainPKCE !== false ? ['plain', 'S256'] : ['S256'], // PKCE support
       // MCP Client ID Metadata Document support (CIMD)
       // Only enabled when global_fetch_strictly_public compat flag is set (for SSRF protection)
@@ -2770,6 +2798,67 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     return new Response(JSON.stringify(response), {
       status: 201,
       headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  /** Token introspection (RFC 7662). Confidential clients only. */
+  private async handleIntrospection(body: any, clientInfo: ClientInfo, env: any, requestUrl: URL): Promise<Response> {
+    // RFC 7662 §2.1: Only confidential clients can introspect tokens
+    if (clientInfo.tokenEndpointAuthMethod === 'none') {
+      return this.createErrorResponse('unauthorized_client', 'Token introspection requires a confidential client', 401);
+    }
+
+    const token = body.token;
+    if (!token) {
+      return this.createErrorResponse('invalid_request', 'token parameter is required');
+    }
+
+    // Try to unwrap the token to get its details
+    const tokenSummary = await this.unwrapToken(token, env);
+
+    if (!tokenSummary) {
+      // RFC 7662 §2.2: inactive response for invalid/expired/unknown tokens
+      return new Response(JSON.stringify({ active: false }), {
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+      });
+    }
+
+    // RFC 7662 §2.1: tokens not issued to the requesting client report as inactive
+    if (tokenSummary.grant.clientId !== clientInfo.clientId) {
+      return new Response(JSON.stringify({ active: false }), {
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+      });
+    }
+
+    // Derive issuer from configured tokenEndpoint, not request URL (Host header is spoofable)
+    const issuer = this.isPath(this.options.tokenEndpoint)
+      ? requestUrl.origin
+      : new URL(this.options.tokenEndpoint).origin;
+
+    // Build the RFC 7662 §2.2 introspection response
+    const introspectionResponse: Record<string, unknown> = {
+      active: true,
+      iss: issuer,
+      client_id: tokenSummary.grant.clientId,
+      token_type: 'bearer',
+      exp: tokenSummary.expiresAt,
+      iat: tokenSummary.createdAt,
+      sub: tokenSummary.userId,
+    };
+
+    // Include scope if present
+    const scope = tokenSummary.scope;
+    if (scope && scope.length > 0) {
+      introspectionResponse.scope = scope.join(' ');
+    }
+
+    // Include audience if present (RFC 8707)
+    if (tokenSummary.audience) {
+      introspectionResponse.aud = tokenSummary.audience;
+    }
+
+    return new Response(JSON.stringify(introspectionResponse), {
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
     });
   }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -353,6 +353,14 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   clientRegistrationEndpoint?: string;
 
   /**
+   * Optional URL for the token introspection endpoint (RFC 7662).
+   * If provided, the provider will implement token introspection, allowing
+   * resource servers to query the authorization server about the state of
+   * an access token. Only confidential clients can introspect tokens.
+   */
+  introspectionEndpoint?: string;
+
+  /**
    * Time-to-live for access tokens in seconds.
    * Defaults to 1 hour (3600 seconds) if not specified.
    */
@@ -1502,7 +1510,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         url.pathname === '/.well-known/oauth-authorization-server' ||
         this.isProtectedResourceMetadataRequest(url) ||
         this.isTokenEndpoint(url) ||
-        (this.options.clientRegistrationEndpoint && this.isClientRegistrationEndpoint(url))
+        (this.options.clientRegistrationEndpoint && this.isClientRegistrationEndpoint(url)) ||
+        (this.options.introspectionEndpoint && this.matchEndpoint(url, this.options.introspectionEndpoint))
       ) {
         // Create an empty 204 No Content response with CORS headers
         return this.addCorsHeaders(
@@ -1552,6 +1561,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Handle client registration endpoint
     if (this.options.clientRegistrationEndpoint && this.isClientRegistrationEndpoint(url)) {
       const response = await this.handleClientRegistration(request, env);
+      return this.addCorsHeaders(response, request);
+    }
+
+    // Handle token introspection endpoint (RFC 7662)
+    if (this.options.introspectionEndpoint && this.matchEndpoint(url, this.options.introspectionEndpoint)) {
+      const parsed = await this.parseTokenEndpointRequest(request, env);
+      if (parsed instanceof Response) {
+        return this.addCorsHeaders(parsed, request);
+      }
+      const response = await this.handleIntrospection(parsed.body, parsed.clientInfo, env, url);
       return this.addCorsHeaders(response, request);
     }
 
@@ -1962,6 +1981,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       registrationEndpoint = this.getFullEndpointUrl(this.options.clientRegistrationEndpoint, requestUrl);
     }
 
+    let introspectionEndpoint: string | undefined = undefined;
+    if (this.options.introspectionEndpoint) {
+      introspectionEndpoint = this.getFullEndpointUrl(this.options.introspectionEndpoint, requestUrl);
+    }
+
     // Determine supported response types
     const responseTypesSupported = ['code'];
 
@@ -2005,9 +2029,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       revocation_endpoint: tokenEndpoint, // Reusing token endpoint for revocation
       // not implemented: revocation_endpoint_auth_methods_supported
       // not implemented: revocation_endpoint_auth_signing_alg_values_supported
-      // not implemented: introspection_endpoint
-      // not implemented: introspection_endpoint_auth_methods_supported
-      // not implemented: introspection_endpoint_auth_signing_alg_values_supported
+      introspection_endpoint: introspectionEndpoint,
+      introspection_endpoint_auth_methods_supported: introspectionEndpoint
+        ? ['client_secret_basic', 'client_secret_post']
+        : undefined,
       code_challenge_methods_supported: this.options.allowPlainPKCE !== false ? ['plain', 'S256'] : ['S256'], // PKCE support
       // MCP Client ID Metadata Document support (CIMD)
       // Only enabled when global_fetch_strictly_public compat flag is set (for SSRF protection)
@@ -3537,6 +3562,70 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     return new Response(JSON.stringify(response), {
       status: 201,
+      headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
+    });
+  }
+
+  /** Token introspection (RFC 7662). Confidential clients only. */
+  private async handleIntrospection(body: any, clientInfo: ClientInfo, env: any, requestUrl: URL): Promise<Response> {
+    // RFC 7662 §2.1: Only confidential clients can introspect tokens
+    if (clientInfo.tokenEndpointAuthMethod === 'none') {
+      return this.createErrorResponse('unauthorized_client', {
+        description: 'Token introspection requires a confidential client',
+        statusCode: 401,
+      });
+    }
+
+    const token = body.token;
+    if (!token) {
+      return this.createErrorResponse('invalid_request', { description: 'token parameter is required' });
+    }
+
+    // Try to unwrap the token to get its details
+    const tokenSummary = await this.unwrapToken(token, env);
+
+    if (!tokenSummary) {
+      // RFC 7662 §2.2: inactive response for invalid/expired/unknown tokens
+      return new Response(JSON.stringify({ active: false }), {
+        headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
+      });
+    }
+
+    // RFC 7662 §2.1: tokens not issued to the requesting client report as inactive
+    if (tokenSummary.grant.clientId !== clientInfo.clientId) {
+      return new Response(JSON.stringify({ active: false }), {
+        headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
+      });
+    }
+
+    // Derive issuer from configured tokenEndpoint, not request URL (Host header is spoofable)
+    const issuer = this.isPath(this.options.tokenEndpoint)
+      ? requestUrl.origin
+      : new URL(this.options.tokenEndpoint).origin;
+
+    // Build the RFC 7662 §2.2 introspection response
+    const introspectionResponse: Record<string, unknown> = {
+      active: true,
+      iss: issuer,
+      client_id: tokenSummary.grant.clientId,
+      token_type: 'bearer',
+      exp: tokenSummary.expiresAt,
+      iat: tokenSummary.createdAt,
+      sub: tokenSummary.userId,
+    };
+
+    // Include scope if present
+    const scope = tokenSummary.scope;
+    if (scope && scope.length > 0) {
+      introspectionResponse.scope = scope.join(' ');
+    }
+
+    // Include audience if present (RFC 8707)
+    if (tokenSummary.audience) {
+      introspectionResponse.aud = tokenSummary.audience;
+    }
+
+    return new Response(JSON.stringify(introspectionResponse), {
       headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });
   }


### PR DESCRIPTION
Adds a token introspection endpoint (RFC 7662), enabled with `introspectionEndpoint`.

## Summary

- Adds `introspectionEndpoint?: string` provider option
- Handles POSTed form-encoded introspection requests using existing token-endpoint client authentication parsing
- Requires a confidential client; public clients get `401 unauthorized_client`
- Returns `{ active: false }` for invalid, expired, unknown, or non-owned tokens
- Returns RFC 7662-style active token metadata for owned access tokens:
  - `active`
  - `iss`
  - `client_id`
  - `token_type`
  - `exp`
  - `iat`
  - `sub`
  - `scope`
  - `aud` when present
- Advertises `introspection_endpoint` and `introspection_endpoint_auth_methods_supported` in authorization-server metadata when configured
- Uses the repo's sensitive response cache headers (`Cache-Control: no-store`, `Pragma: no-cache`) for introspection responses

## Verification

- `npm run check` ✅ — 507 tests passing
- `npm run build` ✅
- `npx prettier --check src/oauth-provider.ts __tests__/oauth-provider.test.ts .changeset/token-introspection.md` ✅
- `git diff --check origin/main...HEAD` ✅

## Note

Do not merge without Matt's explicit approval.
