### PR TITLE
feat: Expose grantId in TokenExchangeCallbackOptions

### DIFF
--- a/.changeset/expose-grant-id-in-token-exchange-callback.md
+++ b/.changeset/expose-grant-id-in-token-exchange-callback.md
@@ -1,0 +1,17 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Expose `grantId` to `tokenExchangeCallback` via `TokenExchangeCallbackOptions`.
+
+Implementations of `tokenExchangeCallback` already received `userId` and
+`clientId`, but had no way to identify which specific grant the library was
+operating on. This made it impossible to surgically revoke a single grant from
+the callback (e.g. on a terminal upstream refresh failure) — implementations had
+to either sweep all grants for a `(userId, clientId)` pair (racy under
+concurrent refreshes) or maintain their own out-of-band mapping.
+
+`grantId` is now provided alongside `userId` so callbacks can pass them
+directly to `OAuthHelpers.revokeGrant`. Populated for all three grant types
+(`authorization_code`, `refresh_token`, `token_exchange`). Stable across
+refreshes for the lifetime of the grant.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -4663,6 +4663,8 @@ describe('OAuthProvider', () => {
       const callbackArgs = callbackInvocations[0];
       expect(callbackArgs.grantType).toBe('authorization_code');
       expect(callbackArgs.clientId).toBe(clientId);
+      expect(callbackArgs.grantId).toEqual(expect.any(String));
+      expect(callbackArgs.grantId.length).toBeGreaterThan(0);
       expect(callbackArgs.props).toEqual({ userId: 'test-user-123', username: 'TestUser' });
 
       // Use the token to access API
@@ -4744,6 +4746,8 @@ describe('OAuthProvider', () => {
       const callbackArgs = callbackInvocations[0];
       expect(callbackArgs.grantType).toBe('refresh_token');
       expect(callbackArgs.clientId).toBe(clientId);
+      expect(callbackArgs.grantId).toEqual(expect.any(String));
+      expect(callbackArgs.grantId.length).toBeGreaterThan(0);
 
       // The props are from the updated grant during auth code flow
       expect(callbackArgs.props).toEqual({
@@ -4793,6 +4797,64 @@ describe('OAuthProvider', () => {
       // Check that the refresh count was incremented in the grant props
       expect(callbackInvocations.length).toBe(1);
       expect(callbackInvocations[0].props.refreshCount).toBe(1);
+    });
+
+    it('should expose the same grantId to the callback across the auth-code exchange and subsequent refreshes', async () => {
+      // Drive a fresh auth-code -> token exchange and capture grantId.
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=stable-grant-id`
+      );
+      const authResponse = await oauthProviderWithCallback.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const codeParams = new URLSearchParams();
+      codeParams.append('grant_type', 'authorization_code');
+      codeParams.append('code', code);
+      codeParams.append('redirect_uri', redirectUri);
+      codeParams.append('client_id', clientId);
+      codeParams.append('client_secret', clientSecret);
+
+      callbackInvocations = [];
+      const tokenResponse = await oauthProviderWithCallback.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          codeParams.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(tokenResponse.status).toBe(200);
+      const tokens = await tokenResponse.json<any>();
+      expect(callbackInvocations.length).toBe(1);
+      const grantIdFromAuthCode = callbackInvocations[0].grantId;
+      expect(grantIdFromAuthCode).toEqual(expect.any(String));
+      expect(grantIdFromAuthCode.length).toBeGreaterThan(0);
+
+      // Refresh once and assert the grantId is the same value.
+      const refreshParams = new URLSearchParams();
+      refreshParams.append('grant_type', 'refresh_token');
+      refreshParams.append('refresh_token', tokens.refresh_token);
+      refreshParams.append('client_id', clientId);
+      refreshParams.append('client_secret', clientSecret);
+
+      callbackInvocations = [];
+      const refreshResponse = await oauthProviderWithCallback.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          refreshParams.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(refreshResponse.status).toBe(200);
+      expect(callbackInvocations.length).toBe(1);
+      expect(callbackInvocations[0].grantId).toBe(grantIdFromAuthCode);
     });
 
     it('should update token props during refresh when explicitly provided', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -145,6 +145,15 @@ export interface TokenExchangeCallbackOptions {
   userId: string;
 
   /**
+   * Identifier of the grant record this callback is operating on. Stable across
+   * refreshes for the lifetime of the grant. Pass this together with `userId`
+   * to {@link OAuthHelpers.revokeGrant} when the callback decides the grant
+   * should be torn down (for example, after an upstream refresh fails with a
+   * terminal error code).
+   */
+  grantId: string;
+
+  /**
    * List of scopes that were granted
    */
   scope: string[];
@@ -2001,6 +2010,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         grantType: GrantType.AUTHORIZATION_CODE,
         clientId: clientInfo.clientId,
         userId: userId,
+        grantId: grantId,
         scope: grantData.scope,
         requestedScope: tokenScopes,
         props: decryptedProps,
@@ -2257,6 +2267,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         grantType: GrantType.REFRESH_TOKEN,
         clientId: clientInfo.clientId,
         userId: userId,
+        grantId: grantId,
         scope: grantData.scope,
         requestedScope: tokenScopes,
         props: decryptedProps,
@@ -2552,6 +2563,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         grantType: GrantType.TOKEN_EXCHANGE,
         clientId: clientInfo.clientId,
         userId: tokenSummary.userId,
+        grantId: tokenSummary.grantId,
         scope: tokenSummary.grant.scope,
         requestedScope: tokenScopes,
         props: decryptedProps,


### PR DESCRIPTION
> **Note on process:** the [contributing guide](https://github.com/cloudflare/.github/blob/main/CONTRIBUTING.md) asks for an issue before a feature PR. This change is small and mechanical (1 type field + 3 one-liners populated from variables already in scope), so I opened it speculatively as a draft to make the use case concrete. Happy to back out and file an issue first if you'd prefer to discuss the design before code!

## Why

Implementations of `tokenExchangeCallback` already receive `userId` and `clientId` but currently have no way to identify *which specific grant* the library is operating on. This makes it impossible to surgically revoke a single grant from the callback (for example, in response to a terminal upstream refresh failure such as `unauthorized_client` from a downstream OAuth provider) without one of two unsatisfying workarounds:

1. **Sweep all grants for the `(userId, clientId)` pair and delete by stored `clientId` match.** Racy under concurrent refreshes — if a parallel successful refresh has just rotated tokens for the same grant, the failing call's revocation can clobber the freshly-refreshed grant.
2. **Maintain an out-of-band mapping in the callback's own KV.** Adds a second source of truth and a migration burden.

We hit this in production at Canva and currently maintain a small local `pnpm patch` to expose `grantId`. This PR upstreams the same change so the patch can be retired.

## Note on `tokenExchangeCallback` direction

I noticed [#99](https://github.com/cloudflare/workers-oauth-provider/pull/99) was closed with the comment that new `tokenExchangeCallback` features shouldn't be encouraged in favour of a split AS / resource-server setup per the MCP spec. Worth flagging upfront how this PR fits that direction:

- It doesn't expand the callback's surface area or enable a new pattern. `grantId` is the natural identifier for "the grant currently being processed" — every other field (`userId`, `clientId`, `scope`, `props`) already identifies the same grant from a different angle, just incompletely.
- The omission is more accurately a gap than an intentional restriction: it's already in scope at every call site (see the diff — three one-liners pulling from local variables that already exist).
- It's not specific to the proxy / "middleman" pattern. Any `tokenExchangeCallback` consumer that wants to revoke a grant on terminal upstream conditions hits the same race today.
- Until the split AS/RS migration path lands, `tokenExchangeCallback` is the documented refresh-time hook. This change makes the *current* mechanism work correctly under realistic concurrency — it's a fix in the spirit of [#199](https://github.com/cloudflare/workers-oauth-provider/pull/199), not a feature build-out.

Happy to discuss if a different shape would be preferred.

## What

- Add `grantId: string` to `TokenExchangeCallbackOptions`.
- Populate it at all three call sites: `authorization_code`, `refresh_token`, `token_exchange`. The `grantId` is already in scope at each site (`grantId` from token-string parse for the first two; `tokenSummary.grantId` for the third).
- Document the field with a pointer at `OAuthHelpers.revokeGrant`.

## Tests

- Augmented existing auth-code and refresh-token callback tests to assert `grantId` is a non-empty string.
- Added a stand-alone test that drives auth-code → refresh and asserts the `grantId` exposed to the callback is identical across both calls (the stable-across-refreshes contract).

`npm run check` (typecheck + 353 tests) passes locally.

## Backwards compatibility

`TokenExchangeCallbackOptions` is a callback **input** type, not an output. Existing implementations that accept the options object as `any` (per the README example) or a structurally-typed subset continue to work unchanged. Implementations that have explicitly typed it will only need a recompile — no behaviour change required to consume the new field.

## Changeset

Included as `minor` since this is a backwards-compatible additive change.