### PR TITLE
fix: validate token endpoint client authentication

### DIFF
--- a/.changeset/fair-donuts-drum.md
+++ b/.changeset/fair-donuts-drum.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Tighten token endpoint client authentication parsing for RFC 6749 compliance.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1731,6 +1731,97 @@ describe('OAuthProvider', () => {
       expect(grant.refreshTokenId).toBeDefined(); // Refresh token should be added
     });
 
+    it('should reject repeated token endpoint parameters', async () => {
+      const params = new URLSearchParams();
+      params.append('grant_type', 'refresh_token');
+      params.append('grant_type', 'authorization_code');
+      params.append('refresh_token', 'invalid-refresh-token');
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+
+      const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
+
+      expect(tokenResponse.status).toBe(400);
+      const error = await tokenResponse.json<any>();
+      expect(error.error).toBe('invalid_request');
+      expect(error.error_description).toBe('Request parameter "grant_type" must not be repeated');
+    });
+
+    it('should reject requests that combine Basic auth with form client credentials', async () => {
+      const params = new URLSearchParams();
+      params.append('grant_type', 'refresh_token');
+      params.append('refresh_token', 'invalid-refresh-token');
+      params.append('client_id', clientId);
+
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        params.toString()
+      );
+
+      const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
+
+      expect(tokenResponse.status).toBe(400);
+      const error = await tokenResponse.json<any>();
+      expect(error.error).toBe('invalid_request');
+      expect(error.error_description).toBe('Client must not use multiple authentication methods');
+    });
+
+    it('should decode Basic auth credentials with form-url-encoding semantics', async () => {
+      const secretWithReservedCharacters = 'secret with spaces:and:colons';
+      await oauthProvider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+      const updatedClient = await mockEnv.OAUTH_PROVIDER!.updateClient(clientId, {
+        clientSecret: secretWithReservedCharacters,
+      });
+      expect(updatedClient).not.toBeNull();
+
+      // First get an auth code
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+
+      const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+      const location = authResponse.headers.get('Location')!;
+      const url = new URL(location);
+      const code = url.searchParams.get('code')!;
+
+      const formEncode = (value: string) => encodeURIComponent(value).replace(/%20/g, '+');
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${formEncode(clientId)}:${formEncode(secretWithReservedCharacters)}`)}`,
+        },
+        params.toString()
+      );
+
+      const tokenResponse = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
+
+      expect(tokenResponse.status).toBe(200);
+      const tokens = await tokenResponse.json<any>();
+      expect(tokens.access_token).toBeDefined();
+      expect(tokens.refresh_token).toBeDefined();
+    });
+
     it('should revoke tokens when authorization code is reused', async () => {
       // First get an auth code
       const authRequest = createMockRequest(

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1687,9 +1687,22 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Process application/x-www-form-urlencoded
     const formData = await request.formData();
+    const processedKeys = new Set<string>();
     for (const [key, value] of formData.entries()) {
+      if (processedKeys.has(key)) {
+        continue;
+      }
+      processedKeys.add(key);
+
       // RFC 8707: resource parameter can appear multiple times
       const allValues = formData.getAll(key);
+      if (key !== 'resource' && allValues.length > 1) {
+        return this.createErrorResponse('invalid_request', {
+          description: `Request parameter "${key}" must not be repeated`,
+          statusCode: 400,
+        });
+      }
+
       body[key] = allValues.length > 1 ? allValues : value;
     }
 
@@ -1699,11 +1712,27 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     let clientSecret = '';
 
     if (authHeader && authHeader.startsWith('Basic ')) {
+      if (body.client_id || body.client_secret) {
+        return this.createErrorResponse('invalid_request', {
+          description: 'Client must not use multiple authentication methods',
+          statusCode: 400,
+        });
+      }
+
       // Basic auth
       const credentials = atob(authHeader.substring(6));
-      const [id, secret] = credentials.split(':', 2);
-      clientId = decodeURIComponent(id);
-      clientSecret = decodeURIComponent(secret || '');
+      const separatorIndex = credentials.indexOf(':');
+      if (separatorIndex === -1) {
+        return this.createErrorResponse('invalid_client', {
+          description: 'Client authentication failed: invalid Basic credentials',
+          statusCode: 401,
+        });
+      }
+
+      const id = credentials.substring(0, separatorIndex);
+      const secret = credentials.substring(separatorIndex + 1);
+      clientId = decodeFormUrlEncodedComponent(id);
+      clientSecret = decodeFormUrlEncodedComponent(secret);
     } else {
       // Form parameters
       clientId = body.client_id;
@@ -4322,6 +4351,15 @@ export function resourceMatches(requested: string, granted: string, originOnly: 
 async function hashSecret(secret: string): Promise<string> {
   // Use the same approach as generateTokenId for consistency
   return generateTokenId(secret);
+}
+
+/**
+ * Decodes an application/x-www-form-urlencoded component.
+ * @param value - The encoded component value
+ * @returns The decoded component value
+ */
+function decodeFormUrlEncodedComponent(value: string): string {
+  return decodeURIComponent(value.replace(/\+/g, ' '));
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes part of #196 by tightening token endpoint request parsing for RFC 6749 client authentication rules.

- reject repeated token endpoint parameters as `invalid_request`, while preserving repeated `resource` support from RFC 8707
- reject requests that combine HTTP Basic auth with form client credentials
- decode HTTP Basic client credentials using application/x-www-form-urlencoded semantics and preserve colons in the password side

## Verification

- `npx vitest run __tests__/oauth-provider.test.ts --testNamePattern "Authorization Code Flow Exchange"`
- `npm run check`
- `npm run build`
