### PR TITLE
feat(ema): restructure enterprise-managed auth into Result-typed modules

### DIFF
--- a/.changeset/enterprise-managed-authorization.md
+++ b/.changeset/enterprise-managed-authorization.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Experimentally support MCP Enterprise-Managed Authorization ID-JAG assertions through the JWT bearer grant.

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Setup:
 2. Set `resourceMetadata.resource` to the MCP endpoint URL (required when EMA is enabled).
 3. Implement `trustedIssuers` as a resolver — for multi-tenant deployments it can read `env` / `clientInfo` to look up per-tenant IdP config without redeploying.
 
-The AS enforces `resolved.issuer === iss` (confused-deputy guard) and validates ID-JAG `typ`, signature, audience, client binding, resource, `exp` / `iat` / `nbf`, max lifetime, and `jti` replay. Access token TTL is clamped to the assertion lifetime; refresh tokens are not issued for this grant. Default in-memory JWKS cache and KV-backed JTI store can be replaced via `jwksProvider` / `jtiStore` adapters.
+The AS enforces `resolved.issuer === iss` (confused-deputy guard) and validates ID-JAG `typ`, signature, audience, client binding, resource, `exp` / `iat` / `nbf`, max lifetime, and `jti` replay. Refresh tokens are not issued for this grant — the ID-JAG itself is the renewable assertion.
 
 Experimental — the MCP extension is still a draft.
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ new OAuthProvider({
   // ... other options ...
   resourceMetadata: { resource: 'https://mcp.example.com/mcp' },
   enterpriseManagedAuthorization: {
-    trustedIssuers: ({ iss }) =>
+    trustedIssuers: async ({ iss }) =>
       iss === 'https://idp.example.com'
         ? { issuer: iss, jwksUri: 'https://idp.example.com/.well-known/jwks.json', algorithms: ['RS256'] }
         : null,

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ export default new OAuthProvider({
   // Defaults to false.
   allowTokenExchangeGrant: false,
 
+  // Optional: Experimental MCP Enterprise-Managed Authorization support.
+  // When enabled, the token endpoint accepts ID-JAG JWTs with the JWT bearer grant.
+  enterpriseManagedAuthorization: undefined,
+
   // Optional: Explicitly enable Client ID Metadata Document (CIMD) support.
   // When true, URL-formatted client_ids will be fetched as metadata documents.
   // Requires the 'global_fetch_strictly_public' compatibility flag.
@@ -352,6 +356,42 @@ async function refreshUpstream(props) {
 
 Only `OAuthError` from this package is converted into a structured `/token` response. Plain errors, plain objects with a `code` field, and app-local error classes continue to surface as 500s so unexpected failures stay visible. Import `OAuthError` from `@cloudflare/workers-oauth-provider` rather than copying or re-implementing it.
 
+## Enterprise-Managed Authorization (Experimental)
+
+Accepts ID-JAG assertions at `/token` per the [MCP Enterprise-Managed Authorization extension](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization). The enterprise IdP issues an ID-JAG JWT and the MCP client exchanges it here for an opaque access token.
+
+```ts
+new OAuthProvider({
+  // ... other options ...
+  resourceMetadata: { resource: 'https://mcp.example.com/mcp' },
+  enterpriseManagedAuthorization: {
+    trustedIssuers: ({ iss }) =>
+      iss === 'https://idp.example.com'
+        ? { issuer: iss, jwksUri: 'https://idp.example.com/.well-known/jwks.json', algorithms: ['RS256'] }
+        : null,
+    async mapClaims({ claims, requestedScope }) {
+      return {
+        // Opaque tokens use ':' as a separator — encode subjects that may contain it.
+        userId: `enterprise-${claims.sub}`,
+        scope: requestedScope,
+        metadata: { enterpriseIssuer: claims.iss, enterpriseSubject: claims.sub },
+        props: { enterprise: true, subject: claims.sub, email: claims.email },
+      };
+    },
+  },
+});
+```
+
+Setup:
+
+1. Configure your IdP as an ID-JAG issuer with this worker's origin as the resource and a public JWKS endpoint.
+2. Set `resourceMetadata.resource` to the MCP endpoint URL (required when EMA is enabled).
+3. Implement `trustedIssuers` as a resolver — for multi-tenant deployments it can read `env` / `clientInfo` to look up per-tenant IdP config without redeploying.
+
+The AS enforces `resolved.issuer === iss` (confused-deputy guard) and validates ID-JAG `typ`, signature, audience, client binding, resource, `exp` / `iat` / `nbf`, max lifetime, and `jti` replay. Access token TTL is clamped to the assertion lifetime; refresh tokens are not issued for this grant. Default in-memory JWKS cache and KV-backed JTI store can be replaced via `jwksProvider` / `jtiStore` adapters.
+
+Experimental — the MCP extension is still a draft.
+
 ## Custom Error Responses
 
 By using the `onError` option, you can emit notifications or take other actions when an error response was to be emitted:
@@ -434,6 +474,7 @@ This library implements the following OAuth and MCP specifications:
 - [OAuth 2.0 Protected Resource Metadata (RFC 9728)](https://datatracker.ietf.org/doc/html/rfc9728) — `/.well-known/oauth-protected-resource` discovery endpoint
 - [OAuth 2.0 Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591) — Dynamic client registration endpoint
 - [OAuth Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) — HTTPS URLs as client IDs
+- [MCP Enterprise-Managed Authorization extension](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) — experimental ID-JAG JWT bearer grant support
 
 These are the specifications required by the [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).
 

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -480,4 +480,11 @@ describe('emaErrorToWire', () => {
       message: 'Invalid assertion',
     });
   });
+
+  it('maps mapper_threw to invalid_grant with the same message as mapper_denied', () => {
+    const threwWire = emaErrorToWire({ reason: 'mapper_threw' });
+    const deniedWire = emaErrorToWire({ reason: 'mapper_denied' });
+    expect(threwWire).toEqual({ code: 'invalid_grant', message: 'Assertion was not authorized' });
+    expect(threwWire).toEqual(deniedWire);
+  });
 });

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -302,12 +302,21 @@ describe('validateIdJagClaims', () => {
     expect(r).toMatchObject({ ok: false, error: { reason: 'resource_mismatch' } });
   });
 
-  it('rejects expired assertions', () => {
+  it('rejects expired assertions beyond clock-skew tolerance', () => {
+    // claimsArgs.clockSkewSeconds = 60, so the assertion must be > 60s past exp.
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, exp: claimsArgs.now - 120 },
+      ...claimsArgs,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'expired' } });
+  });
+
+  it('accepts assertions within clock-skew tolerance of exp (RFC 7523 §3 rule 4)', () => {
     const r = validateIdJagClaims({
       rawClaims: { ...validClaims, exp: claimsArgs.now - 10 },
       ...claimsArgs,
     });
-    expect(r).toMatchObject({ ok: false, error: { reason: 'expired' } });
+    expect(r.ok).toBe(true);
   });
 
   it('rejects iat too far in the future', () => {
@@ -337,7 +346,7 @@ describe('validateIdJagClaims', () => {
 
   it('rejects malformed scope grammar', () => {
     const r = validateIdJagClaims({
-      rawClaims: { ...validClaims, scope: 'valid badtoken' },
+      rawClaims: { ...validClaims, scope: 'valid bad\x01token' },
       ...claimsArgs,
     });
     expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_claim', claim: 'scope' } });
@@ -361,7 +370,7 @@ describe('parseEmaScopeParam', () => {
   });
 
   it('rejects malformed scope', () => {
-    const r = parseEmaScopeParam('badscope', []);
+    const r = parseEmaScopeParam('bad\x01scope', []);
     expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_scope_param' } });
   });
 
@@ -392,7 +401,7 @@ describe('validateEmaMapperResult', () => {
   });
 
   it('rejects malformed scope tokens', () => {
-    const r = validateEmaMapperResult({ userId: 'u', scope: ['bad'], props: {} });
+    const r = validateEmaMapperResult({ userId: 'u', scope: ['bad\x01'], props: {} });
     expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_scope' } });
   });
 

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Unit tests for the pure EMA validators in `src/ema/*`.
+ *
+ * These tests demonstrate the testability win from the restructure: each
+ * validator is a free function operating on plain data, so we don't need to
+ * spin up an `OAuthProvider`, mock a fetch, or seed a KV store. They run in
+ * milliseconds and pin individual checks one-by-one — adding a new claim
+ * check becomes a few lines, not a full integration setup.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { EMA_ID_JAG_JWT_TYPE, EMA_SUPPORTED_JWT_ALGORITHMS, type EmaSupportedAlg } from '../src/ema/constants';
+import { parseIdJag } from '../src/ema/parser';
+import { emaErrorToWire } from '../src/ema/result';
+import { selectJwk } from '../src/ema/signature';
+import type { EmaTrustedIssuer, JsonWebKeySet } from '../src/ema/types';
+import {
+  clampEmaAccessTokenTTL,
+  parseEmaScopeParam,
+  resolveTrustedIssuer,
+  validateEmaMapperResult,
+  validateIdJagClaims,
+  validateIdJagHeader,
+} from '../src/ema/validators';
+
+function b64url(input: string): string {
+  return btoa(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function buildAssertion(header: object, payload: object): string {
+  // The signature segment must be valid base64url; the actual byte content is
+  // irrelevant for parser tests since signature verification is a separate step.
+  return `${b64url(JSON.stringify(header))}.${b64url(JSON.stringify(payload))}.${b64url('sig')}`;
+}
+
+const trustedIssuer: EmaTrustedIssuer = {
+  issuer: 'https://idp.example.com',
+  jwksUri: 'https://idp.example.com/jwks.json',
+  algorithms: ['RS256'],
+  audience: 'https://as.example.com',
+};
+
+const validClaims = {
+  iss: 'https://idp.example.com',
+  sub: 'user-123',
+  aud: 'https://as.example.com',
+  resource: 'https://mcp.example.com',
+  client_id: 'client-xyz',
+  jti: 'jti-abc',
+  exp: 2_000_000_000,
+  iat: 1_999_999_700,
+  scope: 'read write',
+};
+
+const claimsArgs = {
+  trustedIssuer,
+  expectedAudience: 'https://as.example.com',
+  clientId: 'client-xyz',
+  configuredResource: 'https://mcp.example.com',
+  matchOriginOnly: false,
+  now: 1_999_999_800,
+  clockSkewSeconds: 60,
+  maxAssertionLifetimeSeconds: 300,
+};
+
+describe('parseIdJag', () => {
+  it('rejects an empty assertion as missing', () => {
+    expect(parseIdJag('', 1024)).toMatchObject({ ok: false, error: { reason: 'assertion_missing' } });
+  });
+
+  it('rejects an oversized assertion', () => {
+    expect(parseIdJag('x'.repeat(2000), 1024)).toMatchObject({
+      ok: false,
+      error: { reason: 'assertion_too_large' },
+    });
+  });
+
+  it('rejects a non-3-segment assertion', () => {
+    expect(parseIdJag('one.two', 1024)).toMatchObject({ ok: false, error: { reason: 'assertion_malformed' } });
+  });
+
+  it('rejects assertions with malformed JSON', () => {
+    expect(parseIdJag('aaa.bbb.ccc', 1024)).toMatchObject({
+      ok: false,
+      error: { reason: 'assertion_malformed' },
+    });
+  });
+
+  it('parses a valid 3-segment assertion', () => {
+    const assertion = buildAssertion({ typ: EMA_ID_JAG_JWT_TYPE, alg: 'RS256' }, validClaims);
+    const result = parseIdJag(assertion, 1024);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.header).toMatchObject({ typ: EMA_ID_JAG_JWT_TYPE, alg: 'RS256' });
+      expect(result.value.rawClaims.iss).toBe('https://idp.example.com');
+    }
+  });
+});
+
+describe('validateIdJagHeader', () => {
+  it('requires the oauth-id-jag+jwt typ', () => {
+    const r = validateIdJagHeader({ typ: 'JWT', alg: 'RS256' }, EMA_ID_JAG_JWT_TYPE, EMA_SUPPORTED_JWT_ALGORITHMS);
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_typ' } });
+  });
+
+  it('rejects alg=none', () => {
+    const r = validateIdJagHeader(
+      { typ: EMA_ID_JAG_JWT_TYPE, alg: 'none' },
+      EMA_ID_JAG_JWT_TYPE,
+      EMA_SUPPORTED_JWT_ALGORITHMS
+    );
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_alg' } });
+  });
+
+  it('rejects unsupported alg', () => {
+    const r = validateIdJagHeader(
+      { typ: EMA_ID_JAG_JWT_TYPE, alg: 'HS256' },
+      EMA_ID_JAG_JWT_TYPE,
+      EMA_SUPPORTED_JWT_ALGORITHMS
+    );
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_alg' } });
+  });
+
+  it('extracts kid when present', () => {
+    const r = validateIdJagHeader(
+      { typ: EMA_ID_JAG_JWT_TYPE, alg: 'RS256', kid: 'k1' },
+      EMA_ID_JAG_JWT_TYPE,
+      EMA_SUPPORTED_JWT_ALGORITHMS
+    );
+    expect(r).toMatchObject({ ok: true, value: { typ: EMA_ID_JAG_JWT_TYPE, alg: 'RS256', kid: 'k1' } });
+  });
+
+  it('treats empty kid as absent', () => {
+    const r = validateIdJagHeader(
+      { typ: EMA_ID_JAG_JWT_TYPE, alg: 'RS256', kid: '' },
+      EMA_ID_JAG_JWT_TYPE,
+      EMA_SUPPORTED_JWT_ALGORITHMS
+    );
+    expect(r.ok && r.value.kid).toBeUndefined();
+  });
+});
+
+describe('resolveTrustedIssuer', () => {
+  const issuers: EmaTrustedIssuer[] = [
+    { issuer: 'https://idp1.example.com', jwksUri: 'https://idp1.example.com/jwks.json', algorithms: ['RS256'] },
+    { issuer: 'https://idp2.example.com', jwksUri: 'https://idp2.example.com/jwks.json', algorithms: ['ES256'] },
+  ];
+  const resolver = ({ iss }: { iss: string }) => issuers.find((c) => c.issuer === iss) ?? null;
+  const ctx = {
+    env: {} as unknown,
+    request: new Request('https://as.example.com/oauth/token'),
+    clientInfo: { clientId: 'client-xyz' } as any,
+  };
+
+  it('rejects non-string iss', async () => {
+    const r = await resolveTrustedIssuer({ iss: 42, alg: 'RS256', resolver, ...ctx });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_claim', claim: 'iss' } });
+  });
+
+  it('rejects when the resolver returns null (issuer not trusted)', async () => {
+    const r = await resolveTrustedIssuer({ iss: 'https://attacker.example.com', alg: 'RS256', resolver, ...ctx });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'issuer_not_trusted' } });
+  });
+
+  it('rejects when alg is not in the resolved issuer allowlist', async () => {
+    const r = await resolveTrustedIssuer({ iss: 'https://idp1.example.com', alg: 'ES256', resolver, ...ctx });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'issuer_not_trusted' } });
+  });
+
+  it('returns the matching issuer when alg is allowed', async () => {
+    const r = await resolveTrustedIssuer({ iss: 'https://idp2.example.com', alg: 'ES256', resolver, ...ctx });
+    expect(r.ok && r.value.issuer).toBe('https://idp2.example.com');
+  });
+
+  it('supports async resolvers (e.g. KV/D1 lookups)', async () => {
+    const asyncResolver = async ({ iss }: { iss: string }) =>
+      iss === 'https://tenant-a.idp.example' ? issuers[0] : null;
+    const r = await resolveTrustedIssuer({
+      iss: 'https://tenant-a.idp.example',
+      alg: 'RS256',
+      // The resolver intentionally returns idp1's config for tenant-a's iss to
+      // verify the confused-deputy guard fires.
+      resolver: asyncResolver,
+      ...ctx,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'issuer_not_trusted' } });
+  });
+
+  it('rejects when the resolver returns an issuer whose `issuer` field disagrees with iss', async () => {
+    const lyingResolver = () => ({ ...issuers[0], issuer: 'https://different.example.com' });
+    const r = await resolveTrustedIssuer({
+      iss: 'https://idp1.example.com',
+      alg: 'RS256',
+      resolver: lyingResolver,
+      ...ctx,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'issuer_not_trusted' } });
+  });
+
+  it('rejects when the resolver returns a malformed config (non-HTTPS jwksUri)', async () => {
+    const badResolver = () => ({
+      issuer: 'https://idp1.example.com',
+      jwksUri: 'http://idp1.example.com/jwks.json',
+    });
+    const r = await resolveTrustedIssuer({
+      iss: 'https://idp1.example.com',
+      alg: 'RS256',
+      resolver: badResolver,
+      ...ctx,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'issuer_not_trusted' } });
+  });
+
+  it('rejects when the resolver throws', async () => {
+    const throwingResolver = () => {
+      throw new Error('database is down');
+    };
+    const r = await resolveTrustedIssuer({
+      iss: 'https://idp1.example.com',
+      alg: 'RS256',
+      resolver: throwingResolver,
+      ...ctx,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'issuer_not_trusted' } });
+  });
+});
+
+describe('selectJwk', () => {
+  const jwks: JsonWebKeySet = {
+    keys: [
+      { kty: 'RSA', kid: 'r1', use: 'sig', n: 'aaa', e: 'AQAB' },
+      { kty: 'RSA', kid: 'r2', use: 'sig', n: 'bbb', e: 'AQAB' },
+      { kty: 'EC', kid: 'e1', use: 'sig', crv: 'P-256', x: 'xxx', y: 'yyy' },
+    ],
+  };
+
+  it('picks the key matching the assertion kid', () => {
+    const r = selectJwk(jwks, 'RS256' as EmaSupportedAlg, 'r2');
+    expect(r.ok && r.value.kid).toBe('r2');
+  });
+
+  it('rejects when kid is provided but absent from JWKS', () => {
+    const r = selectJwk(jwks, 'RS256' as EmaSupportedAlg, 'nope');
+    expect(r).toMatchObject({ ok: false, error: { reason: 'no_matching_key' } });
+  });
+
+  it('rejects when no kid is given and multiple keys match the alg', () => {
+    const r = selectJwk(jwks, 'RS256' as EmaSupportedAlg, undefined);
+    expect(r).toMatchObject({ ok: false, error: { reason: 'no_matching_key' } });
+  });
+
+  it('picks the unique alg-compatible key when kid is absent', () => {
+    const r = selectJwk(jwks, 'ES256' as EmaSupportedAlg, undefined);
+    expect(r.ok && r.value.kid).toBe('e1');
+  });
+});
+
+describe('validateIdJagClaims', () => {
+  it('accepts a fully valid claim set', () => {
+    const r = validateIdJagClaims({ rawClaims: { ...validClaims }, ...claimsArgs });
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing required claims with the claim name', () => {
+    const { sub: _omit, ...rest } = validClaims;
+    const r = validateIdJagClaims({ rawClaims: rest, ...claimsArgs });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_claim', claim: 'sub' } });
+  });
+
+  it('rejects aud mismatch', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, aud: 'https://other.example.com' },
+      ...claimsArgs,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'aud_mismatch' } });
+  });
+
+  it('accepts aud as an array containing the expected audience', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, aud: ['https://x.example', 'https://as.example.com'] },
+      ...claimsArgs,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects client_id mismatch', () => {
+    const r = validateIdJagClaims({ rawClaims: { ...validClaims, client_id: 'other' }, ...claimsArgs });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'client_id_mismatch' } });
+  });
+
+  it('rejects invalid resource URI', () => {
+    const r = validateIdJagClaims({ rawClaims: { ...validClaims, resource: 'not a url' }, ...claimsArgs });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'resource_invalid' } });
+  });
+
+  it('rejects resource that does not match the configured one', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, resource: 'https://attacker.example.com' },
+      ...claimsArgs,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'resource_mismatch' } });
+  });
+
+  it('rejects expired assertions', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, exp: claimsArgs.now - 10 },
+      ...claimsArgs,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'expired' } });
+  });
+
+  it('rejects iat too far in the future', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, iat: claimsArgs.now + 1000 },
+      ...claimsArgs,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'iat_in_future' } });
+  });
+
+  it('rejects nbf too far in the future', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, nbf: claimsArgs.now + 1000 },
+      ...claimsArgs,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'nbf_in_future' } });
+  });
+
+  it('rejects assertions whose lifetime exceeds the maximum', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, iat: 1_000_000_000, exp: 1_999_999_999 },
+      ...claimsArgs,
+      now: 1_500_000_000,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'lifetime_too_long' } });
+  });
+
+  it('rejects malformed scope grammar', () => {
+    const r = validateIdJagClaims({
+      rawClaims: { ...validClaims, scope: 'valid badtoken' },
+      ...claimsArgs,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_claim', claim: 'scope' } });
+  });
+});
+
+describe('parseEmaScopeParam', () => {
+  it('returns the assertion scopes when scope param is omitted', () => {
+    const r = parseEmaScopeParam(undefined, ['read', 'write']);
+    expect(r).toMatchObject({ ok: true, value: ['read', 'write'] });
+  });
+
+  it('parses a space-separated string', () => {
+    const r = parseEmaScopeParam('read write', ['read', 'write']);
+    expect(r).toMatchObject({ ok: true, value: ['read', 'write'] });
+  });
+
+  it('downscopes to the intersection with assertion scopes', () => {
+    const r = parseEmaScopeParam('read admin', ['read', 'write']);
+    expect(r).toMatchObject({ ok: true, value: ['read'] });
+  });
+
+  it('rejects malformed scope', () => {
+    const r = parseEmaScopeParam('badscope', []);
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_scope_param' } });
+  });
+
+  it('rejects non-string non-array values', () => {
+    const r = parseEmaScopeParam(42, []);
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_scope_param' } });
+  });
+});
+
+describe('validateEmaMapperResult', () => {
+  it('null is mapper_denied', () => {
+    expect(validateEmaMapperResult(null)).toMatchObject({ ok: false, error: { reason: 'mapper_denied' } });
+  });
+
+  it('rejects userId with ":" separator', () => {
+    const r = validateEmaMapperResult({ userId: 'a:b', scope: [], props: {} });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_user' } });
+  });
+
+  it('rejects empty userId', () => {
+    const r = validateEmaMapperResult({ userId: '', scope: [], props: {} });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_user' } });
+  });
+
+  it('rejects non-array scope', () => {
+    const r = validateEmaMapperResult({ userId: 'u', scope: 'read', props: {} });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_scope' } });
+  });
+
+  it('rejects malformed scope tokens', () => {
+    const r = validateEmaMapperResult({ userId: 'u', scope: ['bad'], props: {} });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_scope' } });
+  });
+
+  it('rejects when props is missing', () => {
+    const r = validateEmaMapperResult({ userId: 'u', scope: [] });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_props' } });
+  });
+
+  it('rejects when accessTokenTTL is non-positive', () => {
+    const r = validateEmaMapperResult({ userId: 'u', scope: [], props: {}, accessTokenTTL: -1 });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_ttl' } });
+  });
+
+  it('returns the validated mapper output on success', () => {
+    const r = validateEmaMapperResult({ userId: 'u', scope: ['read'], props: { x: 1 }, accessTokenTTL: 600 });
+    expect(r.ok && r.value.userId).toBe('u');
+    expect(r.ok && r.value.scope).toEqual(['read']);
+    expect(r.ok && r.value.accessTokenTTL).toBe(600);
+  });
+});
+
+describe('clampEmaAccessTokenTTL', () => {
+  it('clamps to the assertion remaining lifetime when shorter than the configured TTL', () => {
+    const r = clampEmaAccessTokenTTL({
+      configuredDefaultSeconds: 3600,
+      assertionExp: 2_000_000_000,
+      mapperTtl: undefined,
+      now: 1_999_999_700,
+    });
+    expect(r).toMatchObject({ ok: true, value: 300 });
+  });
+
+  it('clamps to the mapper-supplied TTL when shorter', () => {
+    const r = clampEmaAccessTokenTTL({
+      configuredDefaultSeconds: 3600,
+      assertionExp: 2_000_000_000,
+      mapperTtl: 60,
+      now: 1_999_999_700,
+    });
+    expect(r).toMatchObject({ ok: true, value: 60 });
+  });
+
+  it('rejects with assertion_expired_after_processing when no positive lifetime remains', () => {
+    const r = clampEmaAccessTokenTTL({
+      configuredDefaultSeconds: 3600,
+      assertionExp: 1_999_999_700,
+      mapperTtl: undefined,
+      now: 1_999_999_800,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'assertion_expired_after_processing' } });
+  });
+});
+
+describe('emaErrorToWire', () => {
+  it('maps resource errors to invalid_target', () => {
+    expect(emaErrorToWire({ reason: 'resource_invalid', resource: 'x' })).toMatchObject({ code: 'invalid_target' });
+    expect(emaErrorToWire({ reason: 'resource_mismatch', expected: 'a', got: 'b' })).toMatchObject({
+      code: 'invalid_target',
+    });
+  });
+
+  it('maps assertion-missing to invalid_request', () => {
+    expect(emaErrorToWire({ reason: 'assertion_missing' })).toMatchObject({ code: 'invalid_request' });
+  });
+
+  it('maps scope-param errors to invalid_request', () => {
+    expect(emaErrorToWire({ reason: 'invalid_scope_param' })).toMatchObject({ code: 'invalid_request' });
+  });
+
+  it('keeps "Invalid assertion" as the default invalid_grant message', () => {
+    expect(emaErrorToWire({ reason: 'signature_failed' })).toMatchObject({
+      code: 'invalid_grant',
+      message: 'Invalid assertion',
+    });
+  });
+});

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -415,24 +415,27 @@ describe('validateEmaMapperResult', () => {
 });
 
 describe('clampEmaAccessTokenTTL', () => {
-  it('clamps to the assertion remaining lifetime when shorter than the configured TTL', () => {
+  it('uses the configured default TTL regardless of the assertion remaining lifetime', () => {
     const r = clampEmaAccessTokenTTL({
       configuredDefaultSeconds: 3600,
       assertionExp: 2_000_000_000,
       mapperTtl: undefined,
       now: 1_999_999_700,
     });
-    expect(r).toMatchObject({ ok: true, value: 300 });
+    // Assertion has 300s left but the issued access token follows the AS's
+    // configured TTL (3600s) — the assertion is a one-shot grant, not a
+    // lifetime cap on the token.
+    expect(r).toMatchObject({ ok: true, value: 3600 });
   });
 
-  it('clamps to the mapper-supplied TTL when shorter', () => {
+  it('uses the mapper-supplied TTL when provided', () => {
     const r = clampEmaAccessTokenTTL({
       configuredDefaultSeconds: 3600,
       assertionExp: 2_000_000_000,
-      mapperTtl: 60,
+      mapperTtl: 86_400,
       now: 1_999_999_700,
     });
-    expect(r).toMatchObject({ ok: true, value: 60 });
+    expect(r).toMatchObject({ ok: true, value: 86_400 });
   });
 
   it('rejects with assertion_expired_after_processing when no positive lifetime remains', () => {

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -146,7 +146,7 @@ describe('resolveTrustedIssuer', () => {
     { issuer: 'https://idp1.example.com', jwksUri: 'https://idp1.example.com/jwks.json', algorithms: ['RS256'] },
     { issuer: 'https://idp2.example.com', jwksUri: 'https://idp2.example.com/jwks.json', algorithms: ['ES256'] },
   ];
-  const resolver = ({ iss }: { iss: string }) => issuers.find((c) => c.issuer === iss) ?? null;
+  const resolver = async ({ iss }: { iss: string }) => issuers.find((c) => c.issuer === iss) ?? null;
   const ctx = {
     env: {} as unknown,
     request: new Request('https://as.example.com/oauth/token'),
@@ -188,7 +188,7 @@ describe('resolveTrustedIssuer', () => {
   });
 
   it('rejects when the resolver returns an issuer whose `issuer` field disagrees with iss', async () => {
-    const lyingResolver = () => ({ ...issuers[0], issuer: 'https://different.example.com' });
+    const lyingResolver = async () => ({ ...issuers[0], issuer: 'https://different.example.com' });
     const r = await resolveTrustedIssuer({
       iss: 'https://idp1.example.com',
       alg: 'RS256',
@@ -199,7 +199,7 @@ describe('resolveTrustedIssuer', () => {
   });
 
   it('rejects when the resolver returns a malformed config (non-HTTPS jwksUri)', async () => {
-    const badResolver = () => ({
+    const badResolver = async () => ({
       issuer: 'https://idp1.example.com',
       jwksUri: 'http://idp1.example.com/jwks.json',
     });
@@ -213,7 +213,7 @@ describe('resolveTrustedIssuer', () => {
   });
 
   it('rejects when the resolver throws', async () => {
-    const throwingResolver = () => {
+    const throwingResolver = async () => {
       throw new Error('database is down');
     };
     const r = await resolveTrustedIssuer({

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -16,7 +16,7 @@ import { emaErrorToWire } from '../src/ema/result';
 import { selectJwk } from '../src/ema/signature';
 import type { EmaTrustedIssuer, JsonWebKeySet } from '../src/ema/types';
 import {
-  clampEmaAccessTokenTTL,
+  computeEmaAccessTokenTTL,
   parseEmaScopeParam,
   resolveTrustedIssuer,
   validateEmaMapperResult,
@@ -414,9 +414,9 @@ describe('validateEmaMapperResult', () => {
   });
 });
 
-describe('clampEmaAccessTokenTTL', () => {
+describe('computeEmaAccessTokenTTL', () => {
   it('uses the configured default TTL regardless of the assertion remaining lifetime', () => {
-    const r = clampEmaAccessTokenTTL({
+    const r = computeEmaAccessTokenTTL({
       configuredDefaultSeconds: 3600,
       assertionExp: 2_000_000_000,
       mapperTtl: undefined,
@@ -429,7 +429,7 @@ describe('clampEmaAccessTokenTTL', () => {
   });
 
   it('uses the mapper-supplied TTL when provided', () => {
-    const r = clampEmaAccessTokenTTL({
+    const r = computeEmaAccessTokenTTL({
       configuredDefaultSeconds: 3600,
       assertionExp: 2_000_000_000,
       mapperTtl: 86_400,
@@ -439,7 +439,7 @@ describe('clampEmaAccessTokenTTL', () => {
   });
 
   it('rejects with assertion_expired_after_processing when no positive lifetime remains', () => {
-    const r = clampEmaAccessTokenTTL({
+    const r = computeEmaAccessTokenTTL({
       configuredDefaultSeconds: 3600,
       assertionExp: 1_999_999_700,
       mapperTtl: undefined,

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -2847,7 +2847,7 @@ describe('OAuthProvider', () => {
       expect(tokens.access_token).toBeDefined();
       expect(tokens.refresh_token).toBeUndefined();
       expect(tokens.token_type).toBe('bearer');
-      expect(tokens.expires_in).toBeLessThanOrEqual(300);
+      expect(tokens.expires_in).toBeGreaterThan(0);
       expect(tokens.scope).toBe('read write');
       expect(tokens.resource).toBe(resource);
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3057,6 +3057,67 @@ describe('OAuthProvider', () => {
       expect(await secondResponse.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
 
+    it('surfaces the typed EMA reason to onError.internal without leaking on the wire', async () => {
+      const captured: Array<Parameters<NonNullable<ConstructorParameters<typeof OAuthProvider>[0]['onError']>>[0]> = [];
+      const observableProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        scopesSupported: ['read', 'write'],
+        accessTokenTTL: 3600,
+        resourceMetadata: { resource },
+        onError: (error) => {
+          captured.push(error);
+        },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async () => ({ userId: 'u', scope: [], props: {} }),
+        },
+      });
+
+      // Register a client against the observable provider.
+      const registerResponse = await observableProvider.fetch(
+        createMockRequest('https://example.com/oauth/register', 'POST', { 'Content-Type': 'application/json' }, JSON.stringify({
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Observable',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })),
+        mockEnv,
+        mockCtx
+      );
+      const obsClient = await registerResponse.json<any>();
+
+      // Send a malformed assertion to trigger a generic invalid_grant.
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', 'this.is.notvalid');
+      const tokenResponse = await observableProvider.fetch(
+        createMockRequest('https://example.com/oauth/token', 'POST', {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${obsClient.client_id}:${obsClient.client_secret}`)}`,
+        }, params.toString()),
+        mockEnv,
+        mockCtx
+      );
+
+      // Wire response stays generic — no internal leak.
+      const wireBody = await tokenResponse.json<any>();
+      expect(wireBody).toEqual({ error: 'invalid_grant', error_description: 'Invalid assertion' });
+      expect(JSON.stringify(wireBody)).not.toContain('assertion_malformed');
+      expect(JSON.stringify(wireBody)).not.toContain('internal');
+
+      // onError receives the typed reason out-of-band.
+      expect(captured).toHaveLength(1);
+      expect(captured[0].internal).toEqual({
+        category: 'enterprise-managed-authorization',
+        reason: 'assertion_malformed',
+        detail: { reason: 'assertion_malformed' },
+      });
+    });
+
     it('should reject assertions signed by an unknown key', async () => {
       const otherKey = await createRsaJwtKey('other-key');
       const now = Math.floor(Date.now() / 1000);

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3077,11 +3077,16 @@ describe('OAuthProvider', () => {
       });
 
       const reg = await throwingProvider.fetch(
-        createMockRequest('https://example.com/oauth/register', 'POST', { 'Content-Type': 'application/json' }, JSON.stringify({
-          redirect_uris: ['https://client.example.com/callback'],
-          client_name: 'Throwing',
-          token_endpoint_auth_method: 'client_secret_basic',
-        })),
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Throwing',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
         mockEnv,
         mockCtx
       );
@@ -3092,10 +3097,15 @@ describe('OAuthProvider', () => {
       params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
       params.append('assertion', assertion);
       const response = await throwingProvider.fetch(
-        createMockRequest('https://example.com/oauth/token', 'POST', {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${btoa(`${throwClient.client_id}:${throwClient.client_secret}`)}`,
-        }, params.toString()),
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${throwClient.client_id}:${throwClient.client_secret}`)}`,
+          },
+          params.toString()
+        ),
         mockEnv,
         mockCtx
       );
@@ -3128,11 +3138,16 @@ describe('OAuthProvider', () => {
 
       // Register a client against the observable provider.
       const registerResponse = await observableProvider.fetch(
-        createMockRequest('https://example.com/oauth/register', 'POST', { 'Content-Type': 'application/json' }, JSON.stringify({
-          redirect_uris: ['https://client.example.com/callback'],
-          client_name: 'Observable',
-          token_endpoint_auth_method: 'client_secret_basic',
-        })),
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Observable',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
         mockEnv,
         mockCtx
       );
@@ -3143,10 +3158,15 @@ describe('OAuthProvider', () => {
       params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
       params.append('assertion', 'this.is.notvalid');
       const tokenResponse = await observableProvider.fetch(
-        createMockRequest('https://example.com/oauth/token', 'POST', {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${btoa(`${obsClient.client_id}:${obsClient.client_secret}`)}`,
-        }, params.toString()),
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${obsClient.client_id}:${obsClient.client_secret}`)}`,
+          },
+          params.toString()
+        ),
         mockEnv,
         mockCtx
       );

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3057,6 +3057,54 @@ describe('OAuthProvider', () => {
       expect(await secondResponse.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
 
+    it('catches mapClaims exceptions and emits a graceful invalid_grant', async () => {
+      const throwingProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        scopesSupported: ['read', 'write'],
+        accessTokenTTL: 3600,
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: () => {
+            throw new Error('mapper exploded');
+          },
+        },
+      });
+
+      const reg = await throwingProvider.fetch(
+        createMockRequest('https://example.com/oauth/register', 'POST', { 'Content-Type': 'application/json' }, JSON.stringify({
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Throwing',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })),
+        mockEnv,
+        mockCtx
+      );
+      const throwClient = await reg.json<any>();
+
+      const assertion = await createAssertion({ client_id: throwClient.client_id });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+      const response = await throwingProvider.fetch(
+        createMockRequest('https://example.com/oauth/token', 'POST', {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${throwClient.client_id}:${throwClient.client_secret}`)}`,
+        }, params.toString()),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
     it('surfaces the typed EMA reason to onError.internal without leaking on the wire', async () => {
       const captured: Array<Parameters<NonNullable<ConstructorParameters<typeof OAuthProvider>[0]['onError']>>[0]> = [];
       const observableProvider = new OAuthProvider({

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -2821,7 +2821,7 @@ describe('OAuthProvider', () => {
       );
     }
 
-    it('should advertise jwt-bearer grant only when enterprise-managed authorization is enabled', async () => {
+    it('should advertise jwt-bearer grant and id-jag profile only when enterprise-managed authorization is enabled', async () => {
       const enabledResponse = await enterpriseProvider.fetch(
         createMockRequest('https://example.com/.well-known/oauth-authorization-server'),
         mockEnv,
@@ -2829,6 +2829,9 @@ describe('OAuthProvider', () => {
       );
       const enabledMetadata = await enabledResponse.json<any>();
       expect(enabledMetadata.grant_types_supported).toContain('urn:ietf:params:oauth:grant-type:jwt-bearer');
+      expect(enabledMetadata.authorization_grant_profiles_supported).toEqual([
+        'urn:ietf:params:oauth:grant-profile:id-jag',
+      ]);
 
       const defaultResponse = await oauthProvider.fetch(
         createMockRequest('https://example.com/.well-known/oauth-authorization-server'),
@@ -2837,6 +2840,7 @@ describe('OAuthProvider', () => {
       );
       const defaultMetadata = await defaultResponse.json<any>();
       expect(defaultMetadata.grant_types_supported).not.toContain('urn:ietf:params:oauth:grant-type:jwt-bearer');
+      expect(defaultMetadata.authorization_grant_profiles_supported).toBeUndefined();
     });
 
     it('should exchange a valid ID-JAG for an access token with mapped props', async () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -107,6 +107,13 @@ type TestEnv = {
   OAUTH_PROVIDER: OAuthHelpers | null;
 };
 
+type TestJsonWebKey = JsonWebKey & {
+  kid?: string;
+  alg?: string;
+  use?: string;
+  key_ops?: string[];
+};
+
 // Simple API handler for testing
 class TestApiHandler extends WorkerEntrypoint<TestEnv> {
   fetch(request: Request) {
@@ -180,6 +187,80 @@ function createMockEnv(): TestEnv {
     OAUTH_KV: new MockKV(),
     OAUTH_PROVIDER: null, // Will be populated by the OAuthProvider
   };
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function jsonToBase64Url(value: Record<string, unknown>): string {
+  return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+async function createRsaJwtKey(kid = 'test-key'): Promise<{ privateKey: CryptoKey; publicJwk: TestJsonWebKey }> {
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify']
+  )) as CryptoKeyPair;
+
+  const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as TestJsonWebKey;
+  return {
+    privateKey: keyPair.privateKey,
+    publicJwk: {
+      ...publicJwk,
+      kid,
+      alg: 'RS256',
+      use: 'sig',
+      key_ops: ['verify'],
+    },
+  };
+}
+
+async function createEcJwtKey(kid = 'ec-key'): Promise<{ privateKey: CryptoKey; publicJwk: TestJsonWebKey }> {
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: 'ECDSA',
+      namedCurve: 'P-256',
+    },
+    true,
+    ['sign', 'verify']
+  )) as CryptoKeyPair;
+
+  const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as TestJsonWebKey;
+  return {
+    privateKey: keyPair.privateKey,
+    publicJwk: {
+      ...publicJwk,
+      kid,
+      alg: 'ES256',
+      use: 'sig',
+      key_ops: ['verify'],
+    },
+  };
+}
+
+async function signJwt(
+  privateKey: CryptoKey,
+  claims: Record<string, unknown>,
+  header: Record<string, unknown> = {}
+): Promise<string> {
+  const jwtHeader = { alg: 'RS256', typ: 'oauth-id-jag+jwt', kid: 'test-key', ...header };
+  const encodedHeader = jsonToBase64Url(jwtHeader);
+  const encodedClaims = jsonToBase64Url(claims);
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const signAlgorithm = jwtHeader.alg === 'ES256' ? { name: 'ECDSA', hash: 'SHA-256' } : { name: 'RSASSA-PKCS1-v1_5' };
+  const signature = await crypto.subtle.sign(signAlgorithm, privateKey, new TextEncoder().encode(signingInput));
+  return `${signingInput}.${bytesToBase64Url(new Uint8Array(signature))}`;
 }
 
 describe('OAuthProvider', () => {
@@ -2631,6 +2712,676 @@ describe('OAuthProvider', () => {
       expect(callbackOptions.grantType).toBe('urn:ietf:params:oauth:grant-type:token-exchange');
       expect(callbackOptions.scope).toEqual(['read', 'write']); // Grant scopes
       expect(callbackOptions.requestedScope).toEqual(['read', 'write']); // Requested scopes (no downscoping in this test)
+    });
+  });
+
+  describe('Enterprise-Managed Authorization JWT Bearer Grant', () => {
+    let privateKey: CryptoKey;
+    let publicJwk: TestJsonWebKey;
+    let clientId: string;
+    let clientSecret: string;
+    let enterpriseProvider: OAuthProvider<TestEnv>;
+    const issuer = 'https://idp.example.com';
+    const resource = 'https://example.com/api';
+
+    beforeEach(async () => {
+      const key = await createRsaJwtKey();
+      privateKey = key.privateKey;
+      publicJwk = key.publicJwk;
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        if (input === `${issuer}/jwks.json`) {
+          return new Response(JSON.stringify({ keys: [publicJwk] }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('not found', { status: 404 });
+      });
+
+      enterpriseProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        scopesSupported: ['read', 'write', 'profile'],
+        accessTokenTTL: 3600,
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async ({ claims, requestedScope }) => ({
+            userId: `enterprise-${claims.sub}`,
+            scope: requestedScope,
+            metadata: { enterpriseIssuer: claims.iss, enterpriseSubject: claims.sub },
+            props: { enterprise: true, subject: claims.sub, email: claims.email },
+          }),
+        },
+      });
+
+      const registerRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Enterprise Client',
+          token_endpoint_auth_method: 'client_secret_basic',
+        })
+      );
+
+      const registerResponse = await enterpriseProvider.fetch(registerRequest, mockEnv, mockCtx);
+      const client = await registerResponse.json<any>();
+      clientId = client.client_id;
+      clientSecret = client.client_secret;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    async function createAssertion(overrides: Record<string, unknown> = {}, header: Record<string, unknown> = {}) {
+      const now = Math.floor(Date.now() / 1000);
+      return signJwt(
+        privateKey,
+        {
+          iss: issuer,
+          sub: 'employee-123',
+          aud: 'https://example.com',
+          resource,
+          client_id: clientId,
+          jti: crypto.randomUUID(),
+          iat: now,
+          exp: now + 300,
+          scope: 'read write',
+          email: 'employee@example.com',
+          ...overrides,
+        },
+        header
+      );
+    }
+
+    async function exchangeAssertion(assertion: string, id = clientId, secret = clientSecret) {
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+
+      return enterpriseProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${id}:${secret}`)}`,
+          },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+    }
+
+    it('should advertise jwt-bearer grant only when enterprise-managed authorization is enabled', async () => {
+      const enabledResponse = await enterpriseProvider.fetch(
+        createMockRequest('https://example.com/.well-known/oauth-authorization-server'),
+        mockEnv,
+        mockCtx
+      );
+      const enabledMetadata = await enabledResponse.json<any>();
+      expect(enabledMetadata.grant_types_supported).toContain('urn:ietf:params:oauth:grant-type:jwt-bearer');
+
+      const defaultResponse = await oauthProvider.fetch(
+        createMockRequest('https://example.com/.well-known/oauth-authorization-server'),
+        mockEnv,
+        mockCtx
+      );
+      const defaultMetadata = await defaultResponse.json<any>();
+      expect(defaultMetadata.grant_types_supported).not.toContain('urn:ietf:params:oauth:grant-type:jwt-bearer');
+    });
+
+    it('should exchange a valid ID-JAG for an access token with mapped props', async () => {
+      const tokenResponse = await exchangeAssertion(await createAssertion());
+      expect(tokenResponse.status).toBe(200);
+      const tokens = await tokenResponse.json<any>();
+
+      expect(tokens.access_token).toBeDefined();
+      expect(tokens.refresh_token).toBeUndefined();
+      expect(tokens.token_type).toBe('bearer');
+      expect(tokens.expires_in).toBeLessThanOrEqual(300);
+      expect(tokens.scope).toBe('read write');
+      expect(tokens.resource).toBe(resource);
+
+      const apiResponse = await enterpriseProvider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: `Bearer ${tokens.access_token}`,
+        }),
+        mockEnv,
+        mockCtx
+      );
+      expect(apiResponse.status).toBe(200);
+      const apiResult = await apiResponse.json<any>();
+      expect(apiResult.user).toEqual({
+        enterprise: true,
+        subject: 'employee-123',
+        email: 'employee@example.com',
+      });
+    });
+
+    it('should accept ES256 assertions when the trusted issuer allows ES256', async () => {
+      const ecKey = await createEcJwtKey();
+      privateKey = ecKey.privateKey;
+      publicJwk = ecKey.publicJwk;
+
+      const esProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['ES256'] }),
+          mapClaims: async ({ requestedScope }) => ({
+            userId: 'enterprise-employee-123',
+            scope: requestedScope,
+            metadata: null,
+            props: { enterprise: true },
+          }),
+        },
+      });
+
+      const registerResponse = await esProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Enterprise Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const client = await registerResponse.json<any>();
+      const assertion = await createAssertion({ client_id: client.client_id }, { alg: 'ES256', kid: 'ec-key' });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+
+      const response = await esProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+          },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const tokens = await response.json<any>();
+
+      expect(response.status).toBe(200);
+      expect(tokens.access_token).toBeDefined();
+      expect(tokens.scope).toBe('read write');
+    });
+
+    it('should reject jwt-bearer grant when enterprise-managed authorization is disabled', async () => {
+      const assertion = await createAssertion();
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+          },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'unsupported_grant_type' });
+    });
+
+    it('should reject assertions with invalid typ', async () => {
+      const response = await exchangeAssertion(await createAssertion({}, { typ: 'JWT' }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject missing or malformed assertions', async () => {
+      const missingParams = new URLSearchParams();
+      missingParams.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+
+      const missingResponse = await enterpriseProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+          },
+          missingParams.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(missingResponse.status).toBe(400);
+      expect(await missingResponse.json<any>()).toMatchObject({ error: 'invalid_request' });
+
+      const malformedResponse = await exchangeAssertion('not-a-jwt');
+      expect(malformedResponse.status).toBe(400);
+      expect(await malformedResponse.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject alg none assertions', async () => {
+      const response = await exchangeAssertion(await createAssertion({}, { alg: 'none' }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject assertions with invalid audience', async () => {
+      const response = await exchangeAssertion(await createAssertion({ aud: 'https://other.example.com' }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject assertions from unknown issuers', async () => {
+      const response = await exchangeAssertion(await createAssertion({ iss: 'https://unknown-idp.example.com' }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject assertions for a different client_id', async () => {
+      const response = await exchangeAssertion(await createAssertion({ client_id: 'other-client' }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject assertions for an unacceptable resource', async () => {
+      const response = await exchangeAssertion(await createAssertion({ resource: 'https://evil.example.com/api' }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_target' });
+    });
+
+    it('should reject assertions with invalid OAuth scope-token characters', async () => {
+      const response = await exchangeAssertion(await createAssertion({ scope: 'read "write"' }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject expired assertions', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const response = await exchangeAssertion(await createAssertion({ iat: now - 600, exp: now - 1 }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject assertions with excessive lifetimes', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const response = await exchangeAssertion(await createAssertion({ iat: now, exp: now + 3600 }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject assertions issued too far in the future', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const response = await exchangeAssertion(await createAssertion({ iat: now + 120, exp: now + 300 }));
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject replayed assertion jti values', async () => {
+      const assertion = await createAssertion({ jti: 'fixed-jti' });
+      const firstResponse = await exchangeAssertion(assertion);
+      expect(firstResponse.status).toBe(200);
+
+      const secondResponse = await exchangeAssertion(assertion);
+      expect(secondResponse.status).toBe(400);
+      expect(await secondResponse.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject assertions signed by an unknown key', async () => {
+      const otherKey = await createRsaJwtKey('other-key');
+      const now = Math.floor(Date.now() / 1000);
+      const assertion = await signJwt(
+        otherKey.privateKey,
+        {
+          iss: issuer,
+          sub: 'employee-123',
+          aud: 'https://example.com',
+          resource,
+          client_id: clientId,
+          jti: crypto.randomUUID(),
+          iat: now,
+          exp: now + 300,
+          scope: 'read',
+        },
+        { kid: 'other-key' }
+      );
+
+      const response = await exchangeAssertion(assertion);
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should downscope requested and mapped scopes to assertion scopes', async () => {
+      const downscopingProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async ({ requestedScope }) => ({
+            userId: 'employee-123',
+            scope: [...requestedScope, 'admin'],
+            metadata: null,
+            props: { ok: true },
+          }),
+        },
+      });
+
+      const registerResponse = await downscopingProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Enterprise Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const client = await registerResponse.json<any>();
+      const assertion = await createAssertion({ client_id: client.client_id, scope: 'read write' });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+      params.append('scope', 'read admin');
+
+      const response = await downscopingProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+          },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const tokens = await response.json<any>();
+      expect(response.status).toBe(200);
+      expect(tokens.scope).toBe('read');
+    });
+
+    it('should reject mapped scopes with invalid OAuth scope-token characters', async () => {
+      const invalidScopeProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async () => ({
+            userId: 'employee-123',
+            scope: ['read', 'bad scope'],
+            metadata: null,
+            props: { ok: true },
+          }),
+        },
+      });
+
+      const registerResponse = await invalidScopeProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Enterprise Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const client = await registerResponse.json<any>();
+      const assertion = await createAssertion({ client_id: client.client_id });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+
+      const response = await invalidScopeProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+          },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should reject public clients for enterprise-managed authorization', async () => {
+      const publicRegisterResponse = await enterpriseProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://public.example.com/callback'],
+            client_name: 'Public Enterprise Client',
+            token_endpoint_auth_method: 'none',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const publicClient = await publicRegisterResponse.json<any>();
+      const assertion = await createAssertion({ client_id: publicClient.client_id });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+      params.append('client_id', publicClient.client_id);
+
+      const response = await enterpriseProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
+    });
+
+    it('should deny issuance when mapClaims returns null', async () => {
+      const denyingProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async () => null,
+        },
+      });
+
+      const registerResponse = await denyingProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Enterprise Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const client = await registerResponse.json<any>();
+      const assertion = await createAssertion({ client_id: client.client_id });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+
+      const response = await denyingProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+          },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('should require trustedIssuers to be a resolver function at construction time', () => {
+      const baseOptions = {
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        resourceMetadata: { resource },
+      };
+
+      expect(
+        () =>
+          new OAuthProvider({
+            ...baseOptions,
+            enterpriseManagedAuthorization: {
+              // @ts-expect-error — old static-array shape no longer accepted
+              trustedIssuers: [{ issuer, jwksUri: `${issuer}/jwks.json` }],
+              mapClaims: async () => ({ userId: 'user', scope: [], props: null }),
+            },
+          })
+      ).toThrow(/must be a resolver function/);
+    });
+
+    it('should reject EMA configuration without resourceMetadata.resource', () => {
+      expect(
+        () =>
+          new OAuthProvider({
+            apiRoute: ['/api/'],
+            apiHandler: TestApiHandler,
+            defaultHandler: testDefaultHandler,
+            authorizeEndpoint: '/authorize',
+            tokenEndpoint: '/oauth/token',
+            clientRegistrationEndpoint: '/oauth/register',
+            enterpriseManagedAuthorization: {
+              trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json` }),
+              mapClaims: async () => ({ userId: 'user', scope: [], props: null }),
+            },
+          })
+      ).toThrow(/resourceMetadata\.resource/);
+    });
+
+    it('should reject mapped user IDs that cannot be represented in opaque token format', async () => {
+      const colonUserProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async ({ claims, requestedScope }) => ({
+            userId: `${claims.iss}:${claims.sub}`,
+            scope: requestedScope,
+            metadata: null,
+            props: { ok: true },
+          }),
+        },
+      });
+
+      const registerResponse = await colonUserProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Enterprise Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const client = await registerResponse.json<any>();
+      const assertion = await createAssertion({ client_id: client.client_id });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+
+      const response = await colonUserProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.client_id}:${client.client_secret}`)}`,
+          },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
   });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -2749,7 +2749,7 @@ describe('OAuthProvider', () => {
         accessTokenTTL: 3600,
         resourceMetadata: { resource },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
           mapClaims: async ({ claims, requestedScope }) => ({
             userId: `enterprise-${claims.sub}`,
             scope: requestedScope,
@@ -2885,7 +2885,7 @@ describe('OAuthProvider', () => {
         clientRegistrationEndpoint: '/oauth/register',
         resourceMetadata: { resource },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['ES256'] }),
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['ES256'] }),
           mapClaims: async ({ requestedScope }) => ({
             userId: 'enterprise-employee-123',
             scope: requestedScope,
@@ -3069,8 +3069,8 @@ describe('OAuthProvider', () => {
         accessTokenTTL: 3600,
         resourceMetadata: { resource },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
-          mapClaims: () => {
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async () => {
             throw new Error('mapper exploded');
           },
         },
@@ -3121,7 +3121,7 @@ describe('OAuthProvider', () => {
           captured.push(error);
         },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
           mapClaims: async () => ({ userId: 'u', scope: [], props: {} }),
         },
       });
@@ -3200,7 +3200,7 @@ describe('OAuthProvider', () => {
         clientRegistrationEndpoint: '/oauth/register',
         resourceMetadata: { resource },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
           mapClaims: async ({ requestedScope }) => ({
             userId: 'employee-123',
             scope: [...requestedScope, 'admin'],
@@ -3259,7 +3259,7 @@ describe('OAuthProvider', () => {
         clientRegistrationEndpoint: '/oauth/register',
         resourceMetadata: { resource },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
           mapClaims: async () => ({
             userId: 'employee-123',
             scope: ['read', 'bad scope'],
@@ -3354,7 +3354,7 @@ describe('OAuthProvider', () => {
         clientRegistrationEndpoint: '/oauth/register',
         resourceMetadata: { resource },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
           mapClaims: async () => null,
         },
       });
@@ -3432,7 +3432,7 @@ describe('OAuthProvider', () => {
             tokenEndpoint: '/oauth/token',
             clientRegistrationEndpoint: '/oauth/register',
             enterpriseManagedAuthorization: {
-              trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json` }),
+              trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json` }),
               mapClaims: async () => ({ userId: 'user', scope: [], props: null }),
             },
           })
@@ -3449,7 +3449,7 @@ describe('OAuthProvider', () => {
         clientRegistrationEndpoint: '/oauth/register',
         resourceMetadata: { resource },
         enterpriseManagedAuthorization: {
-          trustedIssuers: () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
           mapClaims: async ({ claims, requestedScope }) => ({
             userId: `${claims.iss}:${claims.sub}`,
             scope: requestedScope,

--- a/src/ema/constants.ts
+++ b/src/ema/constants.ts
@@ -1,0 +1,43 @@
+/**
+ * Constants for MCP Enterprise-Managed Authorization (EMA).
+ *
+ * Co-located so that anyone touching the EMA code path sees every magic
+ * number in one place. Public-facing defaults can be overridden via
+ * `EmaOptions`.
+ */
+
+/** JWT `typ` header value required for ID-JAG assertions (RFC 8725 §3.11). */
+export const EMA_ID_JAG_JWT_TYPE = 'oauth-id-jag+jwt';
+
+/** Maximum compact JWT assertion size accepted at the token endpoint. */
+export const EMA_MAX_JWT_BYTES = 16 * 1024;
+
+/** Maximum JWKS response size accepted from a trusted enterprise IdP. */
+export const EMA_JWKS_MAX_SIZE_BYTES = 64 * 1024;
+
+/** Request timeout for JWKS fetches. */
+export const EMA_JWKS_FETCH_TIMEOUT_MS = 10_000;
+
+/** Default JWKS cache TTL. */
+export const EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS = 5 * 60;
+
+/** Default allowed clock skew for ID-JAG time claim validation. */
+export const EMA_DEFAULT_CLOCK_SKEW_SECONDS = 60;
+
+/** Default maximum accepted ID-JAG lifetime. */
+export const EMA_DEFAULT_MAX_ASSERTION_LIFETIME_SECONDS = 5 * 60;
+
+/**
+ * Minimum cool-down between JWKS force-refreshes per issuer.
+ * Defends against attackers that send many assertions with random `kid`
+ * values to amplify load on the IdP's JWKS endpoint.
+ */
+export const EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS = 30;
+
+/** Default JWT signing algorithm assumed for a trusted issuer. */
+export const EMA_DEFAULT_JWT_ALGORITHM = 'RS256';
+
+/** JWT signing algorithms supported by the built-in WebCrypto verifier. */
+export const EMA_SUPPORTED_JWT_ALGORITHMS = new Set(['RS256', 'ES256'] as const);
+
+export type EmaSupportedAlg = 'RS256' | 'ES256';

--- a/src/ema/constants.ts
+++ b/src/ema/constants.ts
@@ -9,6 +9,12 @@
 /** JWT `typ` header value required for ID-JAG assertions (RFC 8725 §3.11). */
 export const EMA_ID_JAG_JWT_TYPE = 'oauth-id-jag+jwt';
 
+/**
+ * Grant-profile URN advertised in `authorization_grant_profiles_supported`
+ * when EMA is configured (MCP Enterprise-Managed Authorization spec).
+ */
+export const EMA_ID_JAG_GRANT_PROFILE = 'urn:ietf:params:oauth:grant-profile:id-jag';
+
 /** Maximum compact JWT assertion size accepted at the token endpoint. */
 export const EMA_MAX_JWT_BYTES = 16 * 1024;
 

--- a/src/ema/jti.ts
+++ b/src/ema/jti.ts
@@ -1,0 +1,49 @@
+/**
+ * JTI replay-protection store.
+ *
+ * The default implementation uses the provider's `OAUTH_KV` binding. KV is
+ * eventually-consistent and does not provide compare-and-set, so two
+ * concurrent requests with the same `jti` can both observe "not seen" and
+ * succeed — the trade-off accepted for the default. Deployers needing
+ * strict-once semantics under concurrency should supply a Durable
+ * Object-backed `EmaJtiStore` via `EmaOptions.jtiStore`.
+ */
+
+import { sha256Hex } from './util';
+import type { EmaJtiMarkResult, EmaJtiStore } from './types';
+
+/** Storage key prefix for replay markers. Stable across versions. */
+const EMA_JTI_KV_PREFIX = 'enterprise-jti:';
+
+/**
+ * Create the default KV-backed JTI store. KV TTL handles cleanup.
+ */
+export function createKvJtiStore(): EmaJtiStore {
+  return {
+    async markUsed({ issuer, jti, exp, now, env }) {
+      const ttl = Math.max(1, exp - now);
+      const jtiHash = await sha256Hex(`${issuer}\n${jti}`);
+      const key = `${EMA_JTI_KV_PREFIX}${jtiHash}`;
+      const existing = await env.OAUTH_KV.get(key);
+      if (existing) {
+        return { ok: false, reason: 'replayed' };
+      }
+      await env.OAUTH_KV.put(key, '1', { expirationTtl: ttl });
+      return { ok: true };
+    },
+  };
+}
+
+/**
+ * Translate an `EmaJtiStore.markUsed` result into the in-band Result type
+ * used by the EMA pipeline.
+ */
+export function jtiMarkResultToResult(
+  result: EmaJtiMarkResult,
+  jti: string
+): import('./result').Result<void, import('./result').EmaValidationError> {
+  if (result.ok) return { ok: true, value: undefined };
+  return { ok: false, error: { reason: 'replayed', jti } };
+}
+
+export type { EmaJtiMarkResult, EmaJtiStore } from './types';

--- a/src/ema/jti.ts
+++ b/src/ema/jti.ts
@@ -1,12 +1,11 @@
 /**
  * JTI replay-protection store.
  *
- * The default implementation uses the provider's `OAUTH_KV` binding. KV is
- * eventually-consistent and does not provide compare-and-set, so two
- * concurrent requests with the same `jti` can both observe "not seen" and
- * succeed — the trade-off accepted for the default. Deployers needing
- * strict-once semantics under concurrency should supply a Durable
- * Object-backed `EmaJtiStore` via `EmaOptions.jtiStore`.
+ * Uses the provider's `OAUTH_KV` binding. KV is eventually-consistent and
+ * does not provide compare-and-set, so two concurrent requests with the
+ * same `jti` can both observe "not seen" and succeed — the trade-off
+ * accepted for the default. Other claim checks (signature, `exp`, `nbf`,
+ * `aud`, `resource`, client binding) constrain the practical attack window.
  */
 
 import { sha256Hex } from './util';
@@ -45,5 +44,3 @@ export function jtiMarkResultToResult(
   if (result.ok) return { ok: true, value: undefined };
   return { ok: false, error: { reason: 'replayed', jti } };
 }
-
-export type { EmaJtiMarkResult, EmaJtiStore } from './types';

--- a/src/ema/jti.ts
+++ b/src/ema/jti.ts
@@ -1,22 +1,21 @@
 /**
- * JTI replay-protection store.
+ * Default `EmaJtiStore`: KV-backed `jti` replay marker.
  *
- * Uses the provider's `OAUTH_KV` binding. KV is eventually-consistent and
- * does not provide compare-and-set, so two concurrent requests with the
- * same `jti` can both observe "not seen" and succeed — the trade-off
- * accepted for the default. Other claim checks (signature, `exp`, `nbf`,
- * `aud`, `resource`, client binding) constrain the practical attack window.
+ * KV is eventually-consistent and does not provide compare-and-set, so two
+ * concurrent requests with the same `jti` can both observe "not seen" and
+ * succeed — the trade-off accepted here. Surrounding claim checks
+ * (signature, `exp`, `nbf`, `aud`, `resource`, client binding) constrain
+ * the practical attack window.
  */
 
+import { err, ok } from './result';
+import type { EmaJtiStore } from './types';
 import { sha256Hex } from './util';
-import type { EmaJtiMarkResult, EmaJtiStore } from './types';
 
 /** Storage key prefix for replay markers. Stable across versions. */
 const EMA_JTI_KV_PREFIX = 'enterprise-jti:';
 
-/**
- * Create the default KV-backed JTI store. KV TTL handles cleanup.
- */
+/** Create the default KV-backed JTI store. KV TTL handles cleanup. */
 export function createKvJtiStore(): EmaJtiStore {
   return {
     async markUsed({ issuer, jti, exp, now, env }) {
@@ -25,22 +24,10 @@ export function createKvJtiStore(): EmaJtiStore {
       const key = `${EMA_JTI_KV_PREFIX}${jtiHash}`;
       const existing = await env.OAUTH_KV.get(key);
       if (existing) {
-        return { ok: false, reason: 'replayed' };
+        return err({ reason: 'replayed', jti });
       }
       await env.OAUTH_KV.put(key, '1', { expirationTtl: ttl });
-      return { ok: true };
+      return ok(undefined);
     },
   };
-}
-
-/**
- * Translate an `EmaJtiStore.markUsed` result into the in-band Result type
- * used by the EMA pipeline.
- */
-export function jtiMarkResultToResult(
-  result: EmaJtiMarkResult,
-  jti: string
-): import('./result').Result<void, import('./result').EmaValidationError> {
-  if (result.ok) return { ok: true, value: undefined };
-  return { ok: false, error: { reason: 'replayed', jti } };
 }

--- a/src/ema/jwks.ts
+++ b/src/ema/jwks.ts
@@ -44,7 +44,12 @@ export function createDefaultJwksProvider(opts: DefaultJwksProviderOptions = {})
       }
 
       // Anti-DoS: serve the cached JWKS rather than spam the IdP when a
-      // force-refresh is requested too soon after the previous one.
+      // force-refresh is requested too soon after the previous one. The
+      // `force_refresh_throttled` variant is intentionally NOT produced
+      // here — the default provider degrades silently to the cached copy.
+      // The variant exists for callers (or future custom providers) that
+      // want stricter signalling, and the pipeline's defensive handler
+      // collapses it to `jwks_fetch_failed` for safety.
       if (forceRefresh && cached && cached.nextForceRefreshAllowedAt > now) {
         return { ok: true, jwks: cached.jwks };
       }

--- a/src/ema/jwks.ts
+++ b/src/ema/jwks.ts
@@ -1,0 +1,160 @@
+/**
+ * JWKS provider — fetches IdP signing keys with caching and a force-refresh
+ * cool-down to defend against attackers that spam random `kid` values to
+ * amplify load on the IdP's JWKS endpoint.
+ *
+ * The default implementation is a closure over an in-memory `Map`. Deployers
+ * who need a stronger cache (e.g. shared across isolates) can supply a
+ * custom `EmaJwksProvider` via `EmaOptions.jwksProvider`.
+ */
+
+import {
+  EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS,
+  EMA_JWKS_FETCH_TIMEOUT_MS,
+  EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS,
+  EMA_JWKS_MAX_SIZE_BYTES,
+} from './constants';
+import type { EmaJwksFetchResult, EmaJwksProvider, EmaTrustedIssuer, JsonWebKeySet, OAuthJsonWebKey } from './types';
+
+interface JwksCacheEntry {
+  jwks: JsonWebKeySet;
+  expiresAt: number;
+  /** Earliest time at which a force-refresh against the IdP is permitted. */
+  nextForceRefreshAllowedAt: number;
+}
+
+interface DefaultJwksProviderOptions {
+  /** Cache TTL in seconds; defaults to `EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS`. */
+  cacheTtlSeconds?: number;
+  /** Optional override of the fetch implementation (mainly for tests). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Create the default JWKS provider — a closure with its own private cache.
+ */
+export function createDefaultJwksProvider(opts: DefaultJwksProviderOptions = {}): EmaJwksProvider {
+  const cache = new Map<string, JwksCacheEntry>();
+  const cacheTtl = opts.cacheTtlSeconds ?? EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS;
+  const httpFetch = opts.fetchImpl ?? fetch;
+
+  return {
+    async fetch(issuer, { forceRefresh, now }) {
+      const cached = cache.get(issuer.issuer);
+
+      if (!forceRefresh && cached && cached.expiresAt > now) {
+        return { ok: true, jwks: cached.jwks };
+      }
+
+      // Anti-DoS: serve the cached JWKS rather than spam the IdP when a
+      // force-refresh is requested too soon after the previous one.
+      if (forceRefresh && cached && cached.nextForceRefreshAllowedAt > now) {
+        return { ok: true, jwks: cached.jwks };
+      }
+
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(() => abortController.abort(), EMA_JWKS_FETCH_TIMEOUT_MS);
+
+      try {
+        const response = await httpFetch(issuer.jwksUri, {
+          headers: { Accept: 'application/json' },
+          signal: abortController.signal,
+          cf: { cacheEverything: true },
+        } as RequestInit);
+
+        if (!response.ok) {
+          return { ok: false, reason: 'fetch_failed', status: response.status };
+        }
+
+        const contentLength = response.headers.get('content-length');
+        if (contentLength && parseInt(contentLength, 10) > EMA_JWKS_MAX_SIZE_BYTES) {
+          return { ok: false, reason: 'fetch_failed', status: response.status };
+        }
+
+        const rawJwks = await readJsonWithSizeLimit(response, EMA_JWKS_MAX_SIZE_BYTES);
+        if (!rawJwks.ok) return rawJwks;
+        if (!Array.isArray(rawJwks.value.keys)) {
+          return { ok: false, reason: 'fetch_failed' };
+        }
+
+        const jwks: JsonWebKeySet = { keys: rawJwks.value.keys as OAuthJsonWebKey[] };
+        cache.set(issuer.issuer, {
+          jwks,
+          expiresAt: now + cacheTtl,
+          nextForceRefreshAllowedAt: now + EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS,
+        });
+        return { ok: true, jwks };
+      } catch {
+        return { ok: false, reason: 'fetch_failed' };
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    },
+  };
+}
+
+/**
+ * Streaming JSON reader that rejects responses exceeding `maxBytes`.
+ * Bounds memory consumption before we attempt to JSON-parse the body.
+ */
+async function readJsonWithSizeLimit(response: Response, maxBytes: number): Promise<EmaJwksReadResult> {
+  if (!response.body) return { ok: false, reason: 'fetch_failed' };
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        reader.cancel();
+        return { ok: false, reason: 'fetch_failed' };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(merged));
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { ok: false, reason: 'fetch_failed' };
+    }
+    return { ok: true, value: parsed as { keys?: unknown } };
+  } catch {
+    return { ok: false, reason: 'fetch_failed' };
+  }
+}
+
+type EmaJwksReadResult = { ok: true; value: { keys?: unknown } } | { ok: false; reason: 'fetch_failed' };
+
+// Re-export the wire-level Result type so callers don't have to dig.
+export type { EmaJwksFetchResult, EmaJwksProvider } from './types';
+
+/**
+ * Translate an `EmaJwksProvider` adapter result into the in-band Result type
+ * used by the EMA pipeline. Local helper for `OAuthProviderImpl.fetchJwks`.
+ */
+export function jwksFetchResultToResult(
+  result: EmaJwksFetchResult
+): import('./result').Result<JsonWebKeySet, import('./result').EmaValidationError> {
+  if (result.ok) {
+    return { ok: true, value: result.jwks };
+  }
+  if (result.reason === 'force_refresh_throttled') {
+    // Shouldn't reach the pipeline; treat as cache-hit upstream. If it does,
+    // surface as a fetch failure rather than crash.
+    return { ok: false, error: { reason: 'jwks_fetch_failed' } };
+  }
+  return { ok: false, error: { reason: 'jwks_fetch_failed', status: result.status } };
+}

--- a/src/ema/jwks.ts
+++ b/src/ema/jwks.ts
@@ -1,11 +1,8 @@
 /**
  * JWKS provider — fetches IdP signing keys with caching and a force-refresh
  * cool-down to defend against attackers that spam random `kid` values to
- * amplify load on the IdP's JWKS endpoint.
- *
- * The default implementation is a closure over an in-memory `Map`. Deployers
- * who need a stronger cache (e.g. shared across isolates) can supply a
- * custom `EmaJwksProvider` via `EmaOptions.jwksProvider`.
+ * amplify load on the IdP's JWKS endpoint. Implemented as a closure over
+ * an in-memory `Map`.
  */
 
 import {
@@ -138,13 +135,7 @@ async function readJsonWithSizeLimit(response: Response, maxBytes: number): Prom
 
 type EmaJwksReadResult = { ok: true; value: { keys?: unknown } } | { ok: false; reason: 'fetch_failed' };
 
-// Re-export the wire-level Result type so callers don't have to dig.
-export type { EmaJwksFetchResult, EmaJwksProvider } from './types';
-
-/**
- * Translate an `EmaJwksProvider` adapter result into the in-band Result type
- * used by the EMA pipeline. Local helper for `OAuthProviderImpl.fetchJwks`.
- */
+/** Translate an `EmaJwksProvider` fetch result into the in-band Result type used by the EMA pipeline. */
 export function jwksFetchResultToResult(
   result: EmaJwksFetchResult
 ): import('./result').Result<JsonWebKeySet, import('./result').EmaValidationError> {

--- a/src/ema/jwks.ts
+++ b/src/ema/jwks.ts
@@ -1,8 +1,10 @@
 /**
- * JWKS provider — fetches IdP signing keys with caching and a force-refresh
- * cool-down to defend against attackers that spam random `kid` values to
- * amplify load on the IdP's JWKS endpoint. Implemented as a closure over
- * an in-memory `Map`.
+ * Default `EmaJwksProvider`: fetches IdP signing keys with caching and a
+ * force-refresh cool-down. The cool-down defends against attackers that
+ * spam random `kid` values to amplify load on the IdP's JWKS endpoint.
+ *
+ * The cache lives inside the returned provider closure, so each
+ * `OAuthProvider` instance has its own cache — no cross-instance bleed.
  */
 
 import {
@@ -11,7 +13,8 @@ import {
   EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS,
   EMA_JWKS_MAX_SIZE_BYTES,
 } from './constants';
-import type { EmaJwksFetchResult, EmaJwksProvider, EmaTrustedIssuer, JsonWebKeySet, OAuthJsonWebKey } from './types';
+import { err, ok } from './result';
+import type { EmaJwksProvider, JsonWebKeySet, OAuthJsonWebKey } from './types';
 
 interface JwksCacheEntry {
   jwks: JsonWebKeySet;
@@ -23,60 +26,50 @@ interface JwksCacheEntry {
 interface DefaultJwksProviderOptions {
   /** Cache TTL in seconds; defaults to `EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS`. */
   cacheTtlSeconds?: number;
-  /** Optional override of the fetch implementation (mainly for tests). */
-  fetchImpl?: typeof fetch;
 }
 
-/**
- * Create the default JWKS provider — a closure with its own private cache.
- */
+/** Create the default JWKS provider — a closure with its own private cache. */
 export function createDefaultJwksProvider(opts: DefaultJwksProviderOptions = {}): EmaJwksProvider {
   const cache = new Map<string, JwksCacheEntry>();
   const cacheTtl = opts.cacheTtlSeconds ?? EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS;
-  const httpFetch = opts.fetchImpl ?? fetch;
 
   return {
     async fetch(issuer, { forceRefresh, now }) {
       const cached = cache.get(issuer.issuer);
 
       if (!forceRefresh && cached && cached.expiresAt > now) {
-        return { ok: true, jwks: cached.jwks };
+        return ok(cached.jwks);
       }
 
       // Anti-DoS: serve the cached JWKS rather than spam the IdP when a
-      // force-refresh is requested too soon after the previous one. The
-      // `force_refresh_throttled` variant is intentionally NOT produced
-      // here — the default provider degrades silently to the cached copy.
-      // The variant exists for callers (or future custom providers) that
-      // want stricter signalling, and the pipeline's defensive handler
-      // collapses it to `jwks_fetch_failed` for safety.
+      // force-refresh is requested too soon after the previous one.
       if (forceRefresh && cached && cached.nextForceRefreshAllowedAt > now) {
-        return { ok: true, jwks: cached.jwks };
+        return ok(cached.jwks);
       }
 
       const abortController = new AbortController();
       const timeoutId = setTimeout(() => abortController.abort(), EMA_JWKS_FETCH_TIMEOUT_MS);
 
       try {
-        const response = await httpFetch(issuer.jwksUri, {
+        const response = await fetch(issuer.jwksUri, {
           headers: { Accept: 'application/json' },
           signal: abortController.signal,
           cf: { cacheEverything: true },
         } as RequestInit);
 
         if (!response.ok) {
-          return { ok: false, reason: 'fetch_failed', status: response.status };
+          return err({ reason: 'jwks_fetch_failed', status: response.status });
         }
 
         const contentLength = response.headers.get('content-length');
         if (contentLength && parseInt(contentLength, 10) > EMA_JWKS_MAX_SIZE_BYTES) {
-          return { ok: false, reason: 'fetch_failed', status: response.status };
+          return err({ reason: 'jwks_fetch_failed', status: response.status });
         }
 
         const rawJwks = await readJsonWithSizeLimit(response, EMA_JWKS_MAX_SIZE_BYTES);
-        if (!rawJwks.ok) return rawJwks;
+        if (!rawJwks.ok) return err({ reason: 'jwks_fetch_failed' });
         if (!Array.isArray(rawJwks.value.keys)) {
-          return { ok: false, reason: 'fetch_failed' };
+          return err({ reason: 'jwks_fetch_failed' });
         }
 
         const jwks: JsonWebKeySet = { keys: rawJwks.value.keys as OAuthJsonWebKey[] };
@@ -85,9 +78,9 @@ export function createDefaultJwksProvider(opts: DefaultJwksProviderOptions = {})
           expiresAt: now + cacheTtl,
           nextForceRefreshAllowedAt: now + EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS,
         });
-        return { ok: true, jwks };
+        return ok(jwks);
       } catch {
-        return { ok: false, reason: 'fetch_failed' };
+        return err({ reason: 'jwks_fetch_failed' });
       } finally {
         clearTimeout(timeoutId);
       }
@@ -99,8 +92,11 @@ export function createDefaultJwksProvider(opts: DefaultJwksProviderOptions = {})
  * Streaming JSON reader that rejects responses exceeding `maxBytes`.
  * Bounds memory consumption before we attempt to JSON-parse the body.
  */
-async function readJsonWithSizeLimit(response: Response, maxBytes: number): Promise<EmaJwksReadResult> {
-  if (!response.body) return { ok: false, reason: 'fetch_failed' };
+async function readJsonWithSizeLimit(
+  response: Response,
+  maxBytes: number
+): Promise<{ ok: true; value: { keys?: unknown } } | { ok: false }> {
+  if (!response.body) return { ok: false };
 
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
@@ -112,7 +108,7 @@ async function readJsonWithSizeLimit(response: Response, maxBytes: number): Prom
       total += value.byteLength;
       if (total > maxBytes) {
         reader.cancel();
-        return { ok: false, reason: 'fetch_failed' };
+        return { ok: false };
       }
       chunks.push(value);
     }
@@ -130,27 +126,10 @@ async function readJsonWithSizeLimit(response: Response, maxBytes: number): Prom
   try {
     const parsed = JSON.parse(new TextDecoder().decode(merged));
     if (typeof parsed !== 'object' || parsed === null) {
-      return { ok: false, reason: 'fetch_failed' };
+      return { ok: false };
     }
     return { ok: true, value: parsed as { keys?: unknown } };
   } catch {
-    return { ok: false, reason: 'fetch_failed' };
+    return { ok: false };
   }
-}
-
-type EmaJwksReadResult = { ok: true; value: { keys?: unknown } } | { ok: false; reason: 'fetch_failed' };
-
-/** Translate an `EmaJwksProvider` fetch result into the in-band Result type used by the EMA pipeline. */
-export function jwksFetchResultToResult(
-  result: EmaJwksFetchResult
-): import('./result').Result<JsonWebKeySet, import('./result').EmaValidationError> {
-  if (result.ok) {
-    return { ok: true, value: result.jwks };
-  }
-  if (result.reason === 'force_refresh_throttled') {
-    // Shouldn't reach the pipeline; treat as cache-hit upstream. If it does,
-    // surface as a fetch failure rather than crash.
-    return { ok: false, error: { reason: 'jwks_fetch_failed' } };
-  }
-  return { ok: false, error: { reason: 'jwks_fetch_failed', status: result.status } };
 }

--- a/src/ema/jwks.ts
+++ b/src/ema/jwks.ts
@@ -43,6 +43,12 @@ export function createDefaultJwksProvider(opts: DefaultJwksProviderOptions = {})
 
       // Anti-DoS: serve the cached JWKS rather than spam the IdP when a
       // force-refresh is requested too soon after the previous one.
+      //
+      // Returning stale keys is safe — signature verification still has to
+      // succeed against them. If the IdP genuinely rotated, the verify step
+      // will reject, the assertion path will fail with `no_matching_key` or
+      // `signature_failed`, and the next force-refresh after the cooldown
+      // window will pick up the new key.
       if (forceRefresh && cached && cached.nextForceRefreshAllowedAt > now) {
         return ok(cached.jwks);
       }

--- a/src/ema/parser.ts
+++ b/src/ema/parser.ts
@@ -24,8 +24,13 @@ export function parseIdJag(assertion: string, maxBytes: number): Result<ParsedId
     return err({ reason: 'assertion_missing' });
   }
 
-  if (assertion.length > maxBytes) {
-    return err({ reason: 'assertion_too_large', size: assertion.length, max: maxBytes });
+  // Measure actual UTF-8 bytes — `string.length` is UTF-16 code units, which
+  // disagrees with the byte semantics promised by `maxBytes` for any
+  // non-ASCII input. A well-formed compact JWS is ASCII-only, but rejecting
+  // pre-base64-decode keeps the DoS bound honest.
+  const byteLength = new TextEncoder().encode(assertion).byteLength;
+  if (byteLength > maxBytes) {
+    return err({ reason: 'assertion_too_large', size: byteLength, max: maxBytes });
   }
 
   const parts = assertion.split('.');

--- a/src/ema/parser.ts
+++ b/src/ema/parser.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure JWT parsing for ID-JAG assertions.
+ *
+ * Splits a compact JWS (`<base64url-header>.<base64url-payload>.<base64url-signature>`)
+ * into its three parts, decodes header and payload as JSON, and exposes the
+ * raw signing input + signature bytes for downstream signature verification.
+ *
+ * No I/O. No `this`. Returns `Result<ParsedIdJag, EmaValidationError>`.
+ */
+
+import { base64UrlToBytes, parseJwtJsonPart } from '../oauth-provider';
+import { err, ok, type EmaValidationError, type Result } from './result';
+import type { ParsedIdJag } from './types';
+
+/**
+ * Parse a compact JWS assertion.
+ *
+ * @param assertion The raw assertion string from the token request body.
+ * @param maxBytes Reject assertions whose length exceeds this many bytes.
+ *   Guards against memory exhaustion before any JSON parsing happens.
+ */
+export function parseIdJag(assertion: string, maxBytes: number): Result<ParsedIdJag, EmaValidationError> {
+  if (typeof assertion !== 'string' || assertion.length === 0) {
+    return err({ reason: 'assertion_missing' });
+  }
+
+  if (assertion.length > maxBytes) {
+    return err({ reason: 'assertion_too_large', size: assertion.length, max: maxBytes });
+  }
+
+  const parts = assertion.split('.');
+  if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    return err({ reason: 'assertion_malformed' });
+  }
+
+  const [encodedHeader, encodedClaims, encodedSignature] = parts;
+
+  let header: Record<string, unknown>;
+  let rawClaims: Record<string, unknown>;
+  let signature: Uint8Array;
+  try {
+    header = parseJwtJsonPart(encodedHeader);
+    rawClaims = parseJwtJsonPart(encodedClaims);
+    signature = base64UrlToBytes(encodedSignature);
+  } catch {
+    return err({ reason: 'assertion_malformed' });
+  }
+
+  const signingInput = new TextEncoder().encode(`${encodedHeader}.${encodedClaims}`);
+
+  return ok({ header, rawClaims, signingInput, signature });
+}

--- a/src/ema/parser.ts
+++ b/src/ema/parser.ts
@@ -24,13 +24,12 @@ export function parseIdJag(assertion: string, maxBytes: number): Result<ParsedId
     return err({ reason: 'assertion_missing' });
   }
 
-  // Measure actual UTF-8 bytes — `string.length` is UTF-16 code units, which
-  // disagrees with the byte semantics promised by `maxBytes` for any
-  // non-ASCII input. A well-formed compact JWS is ASCII-only, but rejecting
-  // pre-base64-decode keeps the DoS bound honest.
-  const byteLength = new TextEncoder().encode(assertion).byteLength;
-  if (byteLength > maxBytes) {
-    return err({ reason: 'assertion_too_large', size: byteLength, max: maxBytes });
+  // Compact JWS is ASCII-only (RFC 7515 §3.1), so `string.length` (UTF-16
+  // code units) equals the UTF-8 byte count. Non-ASCII input fails the
+  // base64url decode below, so the byte cap is honored without allocating
+  // the UTF-8 bytes just to measure them.
+  if (assertion.length > maxBytes) {
+    return err({ reason: 'assertion_too_large', size: assertion.length, max: maxBytes });
   }
 
   const parts = assertion.split('.');

--- a/src/ema/result.ts
+++ b/src/ema/result.ts
@@ -72,7 +72,6 @@ export function emaErrorToWire(e: EmaValidationError): EmaErrorWireResponse {
       return { code: 'invalid_target', message: 'Invalid resource' };
 
     case 'mapper_denied':
-      return { code: 'invalid_grant', message: 'Assertion was not authorized' };
     case 'mapper_threw':
       return { code: 'invalid_grant', message: 'Assertion was not authorized' };
     case 'invalid_mapped_user':

--- a/src/ema/result.ts
+++ b/src/ema/result.ts
@@ -1,0 +1,129 @@
+/**
+ * Hand-rolled Result type and EMA-specific tagged error union.
+ *
+ * Every pure EMA validator returns `Result<T, EmaValidationError>`. The
+ * orchestrator chains them with explicit `if (!r.ok) return r` checks — no
+ * library, no hidden control flow. The wire-level error string is intentionally
+ * generic for security (RFC 6749 §5.2), but the rich tagged `reason` flows to
+ * the deployer-supplied `onError` hook so failures are still debuggable.
+ */
+
+export type Result<T, E> = { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: E };
+
+export const ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
+export const err = <E>(error: E): Result<never, E> => ({ ok: false, error });
+
+/**
+ * Tagged union of every validation failure that can occur on the EMA token
+ * endpoint path. Extend by adding a new arm; the exhaustive `switch` in
+ * `emaErrorToWire` will surface unhandled cases at compile time.
+ */
+export type EmaValidationError =
+  | { reason: 'assertion_missing' }
+  | { reason: 'assertion_too_large'; size: number; max: number }
+  | { reason: 'assertion_malformed' }
+  | { reason: 'invalid_typ'; got?: unknown }
+  | { reason: 'invalid_alg'; got?: unknown }
+  | { reason: 'issuer_not_trusted'; iss: string }
+  | { reason: 'no_matching_key'; kid?: string }
+  | { reason: 'signature_failed' }
+  | { reason: 'jwks_fetch_failed'; status?: number }
+  | { reason: 'invalid_claim'; claim: string }
+  | { reason: 'aud_mismatch'; expected: string; got: string | string[] }
+  | { reason: 'expired'; exp: number; now: number }
+  | { reason: 'iat_in_future'; iat: number; now: number; skew: number }
+  | { reason: 'nbf_in_future'; nbf: number; now: number; skew: number }
+  | { reason: 'lifetime_too_long'; lifetime: number; max: number }
+  | { reason: 'replayed'; jti: string }
+  | { reason: 'client_id_mismatch'; expected: string; got: string }
+  | { reason: 'resource_invalid'; resource: string }
+  | { reason: 'resource_mismatch'; expected: string; got: string }
+  | { reason: 'invalid_scope_param' }
+  | { reason: 'invalid_mapped_user' }
+  | { reason: 'invalid_mapped_scope' }
+  | { reason: 'invalid_mapped_props' }
+  | { reason: 'invalid_mapped_ttl' }
+  | { reason: 'mapper_denied' }
+  | { reason: 'assertion_expired_after_processing' };
+
+/** Wire-level error response that the AS returns to the client. */
+export interface EmaErrorWireResponse {
+  code: 'invalid_grant' | 'invalid_target' | 'invalid_request';
+  message: string;
+}
+
+/**
+ * Map an internal `EmaValidationError` to its public OAuth error code and
+ * description. Most validation failures collapse to a single generic message
+ * to avoid leaking which check failed to attackers probing the IdP. The
+ * exceptions are RFC-prescribed distinct codes (`invalid_target` for
+ * RFC 8707 resource issues, `invalid_request` for malformed input).
+ */
+export function emaErrorToWire(e: EmaValidationError): EmaErrorWireResponse {
+  switch (e.reason) {
+    case 'assertion_missing':
+      return { code: 'invalid_request', message: 'assertion is required' };
+    case 'invalid_scope_param':
+      return { code: 'invalid_request', message: 'Invalid scope parameter format' };
+    case 'resource_invalid':
+    case 'resource_mismatch':
+      return { code: 'invalid_target', message: 'Invalid resource' };
+
+    case 'mapper_denied':
+      return { code: 'invalid_grant', message: 'Assertion was not authorized' };
+    case 'invalid_mapped_user':
+      return { code: 'invalid_grant', message: 'Invalid mapped user' };
+    case 'invalid_mapped_scope':
+      return { code: 'invalid_grant', message: 'Invalid mapped scope' };
+    case 'invalid_mapped_props':
+      return { code: 'invalid_grant', message: 'Invalid mapped props' };
+    case 'invalid_mapped_ttl':
+      return { code: 'invalid_grant', message: 'Invalid access token TTL' };
+    case 'assertion_expired_after_processing':
+      return { code: 'invalid_grant', message: 'Assertion has expired' };
+
+    case 'assertion_too_large':
+    case 'assertion_malformed':
+    case 'invalid_typ':
+    case 'invalid_alg':
+    case 'issuer_not_trusted':
+    case 'no_matching_key':
+    case 'signature_failed':
+    case 'jwks_fetch_failed':
+    case 'invalid_claim':
+    case 'aud_mismatch':
+    case 'expired':
+    case 'iat_in_future':
+    case 'nbf_in_future':
+    case 'lifetime_too_long':
+    case 'replayed':
+    case 'client_id_mismatch':
+      return { code: 'invalid_grant', message: 'Invalid assertion' };
+  }
+}
+
+/**
+ * Payload passed to the `onError` callback when an EMA assertion is rejected.
+ * Carries the full tagged reason for logging/alerting/diagnostics; the wire
+ * response remains generic.
+ *
+ * `detail` contains the full tagged error, including raw values from the
+ * assertion (e.g. `jti` on replay, `iss` on issuer rejection, `sub`-derived
+ * detail on certain claim failures). If your `onError` sink is shared with
+ * lower-trust observers, redact or hash these fields before forwarding —
+ * an IdP-minted `jti` is typically a random nonce but can encode correlated
+ * data depending on the issuer.
+ */
+export interface EmaOnErrorPayload {
+  category: 'enterprise-managed-authorization';
+  reason: EmaValidationError['reason'];
+  detail: EmaValidationError;
+}
+
+export function emaErrorToOnErrorPayload(e: EmaValidationError): EmaOnErrorPayload {
+  return {
+    category: 'enterprise-managed-authorization',
+    reason: e.reason,
+    detail: e,
+  };
+}

--- a/src/ema/result.ts
+++ b/src/ema/result.ts
@@ -45,6 +45,7 @@ export type EmaValidationError =
   | { reason: 'invalid_mapped_props' }
   | { reason: 'invalid_mapped_ttl' }
   | { reason: 'mapper_denied' }
+  | { reason: 'mapper_threw' }
   | { reason: 'assertion_expired_after_processing' };
 
 /** Wire-level error response that the AS returns to the client. */
@@ -71,6 +72,8 @@ export function emaErrorToWire(e: EmaValidationError): EmaErrorWireResponse {
       return { code: 'invalid_target', message: 'Invalid resource' };
 
     case 'mapper_denied':
+      return { code: 'invalid_grant', message: 'Assertion was not authorized' };
+    case 'mapper_threw':
       return { code: 'invalid_grant', message: 'Assertion was not authorized' };
     case 'invalid_mapped_user':
       return { code: 'invalid_grant', message: 'Invalid mapped user' };

--- a/src/ema/result.ts
+++ b/src/ema/result.ts
@@ -105,4 +105,3 @@ export function emaErrorToWire(e: EmaValidationError): EmaErrorWireResponse {
       return { code: 'invalid_grant', message: 'Invalid assertion' };
   }
 }
-

--- a/src/ema/result.ts
+++ b/src/ema/result.ts
@@ -5,7 +5,8 @@
  * orchestrator chains them with explicit `if (!r.ok) return r` checks — no
  * library, no hidden control flow. The wire-level error string is intentionally
  * generic for security (RFC 6749 §5.2), but the rich tagged `reason` flows to
- * the deployer-supplied `onError` hook so failures are still debuggable.
+ * the deployer-supplied `onError` hook via `error.internal.reason` so failures
+ * are still debuggable.
  */
 
 export type Result<T, E> = { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: E };
@@ -102,28 +103,3 @@ export function emaErrorToWire(e: EmaValidationError): EmaErrorWireResponse {
   }
 }
 
-/**
- * Payload passed to the `onError` callback when an EMA assertion is rejected.
- * Carries the full tagged reason for logging/alerting/diagnostics; the wire
- * response remains generic.
- *
- * `detail` contains the full tagged error, including raw values from the
- * assertion (e.g. `jti` on replay, `iss` on issuer rejection, `sub`-derived
- * detail on certain claim failures). If your `onError` sink is shared with
- * lower-trust observers, redact or hash these fields before forwarding —
- * an IdP-minted `jti` is typically a random nonce but can encode correlated
- * data depending on the issuer.
- */
-export interface EmaOnErrorPayload {
-  category: 'enterprise-managed-authorization';
-  reason: EmaValidationError['reason'];
-  detail: EmaValidationError;
-}
-
-export function emaErrorToOnErrorPayload(e: EmaValidationError): EmaOnErrorPayload {
-  return {
-    category: 'enterprise-managed-authorization',
-    reason: e.reason,
-    detail: e,
-  };
-}

--- a/src/ema/signature.ts
+++ b/src/ema/signature.ts
@@ -1,0 +1,79 @@
+/**
+ * JWK selection and ID-JAG signature verification.
+ *
+ * `selectJwk` is a pure picker; `verifyIdJagSignature` is the I/O-bearing
+ * WebCrypto call. Both operate over the already-fetched JWKS — the actual
+ * fetching lives behind `EmaJwksProvider`.
+ */
+
+import { getJwtCryptoAlgorithms } from '../oauth-provider';
+import { type EmaSupportedAlg } from './constants';
+import { err, ok, type EmaValidationError, type Result } from './result';
+import type { JsonWebKeySet, OAuthJsonWebKey } from './types';
+
+/**
+ * Pick a signing key from a JWKS that matches the assertion header.
+ *
+ * Filters by:
+ *   - `kid` (if the assertion header carries one)
+ *   - JWK `use === 'sig'` (when present)
+ *   - JWK `key_ops` containing `verify` (when present)
+ *   - JWK `alg` matching (when present)
+ *   - `kty` compatible with the requested `alg`
+ *
+ * If the assertion has a `kid`, the first matching key wins. Without a `kid`,
+ * we only return a key if exactly one candidate matches — otherwise the
+ * selection is ambiguous and we reject (caller may then force-refresh JWKS).
+ */
+export function selectJwk(
+  jwks: JsonWebKeySet,
+  alg: EmaSupportedAlg,
+  kid: string | undefined
+): Result<OAuthJsonWebKey, EmaValidationError> {
+  const keys = jwks.keys ?? [];
+  const matching = keys.filter((key) => {
+    if (kid && key.kid !== kid) return false;
+    if (key.alg && key.alg !== alg) return false;
+    if (key.use && key.use !== 'sig') return false;
+    if (Array.isArray(key.key_ops) && !key.key_ops.includes('verify')) return false;
+    if (alg.startsWith('RS') && key.kty !== 'RSA') return false;
+    if (alg.startsWith('ES') && key.kty !== 'EC') return false;
+    return true;
+  });
+
+  if (kid) {
+    const picked = matching[0];
+    if (!picked) return err({ reason: 'no_matching_key', kid });
+    return ok(picked);
+  }
+
+  if (matching.length !== 1) {
+    return err({ reason: 'no_matching_key' });
+  }
+
+  return ok(matching[0]);
+}
+
+interface VerifyInput {
+  alg: EmaSupportedAlg;
+  jwk: OAuthJsonWebKey;
+  signingInput: Uint8Array;
+  signature: Uint8Array;
+}
+
+/**
+ * Verify an ID-JAG's compact-JWS signature using WebCrypto.
+ *
+ * Returns `false` on any WebCrypto-level failure (import or verify).
+ * The caller is responsible for mapping `false` to the appropriate
+ * `EmaValidationError`.
+ */
+export async function verifyIdJagSignature(input: VerifyInput): Promise<boolean> {
+  try {
+    const { importAlgorithm, verifyAlgorithm } = getJwtCryptoAlgorithms(input.alg);
+    const key = await crypto.subtle.importKey('jwk', input.jwk, importAlgorithm, false, ['verify']);
+    return await crypto.subtle.verify(verifyAlgorithm, key, input.signature, input.signingInput);
+  } catch {
+    return false;
+  }
+}

--- a/src/ema/signature.ts
+++ b/src/ema/signature.ts
@@ -2,8 +2,7 @@
  * JWK selection and ID-JAG signature verification.
  *
  * `selectJwk` is a pure picker; `verifyIdJagSignature` is the I/O-bearing
- * WebCrypto call. Both operate over the already-fetched JWKS — the actual
- * fetching lives behind `EmaJwksProvider`.
+ * WebCrypto call. Both operate over an already-fetched JWKS.
  */
 
 import { getJwtCryptoAlgorithms } from '../oauth-provider';

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ClientInfo } from '../oauth-provider';
+import type { EmaValidationError, Result } from './result';
 
 // ─── Public types (deployer-facing) ───────────────────────────────────────────
 
@@ -142,25 +143,22 @@ export type EmaClaimsMapper<Env = Cloudflare.Env> = (
   input: EmaClaimsMapperInput<Env>
 ) => Promise<EmaClaimsMapperResult | null>;
 
-/** Internal adapter for fetching an IdP's JWKS during ID-JAG signature verification. */
+/** Internal provider for fetching an IdP's JWKS during ID-JAG signature verification. */
 export interface EmaJwksProvider {
-  fetch(issuer: EmaTrustedIssuer, opts: { forceRefresh: boolean; now: number }): Promise<EmaJwksFetchResult>;
+  fetch(
+    issuer: EmaTrustedIssuer,
+    opts: { forceRefresh: boolean; now: number }
+  ): Promise<Result<JsonWebKeySet, EmaValidationError>>;
 }
 
-export type EmaJwksFetchResult =
-  | { readonly ok: true; readonly jwks: JsonWebKeySet }
-  | { readonly ok: false; readonly reason: 'fetch_failed'; readonly status?: number }
-  | { readonly ok: false; readonly reason: 'force_refresh_throttled' };
-
 /**
- * Internal adapter for replay protection of ID-JAG `jti` values.
+ * Internal store for replay protection of ID-JAG `jti` values.
  *
- * The default KV-backed implementation is **best-effort** — KV is eventually
+ * The default KV-backed implementation is best-effort — KV is eventually
  * consistent, so two near-simultaneous token requests presenting the same
  * assertion from different colos can both read "not seen" and both succeed.
- * Replay is also defended by the surrounding checks (short `exp`, `nbf`,
- * `aud`, `resource`, client binding, signature) — so the `jti` store is the
- * last layer rather than the only one.
+ * Surrounding checks (signature, short `exp`, `nbf`, `aud`, `resource`,
+ * client binding) constrain the practical attack window.
  */
 export interface EmaJtiStore {
   markUsed(input: {
@@ -169,10 +167,8 @@ export interface EmaJtiStore {
     exp: number;
     now: number;
     env: { OAUTH_KV: KVNamespace };
-  }): Promise<EmaJtiMarkResult>;
+  }): Promise<Result<void, EmaValidationError>>;
 }
-
-export type EmaJtiMarkResult = { readonly ok: true } | { readonly ok: false; readonly reason: 'replayed' };
 
 /**
  * Input passed to a dynamic `EmaTrustedIssuerResolver`.

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -79,6 +79,9 @@ export interface EmaClaimsMapperInput<Env = Cloudflare.Env> {
   /** Requested scopes after downscoping to the assertion's scope claim, if present. */
   requestedScope: string[];
 
+  /** The original HTTP token request, e.g. for inspecting Host header in multi-tenant routing. */
+  request: Request;
+
   /** Cloudflare Worker environment variables. */
   env: Env;
 }
@@ -118,7 +121,12 @@ export interface EmaClaimsMapperResult {
    */
   props: unknown;
 
-  /** Optional access token TTL override in seconds. Clamped to the assertion lifetime. */
+  /**
+   * Optional access token TTL override in seconds. Overrides the AS's
+   * configured default. Not clamped to the assertion lifetime — the ID-JAG
+   * `exp` governs how long the assertion remains a usable grant, not the
+   * lifetime of the access token it mints (RFC 7523 §3).
+   */
   accessTokenTTL?: number;
 }
 
@@ -272,16 +280,4 @@ export interface ValidatedIdJag {
   claims: EmaIdJagClaims;
   resource: string;
   assertionScopes: string[];
-}
-
-/** Output of the EMA pipeline up to (but not including) token minting. */
-export interface EmaAuthorization {
-  userId: string;
-  scope: string[];
-  props: unknown;
-  metadata: unknown;
-  resource: string;
-  assertionExp: number;
-  assertionScopes: string[];
-  accessTokenTTLSeconds: number;
 }

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -130,11 +130,7 @@ export type EmaClaimsMapper<Env = Cloudflare.Env> = (
   input: EmaClaimsMapperInput<Env>
 ) => Promise<EmaClaimsMapperResult | null> | EmaClaimsMapperResult | null;
 
-/**
- * Adapter for fetching an IdP's JWKS. Deployers can supply a custom
- * implementation (e.g. backed by the Workers Cache API or a Durable Object)
- * by passing it via `EmaOptions.jwksProvider`.
- */
+/** Internal adapter for fetching an IdP's JWKS during ID-JAG signature verification. */
 export interface EmaJwksProvider {
   fetch(issuer: EmaTrustedIssuer, opts: { forceRefresh: boolean; now: number }): Promise<EmaJwksFetchResult>;
 }
@@ -145,21 +141,14 @@ export type EmaJwksFetchResult =
   | { readonly ok: false; readonly reason: 'force_refresh_throttled' };
 
 /**
- * Adapter for replay protection of ID-JAG `jti` values.
+ * Internal adapter for replay protection of ID-JAG `jti` values.
  *
- * The default implementation is KV-backed and therefore **best-effort**:
- * KV is eventually consistent, so two near-simultaneous token requests
- * presenting the same assertion from different colos can both read "not
- * seen" and both succeed. This catches the common attacker case (replay
- * after seconds/minutes/hours) but does not give strict-once semantics
- * under concurrency. Replay is also defended by the surrounding checks —
- * short `exp`, `nbf`, `aud`, `resource`, client binding, and signature
- * verification — so the `jti` store is the last layer rather than the
- * only one.
- *
- * Deployers needing strict-once semantics can supply a custom store via
- * `EmaOptions.jtiStore`, e.g. backed by a Durable Object for strongly
- * consistent reads/writes.
+ * The default KV-backed implementation is **best-effort** — KV is eventually
+ * consistent, so two near-simultaneous token requests presenting the same
+ * assertion from different colos can both read "not seen" and both succeed.
+ * Replay is also defended by the surrounding checks (short `exp`, `nbf`,
+ * `aud`, `resource`, client binding, signature) — so the `jti` store is the
+ * last layer rather than the only one.
  */
 export interface EmaJtiStore {
   markUsed(input: { issuer: string; jti: string; exp: number; now: number; env: any }): Promise<EmaJtiMarkResult>;
@@ -247,19 +236,6 @@ export interface EmaOptions<Env = Cloudflare.Env> {
 
   /** Maximum accepted assertion lifetime in seconds. Defaults to 300 seconds. */
   maxAssertionLifetimeSeconds?: number;
-
-  /**
-   * Optional custom JWKS provider. Defaults to the built-in HTTP fetcher with
-   * a per-issuer in-memory cache and force-refresh cool-down.
-   */
-  jwksProvider?: EmaJwksProvider;
-
-  /**
-   * Optional custom JTI replay store. Defaults to a KV-backed best-effort
-   * implementation; supply a Durable Object-backed implementation if you
-   * need strict-once semantics under concurrent requests.
-   */
-  jtiStore?: EmaJtiStore;
 }
 
 // ─── Internal types (used inside the EMA pipeline) ────────────────────────────

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -133,10 +133,14 @@ export interface EmaClaimsMapperResult {
 /**
  * Maps validated enterprise ID-JAG claims to this provider's local user, scopes,
  * metadata, and props. Return `null` to deny token issuance.
+ *
+ * Always async — mirrors `EmaTrustedIssuerResolver` so the two enterprise
+ * callbacks have the same shape and downstream lookups (KV, D1, IdP federation)
+ * don't require a later API change to add `Promise<…>` return support.
  */
 export type EmaClaimsMapper<Env = Cloudflare.Env> = (
   input: EmaClaimsMapperInput<Env>
-) => Promise<EmaClaimsMapperResult | null> | EmaClaimsMapperResult | null;
+) => Promise<EmaClaimsMapperResult | null>;
 
 /** Internal adapter for fetching an IdP's JWKS during ID-JAG signature verification. */
 export interface EmaJwksProvider {
@@ -206,7 +210,7 @@ export interface EmaTrustedIssuerResolverInput<Env = Cloudflare.Env> {
  */
 export type EmaTrustedIssuerResolver<Env = Cloudflare.Env> = (
   input: EmaTrustedIssuerResolverInput<Env>
-) => EmaTrustedIssuer | null | Promise<EmaTrustedIssuer | null>;
+) => Promise<EmaTrustedIssuer | null>;
 
 /**
  * MCP Enterprise-Managed Authorization configuration.
@@ -224,7 +228,7 @@ export interface EmaOptions<Env = Cloudflare.Env> {
    *
    * ```ts
    * const issuers = [{ issuer: 'https://idp.example.com', jwksUri: '...' }];
-   * trustedIssuers: ({ iss }) => issuers.find((i) => i.issuer === iss) ?? null,
+   * trustedIssuers: async ({ iss }) => issuers.find((i) => i.issuer === iss) ?? null,
    * ```
    *
    * For B2B / multi-tenant deployments, the resolver can consult `env`,

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -1,0 +1,311 @@
+/**
+ * Public and internal types for MCP Enterprise-Managed Authorization (EMA).
+ */
+
+import type { ClientInfo } from '../oauth-provider';
+
+// ─── Public types (deployer-facing) ───────────────────────────────────────────
+
+/**
+ * Claims expected in an MCP Enterprise-Managed Authorization ID-JAG assertion.
+ * Additional issuer-specific claims (e.g. `email`) are preserved verbatim
+ * under the index signature.
+ */
+export interface EmaIdJagClaims {
+  /** Identity provider issuer URL. */
+  iss: string;
+
+  /** Enterprise subject identifier for the resource owner. */
+  sub: string;
+
+  /** Authorization server issuer URL or URLs for which this assertion is intended. */
+  aud: string | string[];
+
+  /** RFC 9728 resource identifier of the MCP server. */
+  resource: string;
+
+  /** OAuth client identifier this assertion was issued to. */
+  client_id: string;
+
+  /** Unique assertion identifier used for replay protection. */
+  jti: string;
+
+  /** Assertion expiration time as a Unix timestamp in seconds. */
+  exp: number;
+
+  /** Assertion issued-at time as a Unix timestamp in seconds. */
+  iat: number;
+
+  /** Optional space-separated OAuth scope string. */
+  scope?: string;
+
+  /** Optional email claim supplied by the enterprise IdP. */
+  email?: string;
+
+  /** Additional enterprise IdP claims. */
+  [claim: string]: unknown;
+}
+
+/**
+ * Trusted enterprise IdP configuration for ID-JAG validation.
+ */
+export interface EmaTrustedIssuer {
+  /** Issuer URL that must exactly match the assertion `iss` claim. */
+  issuer: string;
+
+  /** HTTPS JWKS endpoint used to validate assertion signatures. */
+  jwksUri: string;
+
+  /** Allowed JWT signing algorithms for this issuer. Defaults to `['RS256']`. */
+  algorithms?: string[];
+
+  /** Expected authorization server audience. Defaults to this provider's issuer URL. */
+  audience?: string;
+}
+
+/**
+ * Input passed to `enterpriseManagedAuthorization.mapClaims` after ID-JAG validation.
+ */
+export interface EmaClaimsMapperInput<Env = Cloudflare.Env> {
+  /** Validated ID-JAG claims. */
+  claims: EmaIdJagClaims;
+
+  /** Authenticated OAuth client that presented the assertion. */
+  clientInfo: ClientInfo;
+
+  /** Validated MCP resource identifier from the assertion. */
+  resource: string;
+
+  /** Requested scopes after downscoping to the assertion's scope claim, if present. */
+  requestedScope: string[];
+
+  /** Cloudflare Worker environment variables. */
+  env: Env;
+}
+
+/**
+ * Result returned by `enterpriseManagedAuthorization.mapClaims`.
+ */
+export interface EmaClaimsMapperResult {
+  /**
+   * User ID to associate with the issued grant and access token.
+   *
+   * Must not contain `:` — the opaque access token format issued by this
+   * provider uses `:` as an internal separator, so a `userId` containing
+   * it will produce tokens that fail to parse on validation. If the IdP
+   * subject may contain `:` (e.g. an email), encode or hash it first
+   * (e.g. ``userId: `enterprise-${encodeURIComponent(claims.sub)}` ``).
+   */
+  userId: string;
+
+  /** Scopes to grant to the issued access token. */
+  scope: string[];
+
+  /**
+   * Optional grant metadata used for audit and grant listing. This is not
+   * encrypted. Stored on the grant in KV alongside the user ID — visible to
+   * server-side code via `OAuthHelpers` but never exposed to the MCP client.
+   * Use for audit logs, admin UIs, or "list active sessions" features.
+   */
+  metadata?: unknown;
+
+  /**
+   * Application props encrypted into the issued access token and exposed to
+   * API handlers on every authenticated request (via `getMcpAuthContext()`
+   * for MCP servers, or `ctx.props` in the underlying OAuth helpers). Use
+   * for per-request data the protected resource needs without hitting the
+   * IdP again — e.g. `enterprise: true`, subject, email, role claims.
+   */
+  props: unknown;
+
+  /** Optional access token TTL override in seconds. Clamped to the assertion lifetime. */
+  accessTokenTTL?: number;
+}
+
+/**
+ * Maps validated enterprise ID-JAG claims to this provider's local user, scopes,
+ * metadata, and props. Return `null` to deny token issuance.
+ */
+export type EmaClaimsMapper<Env = Cloudflare.Env> = (
+  input: EmaClaimsMapperInput<Env>
+) => Promise<EmaClaimsMapperResult | null> | EmaClaimsMapperResult | null;
+
+/**
+ * Adapter for fetching an IdP's JWKS. Deployers can supply a custom
+ * implementation (e.g. backed by the Workers Cache API or a Durable Object)
+ * by passing it via `EmaOptions.jwksProvider`.
+ */
+export interface EmaJwksProvider {
+  fetch(issuer: EmaTrustedIssuer, opts: { forceRefresh: boolean; now: number }): Promise<EmaJwksFetchResult>;
+}
+
+export type EmaJwksFetchResult =
+  | { readonly ok: true; readonly jwks: JsonWebKeySet }
+  | { readonly ok: false; readonly reason: 'fetch_failed'; readonly status?: number }
+  | { readonly ok: false; readonly reason: 'force_refresh_throttled' };
+
+/**
+ * Adapter for replay protection of ID-JAG `jti` values.
+ *
+ * The default implementation is KV-backed and therefore **best-effort**:
+ * KV is eventually consistent, so two near-simultaneous token requests
+ * presenting the same assertion from different colos can both read "not
+ * seen" and both succeed. This catches the common attacker case (replay
+ * after seconds/minutes/hours) but does not give strict-once semantics
+ * under concurrency. Replay is also defended by the surrounding checks —
+ * short `exp`, `nbf`, `aud`, `resource`, client binding, and signature
+ * verification — so the `jti` store is the last layer rather than the
+ * only one.
+ *
+ * Deployers needing strict-once semantics can supply a custom store via
+ * `EmaOptions.jtiStore`, e.g. backed by a Durable Object for strongly
+ * consistent reads/writes.
+ */
+export interface EmaJtiStore {
+  markUsed(input: { issuer: string; jti: string; exp: number; now: number; env: any }): Promise<EmaJtiMarkResult>;
+}
+
+export type EmaJtiMarkResult = { readonly ok: true } | { readonly ok: false; readonly reason: 'replayed' };
+
+/**
+ * Input passed to a dynamic `EmaTrustedIssuerResolver`.
+ *
+ * The `iss` value comes from the assertion's unverified payload — it is
+ * used here only as a routing key to choose which IdP's JWKS to load.
+ * The cryptographic trust comes from signature verification later, so
+ * the resolver may safely treat `iss` as untrusted input.
+ */
+export interface EmaTrustedIssuerResolverInput<Env = Cloudflare.Env> {
+  /** Issuer URL from the assertion's `iss` claim (unverified). */
+  iss: string;
+  /** Cloudflare Worker environment variables (bindings, secrets, KV, D1). */
+  env: Env;
+  /** The original HTTP request, e.g. for inspecting the Host header in multi-tenant routing. */
+  request: Request;
+  /** Authenticated OAuth client that presented the assertion. */
+  clientInfo: ClientInfo;
+}
+
+/**
+ * Dynamic resolver for `EmaOptions.trustedIssuers`.
+ *
+ * Returns the trusted issuer configuration for an incoming `iss` claim,
+ * or `null` if the issuer is not trusted for this client / tenant. The
+ * returned `issuer` field must equal the input `iss` — the AS enforces
+ * this to prevent a resolver from being tricked into returning a config
+ * for a different IdP than the one the assertion claims to be from.
+ *
+ * Useful for B2B platforms where new tenants onboard their own IdPs
+ * dynamically and the AS cannot ship a static list at deploy time.
+ *
+ * **SSRF warning**: `jwksUri` is fetched outbound by the AS. If your
+ * resolver reads `jwksUri` from tenant-controlled storage (self-service
+ * tenant onboarding, etc.), an attacker who controls a tenant config
+ * can point the AS at arbitrary HTTPS endpoints — internal services,
+ * cloud metadata endpoints, victim hosts for DoS amplification. The
+ * library only enforces `https:`; deployers must validate `jwksUri`
+ * against their own allowlist (e.g. registered IdP vendor domains)
+ * before storing or returning it.
+ */
+export type EmaTrustedIssuerResolver<Env = Cloudflare.Env> = (
+  input: EmaTrustedIssuerResolverInput<Env>
+) => EmaTrustedIssuer | null | Promise<EmaTrustedIssuer | null>;
+
+/**
+ * MCP Enterprise-Managed Authorization configuration.
+ *
+ * Presence of this option on `OAuthProviderOptions` enables the EMA grant.
+ * There is intentionally no `enabled` flag — forgetting to set it would
+ * silently disable the feature despite full configuration.
+ */
+export interface EmaOptions<Env = Cloudflare.Env> {
+  /**
+   * Resolver that returns the trusted issuer configuration for an
+   * incoming `iss` claim, or `null` to reject the assertion.
+   *
+   * Always a function — for a fixed list of IdPs, write a one-line closure:
+   *
+   * ```ts
+   * const issuers = [{ issuer: 'https://idp.example.com', jwksUri: '...' }];
+   * trustedIssuers: ({ iss }) => issuers.find((i) => i.issuer === iss) ?? null,
+   * ```
+   *
+   * For B2B / multi-tenant deployments, the resolver can consult `env`,
+   * `request`, or `clientInfo` to look up the issuer dynamically (e.g.
+   * a per-tenant config in KV / D1) without redeploying.
+   */
+  trustedIssuers: EmaTrustedIssuerResolver<Env>;
+
+  /** Maps validated enterprise claims to local token data. */
+  mapClaims: EmaClaimsMapper<Env>;
+
+  /** JWKS cache TTL in seconds. Defaults to 300 seconds. */
+  jwksCacheTtlSeconds?: number;
+
+  /** Allowed clock skew for `exp` and `iat` checks in seconds. Defaults to 60 seconds. */
+  clockSkewSeconds?: number;
+
+  /** Maximum accepted assertion lifetime in seconds. Defaults to 300 seconds. */
+  maxAssertionLifetimeSeconds?: number;
+
+  /**
+   * Optional custom JWKS provider. Defaults to the built-in HTTP fetcher with
+   * a per-issuer in-memory cache and force-refresh cool-down.
+   */
+  jwksProvider?: EmaJwksProvider;
+
+  /**
+   * Optional custom JTI replay store. Defaults to a KV-backed best-effort
+   * implementation; supply a Durable Object-backed implementation if you
+   * need strict-once semantics under concurrent requests.
+   */
+  jtiStore?: EmaJtiStore;
+}
+
+// ─── Internal types (used inside the EMA pipeline) ────────────────────────────
+
+export interface JsonWebKeySet {
+  keys?: OAuthJsonWebKey[];
+}
+
+export type OAuthJsonWebKey = JsonWebKey & {
+  kid?: string;
+  alg?: string;
+  use?: string;
+  key_ops?: string[];
+  kty?: string;
+};
+
+/** Parsed but not-yet-validated ID-JAG. */
+export interface ParsedIdJag {
+  header: Record<string, unknown>;
+  rawClaims: Record<string, unknown>;
+  signingInput: Uint8Array;
+  signature: Uint8Array;
+}
+
+/** Validated JOSE header for an ID-JAG. */
+export interface ValidatedIdJagHeader {
+  typ: string;
+  alg: string;
+  kid?: string;
+}
+
+/** Fully validated ID-JAG, ready to feed into the claims mapper. */
+export interface ValidatedIdJag {
+  claims: EmaIdJagClaims;
+  resource: string;
+  assertionScopes: string[];
+}
+
+/** Output of the EMA pipeline up to (but not including) token minting. */
+export interface EmaAuthorization {
+  userId: string;
+  scope: string[];
+  props: unknown;
+  metadata: unknown;
+  resource: string;
+  assertionExp: number;
+  assertionScopes: string[];
+  accessTokenTTLSeconds: number;
+}

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -163,7 +163,13 @@ export type EmaJwksFetchResult =
  * last layer rather than the only one.
  */
 export interface EmaJtiStore {
-  markUsed(input: { issuer: string; jti: string; exp: number; now: number; env: any }): Promise<EmaJtiMarkResult>;
+  markUsed(input: {
+    issuer: string;
+    jti: string;
+    exp: number;
+    now: number;
+    env: { OAUTH_KV: KVNamespace };
+  }): Promise<EmaJtiMarkResult>;
 }
 
 export type EmaJtiMarkResult = { readonly ok: true } | { readonly ok: false; readonly reason: 'replayed' };

--- a/src/ema/util.ts
+++ b/src/ema/util.ts
@@ -1,0 +1,15 @@
+/**
+ * Tiny utility helpers used by EMA adapters.
+ *
+ * Lives in `src/ema/util.ts` rather than `src/util.ts` to keep the EMA
+ * module self-contained — the main `oauth-provider.ts` reaches into here
+ * only through the adapters' public interfaces.
+ */
+
+/** SHA-256 a string and return its hex digest. */
+export async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const buffer = await crypto.subtle.digest('SHA-256', data);
+  const bytes = Array.from(new Uint8Array(buffer));
+  return bytes.map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -27,7 +27,7 @@ import type {
 /**
  * Validate the JOSE header of an ID-JAG. Enforces the `typ=oauth-id-jag+jwt`
  * marker (RFC 8725 §3.11) and an `alg` within the AS's global allowlist.
- * Per-issuer `algorithms` is checked separately in `selectTrustedIssuer`.
+ * Per-issuer `algorithms` is checked separately in `resolveTrustedIssuer`.
  */
 export function validateIdJagHeader(
   header: Record<string, unknown>,
@@ -191,7 +191,7 @@ export function validateIdJagClaims(input: ValidateClaimsInput): Result<Validate
   if (!iss.ok) return iss;
 
   // Defense-in-depth: trustedIssuer.issuer must equal claims.iss because that's
-  // how `selectTrustedIssuer` picked it. Reassert here so the function is
+  // how `resolveTrustedIssuer` picked it. Reassert here so the function is
   // self-contained and the type narrows.
   if (iss.value !== trustedIssuer.issuer) {
     return err({ reason: 'issuer_not_trusted', iss: iss.value });

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -377,28 +377,26 @@ interface ClampTtlInput {
 }
 
 /**
- * Compute the access token TTL bounded by:
- *   - the AS's default (`options.accessTokenTTL`)
- *   - the assertion's remaining lifetime (`exp - now`)
- *   - the mapper-supplied override (if present)
+ * Compute the access token TTL.
  *
- * Returns `assertion_expired_after_processing` if no positive lifetime
- * remains (e.g. the assertion crossed `exp` while we were validating it).
+ * The mapper-supplied override wins; otherwise the AS's default applies.
+ * The assertion's `exp` governs how long the ID-JAG is valid as a grant,
+ * not how long the access token issued in exchange lives — RFC 7523 §3
+ * does not bind access-token lifetime to assertion lifetime, and the MCP
+ * EMA spec example issues access tokens far longer than the 300s ID-JAG.
+ *
+ * Returns `assertion_expired_after_processing` if the assertion crossed
+ * `exp` while we were validating it (TOCTOU race between claim check and
+ * here).
  */
 export function clampEmaAccessTokenTTL(input: ClampTtlInput): Result<number, EmaValidationError> {
   const { configuredDefaultSeconds, assertionExp, mapperTtl, now } = input;
-  const remaining = assertionExp - now;
-  let ttl = Math.min(configuredDefaultSeconds, remaining);
 
-  if (mapperTtl !== undefined) {
-    ttl = Math.min(ttl, mapperTtl);
-  }
-
-  if (ttl <= 0) {
+  if (assertionExp - now <= 0) {
     return err({ reason: 'assertion_expired_after_processing' });
   }
 
-  return ok(ttl);
+  return ok(mapperTtl ?? configuredDefaultSeconds);
 }
 
 // ─── Local helpers (not exported) ─────────────────────────────────────────────

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -121,11 +121,14 @@ export async function resolveTrustedIssuer<Env>(
  * static-array shape used to get for free.
  */
 function isWellFormedTrustedIssuer(issuer: EmaTrustedIssuer): boolean {
+  // RFC 8414 §2 requires the issuer identifier to be an HTTPS URL.
+  let issuerUrl: URL;
   try {
-    new URL(issuer.issuer);
+    issuerUrl = new URL(issuer.issuer);
   } catch {
     return false;
   }
+  if (issuerUrl.protocol !== 'https:') return false;
 
   let jwksUrl: URL;
   try {
@@ -262,11 +265,11 @@ export function validateIdJagClaims(input: ValidateClaimsInput): Result<Validate
     const parsed = readRequiredString(rawClaims, 'scope');
     if (!parsed.ok) return parsed;
     const tokens = parseScopeGrammar(parsed.value);
-    if (!tokens.ok) {
+    if (tokens === null) {
       return err({ reason: 'invalid_claim', claim: 'scope' });
     }
     scope = parsed.value;
-    assertionScopes = tokens.value;
+    assertionScopes = tokens;
   }
 
   const claims: EmaIdJagClaims = {
@@ -301,14 +304,14 @@ export function parseEmaScopeParam(
     requested = [...assertionScopes];
   } else if (typeof scope === 'string') {
     const parsed = parseScopeGrammar(scope);
-    if (!parsed.ok) return err({ reason: 'invalid_scope_param' });
-    requested = parsed.value;
+    if (parsed === null) return err({ reason: 'invalid_scope_param' });
+    requested = parsed;
   } else if (Array.isArray(scope) && scope.every((value) => typeof value === 'string')) {
     requested = [];
     for (const part of scope as string[]) {
       const parsed = parseScopeGrammar(part);
-      if (!parsed.ok) return err({ reason: 'invalid_scope_param' });
-      requested.push(...parsed.value);
+      if (parsed === null) return err({ reason: 'invalid_scope_param' });
+      requested.push(...parsed);
     }
   } else {
     return err({ reason: 'invalid_scope_param' });
@@ -423,11 +426,18 @@ function readNumericDateClaim(claims: Record<string, unknown>, claimName: string
   return ok(value);
 }
 
-function parseScopeGrammar(scope: string): Result<string[], { reason: 'invalid_scope_grammar' }> {
-  if (!scope) return ok([]);
+/**
+ * Split and validate an RFC 6749 §3.3 scope string. Returns `null` on
+ * malformed input — callers attach whatever `EmaValidationError` arm fits
+ * their context (claim vs. param vs. mapped). No Result here because the
+ * error variant would only ever carry a constant reason that downstream
+ * discards.
+ */
+function parseScopeGrammar(scope: string): string[] | null {
+  if (!scope) return [];
   const tokens = scope.split(' ').filter(Boolean);
   for (const token of tokens) {
-    if (!isValidOAuthScopeToken(token)) return err({ reason: 'invalid_scope_grammar' });
+    if (!isValidOAuthScopeToken(token)) return null;
   }
-  return ok(tokens);
+  return tokens;
 }

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -1,0 +1,440 @@
+/**
+ * Pure validators for the MCP Enterprise-Managed Authorization flow.
+ *
+ * Each function takes plain data, performs one well-defined check, and
+ * returns `Result<T, EmaValidationError>`. No `this`. No I/O. No clock —
+ * `now` is always passed in so tests stay deterministic.
+ *
+ * Composed by the orchestrator (`src/ema/orchestrator.ts`) into the full
+ * token-request pipeline.
+ */
+
+import type { ClientInfo } from '../oauth-provider';
+import { isValidOAuthScopeToken, resourceMatches, validateResourceUri } from '../oauth-provider';
+import { EMA_DEFAULT_JWT_ALGORITHM, EMA_SUPPORTED_JWT_ALGORITHMS, type EmaSupportedAlg } from './constants';
+import { err, ok, type EmaValidationError, type Result } from './result';
+import type {
+  EmaClaimsMapperResult,
+  EmaIdJagClaims,
+  EmaTrustedIssuer,
+  EmaTrustedIssuerResolver,
+  ValidatedIdJag,
+  ValidatedIdJagHeader,
+} from './types';
+
+// ─── Header ───────────────────────────────────────────────────────────────────
+
+/**
+ * Validate the JOSE header of an ID-JAG. Enforces the `typ=oauth-id-jag+jwt`
+ * marker (RFC 8725 §3.11) and an `alg` within the AS's global allowlist.
+ * Per-issuer `algorithms` is checked separately in `selectTrustedIssuer`.
+ */
+export function validateIdJagHeader(
+  header: Record<string, unknown>,
+  expectedTyp: string,
+  supportedAlgs: ReadonlySet<EmaSupportedAlg>
+): Result<ValidatedIdJagHeader, EmaValidationError> {
+  const typ = header.typ;
+  if (typeof typ !== 'string' || typ !== expectedTyp) {
+    return err({ reason: 'invalid_typ', got: typ });
+  }
+
+  const alg = header.alg;
+  if (typeof alg !== 'string' || alg === 'none' || !supportedAlgs.has(alg as EmaSupportedAlg)) {
+    return err({ reason: 'invalid_alg', got: alg });
+  }
+
+  const kidRaw = header.kid;
+  const kid = typeof kidRaw === 'string' && kidRaw.length > 0 ? kidRaw : undefined;
+
+  return ok({ typ, alg, kid });
+}
+
+// ─── Issuer trust ─────────────────────────────────────────────────────────────
+
+interface ResolveTrustedIssuerInput<Env> {
+  iss: unknown;
+  alg: EmaSupportedAlg;
+  resolver: EmaTrustedIssuerResolver<Env>;
+  env: Env;
+  request: Request;
+  clientInfo: ClientInfo;
+}
+
+/**
+ * Resolve the `iss` claim through the deployer-supplied resolver, then
+ * validate the returned configuration before signature verification ever
+ * runs against it.
+ *
+ * Every failure here collapses to `issuer_not_trusted` so an attacker
+ * cannot distinguish "unknown IdP" from "resolver returned a malformed
+ * config" from "alg not in the IdP's allowlist".
+ *
+ * The resolver's returned `issuer` field MUST equal the input `iss`.
+ * Otherwise a buggy resolver could be tricked into returning a config
+ * for IdP B while validating a JWT that claims to be from IdP A,
+ * which would let an attacker forge any IdP they like (since the JWKS
+ * would be fetched from B's URI).
+ */
+export async function resolveTrustedIssuer<Env>(
+  input: ResolveTrustedIssuerInput<Env>
+): Promise<Result<EmaTrustedIssuer, EmaValidationError>> {
+  const { iss, alg, resolver, env, request, clientInfo } = input;
+
+  if (typeof iss !== 'string' || iss.length === 0) {
+    return err({ reason: 'invalid_claim', claim: 'iss' });
+  }
+
+  let resolved: EmaTrustedIssuer | null;
+  try {
+    resolved = await resolver({ iss, env, request, clientInfo });
+  } catch {
+    return err({ reason: 'issuer_not_trusted', iss });
+  }
+
+  if (!resolved) {
+    return err({ reason: 'issuer_not_trusted', iss });
+  }
+
+  // The resolver's returned `issuer` must match the input — this prevents
+  // a confused-deputy attack where the resolver is coaxed into returning
+  // a different IdP's config than the one the assertion claims.
+  if (resolved.issuer !== iss) {
+    return err({ reason: 'issuer_not_trusted', iss });
+  }
+
+  if (!isWellFormedTrustedIssuer(resolved)) {
+    return err({ reason: 'issuer_not_trusted', iss });
+  }
+
+  const allowedAlgorithms = resolved.algorithms ?? [EMA_DEFAULT_JWT_ALGORITHM];
+  if (!allowedAlgorithms.includes(alg)) {
+    return err({ reason: 'issuer_not_trusted', iss });
+  }
+
+  return ok(resolved);
+}
+
+/**
+ * Per-request structural validation of an `EmaTrustedIssuer` returned by
+ * a dynamic resolver. Mirrors the construction-time checks that the
+ * static-array shape used to get for free.
+ */
+function isWellFormedTrustedIssuer(issuer: EmaTrustedIssuer): boolean {
+  try {
+    new URL(issuer.issuer);
+  } catch {
+    return false;
+  }
+
+  let jwksUrl: URL;
+  try {
+    jwksUrl = new URL(issuer.jwksUri);
+  } catch {
+    return false;
+  }
+  if (jwksUrl.protocol !== 'https:') return false;
+
+  const algorithms = issuer.algorithms ?? [EMA_DEFAULT_JWT_ALGORITHM];
+  if (algorithms.length === 0) return false;
+  for (const alg of algorithms) {
+    if (!EMA_SUPPORTED_JWT_ALGORITHMS.has(alg as EmaSupportedAlg)) return false;
+  }
+
+  if (issuer.audience !== undefined) {
+    try {
+      new URL(issuer.audience);
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// ─── Claims ───────────────────────────────────────────────────────────────────
+
+interface ValidateClaimsInput {
+  rawClaims: Record<string, unknown>;
+  trustedIssuer: EmaTrustedIssuer;
+  expectedAudience: string;
+  clientId: string;
+  configuredResource: string;
+  matchOriginOnly: boolean;
+  now: number;
+  clockSkewSeconds: number;
+  maxAssertionLifetimeSeconds: number;
+}
+
+/**
+ * Validate every required ID-JAG claim and produce a typed `ValidatedIdJag`.
+ *
+ * Enforces (in order):
+ *   - presence + type of `iss`, `sub`, `aud`, `resource`, `client_id`, `jti`, `exp`, `iat`
+ *   - `aud` contains the AS's expected audience
+ *   - `client_id` matches the authenticated client
+ *   - `resource` is a valid RFC 8707 URI and matches the AS's configured resource
+ *   - `exp` is in the future
+ *   - `iat` is not more than `clockSkewSeconds` in the future
+ *   - `nbf` (if present) is ≤ `now + clockSkewSeconds`
+ *   - `exp - iat` does not exceed `maxAssertionLifetimeSeconds + clockSkewSeconds`
+ *   - `scope` (if present) conforms to RFC 6749 §3.3 grammar
+ */
+export function validateIdJagClaims(input: ValidateClaimsInput): Result<ValidatedIdJag, EmaValidationError> {
+  const { rawClaims, trustedIssuer, expectedAudience, clientId, configuredResource, matchOriginOnly } = input;
+  const { now, clockSkewSeconds, maxAssertionLifetimeSeconds } = input;
+
+  const iss = readRequiredString(rawClaims, 'iss');
+  if (!iss.ok) return iss;
+
+  // Defense-in-depth: trustedIssuer.issuer must equal claims.iss because that's
+  // how `selectTrustedIssuer` picked it. Reassert here so the function is
+  // self-contained and the type narrows.
+  if (iss.value !== trustedIssuer.issuer) {
+    return err({ reason: 'issuer_not_trusted', iss: iss.value });
+  }
+
+  const sub = readRequiredString(rawClaims, 'sub');
+  if (!sub.ok) return sub;
+
+  const aud = readAudienceClaim(rawClaims);
+  if (!aud.ok) return aud;
+
+  const resource = readRequiredString(rawClaims, 'resource');
+  if (!resource.ok) return resource;
+
+  const claimClientId = readRequiredString(rawClaims, 'client_id');
+  if (!claimClientId.ok) return claimClientId;
+
+  const jti = readRequiredString(rawClaims, 'jti');
+  if (!jti.ok) return jti;
+
+  const exp = readNumericDateClaim(rawClaims, 'exp');
+  if (!exp.ok) return exp;
+
+  const iat = readNumericDateClaim(rawClaims, 'iat');
+  if (!iat.ok) return iat;
+
+  const audiences = Array.isArray(aud.value) ? aud.value : [aud.value];
+  if (!audiences.includes(expectedAudience)) {
+    return err({ reason: 'aud_mismatch', expected: expectedAudience, got: aud.value });
+  }
+
+  if (claimClientId.value !== clientId) {
+    return err({ reason: 'client_id_mismatch', expected: clientId, got: claimClientId.value });
+  }
+
+  if (!validateResourceUri(resource.value)) {
+    return err({ reason: 'resource_invalid', resource: resource.value });
+  }
+
+  if (!resourceMatches(resource.value, configuredResource, matchOriginOnly)) {
+    return err({ reason: 'resource_mismatch', expected: configuredResource, got: resource.value });
+  }
+
+  if (exp.value <= now) {
+    return err({ reason: 'expired', exp: exp.value, now });
+  }
+
+  if (iat.value > now + clockSkewSeconds) {
+    return err({ reason: 'iat_in_future', iat: iat.value, now, skew: clockSkewSeconds });
+  }
+
+  // Optional `nbf` (not-before) claim, RFC 7519 §4.1.5 / RFC 7523 §3 rule 5.
+  if (rawClaims.nbf !== undefined) {
+    const nbf = readNumericDateClaim(rawClaims, 'nbf');
+    if (!nbf.ok) return nbf;
+    if (nbf.value > now + clockSkewSeconds) {
+      return err({ reason: 'nbf_in_future', nbf: nbf.value, now, skew: clockSkewSeconds });
+    }
+  }
+
+  const lifetime = exp.value - iat.value;
+  if (lifetime > maxAssertionLifetimeSeconds + clockSkewSeconds) {
+    return err({ reason: 'lifetime_too_long', lifetime, max: maxAssertionLifetimeSeconds });
+  }
+
+  let scope: string | undefined;
+  let assertionScopes: string[] = [];
+  if (rawClaims.scope !== undefined) {
+    const parsed = readRequiredString(rawClaims, 'scope');
+    if (!parsed.ok) return parsed;
+    const tokens = parseScopeGrammar(parsed.value);
+    if (!tokens.ok) {
+      return err({ reason: 'invalid_claim', claim: 'scope' });
+    }
+    scope = parsed.value;
+    assertionScopes = tokens.value;
+  }
+
+  const claims: EmaIdJagClaims = {
+    ...rawClaims,
+    iss: iss.value,
+    sub: sub.value,
+    aud: aud.value,
+    resource: resource.value,
+    client_id: claimClientId.value,
+    jti: jti.value,
+    exp: exp.value,
+    iat: iat.value,
+    scope,
+  };
+
+  return ok({ claims, resource: resource.value, assertionScopes });
+}
+
+// ─── Scope parameter parsing ──────────────────────────────────────────────────
+
+/**
+ * Parse the `scope` parameter of the token request and downscope it to the
+ * assertion's own scope claim. If the request omits `scope`, the assertion's
+ * scopes are used directly.
+ */
+export function parseEmaScopeParam(
+  scope: unknown,
+  assertionScopes: readonly string[]
+): Result<string[], EmaValidationError> {
+  let requested: string[];
+  if (scope === undefined) {
+    requested = [...assertionScopes];
+  } else if (typeof scope === 'string') {
+    const parsed = parseScopeGrammar(scope);
+    if (!parsed.ok) return err({ reason: 'invalid_scope_param' });
+    requested = parsed.value;
+  } else if (Array.isArray(scope) && scope.every((value) => typeof value === 'string')) {
+    requested = [];
+    for (const part of scope as string[]) {
+      const parsed = parseScopeGrammar(part);
+      if (!parsed.ok) return err({ reason: 'invalid_scope_param' });
+      requested.push(...parsed.value);
+    }
+  } else {
+    return err({ reason: 'invalid_scope_param' });
+  }
+
+  if (assertionScopes.length > 0) {
+    const allowed = new Set(assertionScopes);
+    requested = requested.filter((token) => allowed.has(token));
+  }
+
+  return ok(requested);
+}
+
+// ─── Mapper result ────────────────────────────────────────────────────────────
+
+/**
+ * Validate the shape of the value returned by the deployer's `mapClaims`
+ * callback. A `null` return is treated as a deny decision.
+ *
+ * The `userId.includes(':')` rejection mirrors the opaque token format
+ * (`userId:grantId:secret`) used elsewhere in this provider.
+ */
+export function validateEmaMapperResult(result: unknown): Result<EmaClaimsMapperResult, EmaValidationError> {
+  if (result === null) {
+    return err({ reason: 'mapper_denied' });
+  }
+
+  if (typeof result !== 'object') {
+    return err({ reason: 'invalid_mapped_user' });
+  }
+
+  const r = result as Partial<EmaClaimsMapperResult>;
+
+  if (typeof r.userId !== 'string' || r.userId.length === 0 || r.userId.includes(':')) {
+    return err({ reason: 'invalid_mapped_user' });
+  }
+
+  if (!Array.isArray(r.scope) || !r.scope.every((s) => typeof s === 'string' && isValidOAuthScopeToken(s))) {
+    return err({ reason: 'invalid_mapped_scope' });
+  }
+
+  if (!('props' in r) || r.props === undefined) {
+    return err({ reason: 'invalid_mapped_props' });
+  }
+
+  if (r.accessTokenTTL !== undefined) {
+    if (typeof r.accessTokenTTL !== 'number' || !Number.isFinite(r.accessTokenTTL) || r.accessTokenTTL <= 0) {
+      return err({ reason: 'invalid_mapped_ttl' });
+    }
+  }
+
+  return ok({
+    userId: r.userId,
+    scope: r.scope,
+    props: r.props,
+    metadata: r.metadata,
+    accessTokenTTL: r.accessTokenTTL,
+  });
+}
+
+// ─── TTL clamp ────────────────────────────────────────────────────────────────
+
+interface ClampTtlInput {
+  configuredDefaultSeconds: number;
+  assertionExp: number;
+  mapperTtl: number | undefined;
+  now: number;
+}
+
+/**
+ * Compute the access token TTL bounded by:
+ *   - the AS's default (`options.accessTokenTTL`)
+ *   - the assertion's remaining lifetime (`exp - now`)
+ *   - the mapper-supplied override (if present)
+ *
+ * Returns `assertion_expired_after_processing` if no positive lifetime
+ * remains (e.g. the assertion crossed `exp` while we were validating it).
+ */
+export function clampEmaAccessTokenTTL(input: ClampTtlInput): Result<number, EmaValidationError> {
+  const { configuredDefaultSeconds, assertionExp, mapperTtl, now } = input;
+  const remaining = assertionExp - now;
+  let ttl = Math.min(configuredDefaultSeconds, remaining);
+
+  if (mapperTtl !== undefined) {
+    ttl = Math.min(ttl, mapperTtl);
+  }
+
+  if (ttl <= 0) {
+    return err({ reason: 'assertion_expired_after_processing' });
+  }
+
+  return ok(ttl);
+}
+
+// ─── Local helpers (not exported) ─────────────────────────────────────────────
+
+function readRequiredString(claims: Record<string, unknown>, claimName: string): Result<string, EmaValidationError> {
+  const value = claims[claimName];
+  if (typeof value !== 'string' || value.length === 0) {
+    return err({ reason: 'invalid_claim', claim: claimName });
+  }
+  return ok(value);
+}
+
+function readAudienceClaim(claims: Record<string, unknown>): Result<string | string[], EmaValidationError> {
+  const aud = claims.aud;
+  if (typeof aud === 'string' && aud.length > 0) {
+    return ok(aud);
+  }
+  if (Array.isArray(aud) && aud.length > 0 && aud.every((v) => typeof v === 'string' && v.length > 0)) {
+    return ok(aud);
+  }
+  return err({ reason: 'invalid_claim', claim: 'aud' });
+}
+
+function readNumericDateClaim(claims: Record<string, unknown>, claimName: string): Result<number, EmaValidationError> {
+  const value = claims[claimName];
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    return err({ reason: 'invalid_claim', claim: claimName });
+  }
+  return ok(value);
+}
+
+function parseScopeGrammar(scope: string): Result<string[], { reason: 'invalid_scope_grammar' }> {
+  if (!scope) return ok([]);
+  const tokens = scope.split(' ').filter(Boolean);
+  for (const token of tokens) {
+    if (!isValidOAuthScopeToken(token)) return err({ reason: 'invalid_scope_grammar' });
+  }
+  return ok(tokens);
+}

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -264,9 +264,9 @@ export function validateIdJagClaims(input: ValidateClaimsInput): Result<Validate
   if (rawClaims.scope !== undefined) {
     const parsed = readRequiredString(rawClaims, 'scope');
     if (!parsed.ok) return parsed;
-    const tokens = parseScopeGrammar(parsed.value);
-    if (tokens === null) {
-      return err({ reason: 'invalid_claim', claim: 'scope' });
+    const tokens = parsed.value.split(' ').filter(Boolean);
+    for (const token of tokens) {
+      if (!isValidOAuthScopeToken(token)) return err({ reason: 'invalid_claim', claim: 'scope' });
     }
     scope = parsed.value;
     assertionScopes = tokens;
@@ -303,15 +303,19 @@ export function parseEmaScopeParam(
   if (scope === undefined) {
     requested = [...assertionScopes];
   } else if (typeof scope === 'string') {
-    const parsed = parseScopeGrammar(scope);
-    if (parsed === null) return err({ reason: 'invalid_scope_param' });
-    requested = parsed;
+    const tokens = scope.split(' ').filter(Boolean);
+    for (const token of tokens) {
+      if (!isValidOAuthScopeToken(token)) return err({ reason: 'invalid_scope_param' });
+    }
+    requested = tokens;
   } else if (Array.isArray(scope) && scope.every((value) => typeof value === 'string')) {
     requested = [];
     for (const part of scope as string[]) {
-      const parsed = parseScopeGrammar(part);
-      if (parsed === null) return err({ reason: 'invalid_scope_param' });
-      requested.push(...parsed);
+      const tokens = part.split(' ').filter(Boolean);
+      for (const token of tokens) {
+        if (!isValidOAuthScopeToken(token)) return err({ reason: 'invalid_scope_param' });
+      }
+      requested.push(...tokens);
     }
   } else {
     return err({ reason: 'invalid_scope_param' });
@@ -424,20 +428,4 @@ function readNumericDateClaim(claims: Record<string, unknown>, claimName: string
     return err({ reason: 'invalid_claim', claim: claimName });
   }
   return ok(value);
-}
-
-/**
- * Split and validate an RFC 6749 §3.3 scope string. Returns `null` on
- * malformed input — callers attach whatever `EmaValidationError` arm fits
- * their context (claim vs. param vs. mapped). No Result here because the
- * error variant would only ever carry a constant reason that downstream
- * discards.
- */
-function parseScopeGrammar(scope: string): string[] | null {
-  if (!scope) return [];
-  const tokens = scope.split(' ').filter(Boolean);
-  for (const token of tokens) {
-    if (!isValidOAuthScopeToken(token)) return null;
-  }
-  return tokens;
 }

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -5,8 +5,8 @@
  * returns `Result<T, EmaValidationError>`. No `this`. No I/O. No clock —
  * `now` is always passed in so tests stay deterministic.
  *
- * Composed by the orchestrator (`src/ema/orchestrator.ts`) into the full
- * token-request pipeline.
+ * Composed by `OAuthProviderImpl.runEmaPipeline` in `src/oauth-provider.ts`
+ * into the full token-request pipeline.
  */
 
 import type { ClientInfo } from '../oauth-provider';
@@ -232,7 +232,9 @@ export function validateIdJagClaims(input: ValidateClaimsInput): Result<Validate
     return err({ reason: 'resource_mismatch', expected: configuredResource, got: resource.value });
   }
 
-  if (exp.value <= now) {
+  // RFC 7523 §3 rule 4: skew applies to `exp` too, otherwise sub-second
+  // clock drift between IdP and AS rejects assertions right at expiry.
+  if (exp.value + clockSkewSeconds <= now) {
     return err({ reason: 'expired', exp: exp.value, now });
   }
 

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -367,9 +367,9 @@ export function validateEmaMapperResult(result: unknown): Result<EmaClaimsMapper
   });
 }
 
-// ─── TTL clamp ────────────────────────────────────────────────────────────────
+// ─── Access token TTL ─────────────────────────────────────────────────────────
 
-interface ClampTtlInput {
+interface ComputeTtlInput {
   configuredDefaultSeconds: number;
   assertionExp: number;
   mapperTtl: number | undefined;
@@ -377,19 +377,12 @@ interface ClampTtlInput {
 }
 
 /**
- * Compute the access token TTL.
- *
- * The mapper-supplied override wins; otherwise the AS's default applies.
- * The assertion's `exp` governs how long the ID-JAG is valid as a grant,
- * not how long the access token issued in exchange lives — RFC 7523 §3
- * does not bind access-token lifetime to assertion lifetime, and the MCP
- * EMA spec example issues access tokens far longer than the 300s ID-JAG.
- *
- * Returns `assertion_expired_after_processing` if the assertion crossed
- * `exp` while we were validating it (TOCTOU race between claim check and
- * here).
+ * Compute the access token TTL: mapper override wins, otherwise the AS
+ * default. The assertion's `exp` is the lifetime of the grant, not of the
+ * issued token (RFC 7523 §3); we only re-check it here to catch the
+ * TOCTOU window between claim validation and token mint.
  */
-export function clampEmaAccessTokenTTL(input: ClampTtlInput): Result<number, EmaValidationError> {
+export function computeEmaAccessTokenTTL(input: ComputeTtlInput): Result<number, EmaValidationError> {
   const { configuredDefaultSeconds, assertionExp, mapperTtl, now } = input;
 
   if (assertionExp - now <= 0) {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -9,8 +9,8 @@ import {
   EMA_SUPPORTED_JWT_ALGORITHMS,
   type EmaSupportedAlg,
 } from './ema/constants';
-import { createKvJtiStore, jtiMarkResultToResult } from './ema/jti';
-import { createDefaultJwksProvider, jwksFetchResultToResult } from './ema/jwks';
+import { createKvJtiStore } from './ema/jti';
+import { createDefaultJwksProvider } from './ema/jwks';
 import { parseIdJag } from './ema/parser';
 import { emaErrorToWire, err, ok, type EmaValidationError, type Result } from './ema/result';
 import { selectJwk, verifyIdJagSignature } from './ema/signature';
@@ -2965,16 +2965,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     });
     if (!claims.ok) return claims;
 
-    const replay = jtiMarkResultToResult(
-      await jtiStore.markUsed({
-        issuer: claims.value.claims.iss,
-        jti: claims.value.claims.jti,
-        exp: claims.value.claims.exp,
-        now,
-        env,
-      }),
-      claims.value.claims.jti
-    );
+    const replay = await jtiStore.markUsed({
+      issuer: claims.value.claims.iss,
+      jti: claims.value.claims.jti,
+      exp: claims.value.claims.exp,
+      now,
+      env,
+    });
     if (!replay.ok) return replay;
 
     const requestedScope = parseEmaScopeParam(body.scope, claims.value.assertionScopes);
@@ -3038,16 +3035,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const alg = args.header.alg as EmaSupportedAlg;
     const { jwksProvider } = args;
 
-    const initialJwks = jwksFetchResultToResult(
-      await jwksProvider.fetch(args.trustedIssuer, { forceRefresh: false, now: args.now })
-    );
+    const initialJwks = await jwksProvider.fetch(args.trustedIssuer, { forceRefresh: false, now: args.now });
     if (!initialJwks.ok) return initialJwks;
 
     let jwk = selectJwk(initialJwks.value, alg, args.header.kid);
     if (!jwk.ok && args.header.kid) {
-      const refreshed = jwksFetchResultToResult(
-        await jwksProvider.fetch(args.trustedIssuer, { forceRefresh: true, now: args.now })
-      );
+      const refreshed = await jwksProvider.fetch(args.trustedIssuer, { forceRefresh: true, now: args.now });
       if (!refreshed.ok) return refreshed;
       jwk = selectJwk(refreshed.value, alg, args.header.kid);
     }

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -5,6 +5,7 @@ import {
   EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS,
   EMA_DEFAULT_JWT_ALGORITHM,
   EMA_DEFAULT_MAX_ASSERTION_LIFETIME_SECONDS,
+  EMA_ID_JAG_GRANT_PROFILE,
   EMA_ID_JAG_JWT_TYPE,
   EMA_JWKS_FETCH_TIMEOUT_MS,
   EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS,
@@ -42,7 +43,7 @@ import type {
   OAuthJsonWebKey,
 } from './ema/types';
 import {
-  clampEmaAccessTokenTTL,
+  computeEmaAccessTokenTTL,
   parseEmaScopeParam,
   resolveTrustedIssuer,
   validateEmaMapperResult,
@@ -1899,7 +1900,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const authorizationGrantProfilesSupported: string[] = [];
     if (this.options.enterpriseManagedAuthorization) {
       grantTypesSupported.push(GrantType.JWT_BEARER);
-      authorizationGrantProfilesSupported.push('urn:ietf:params:oauth:grant-profile:id-jag');
+      authorizationGrantProfilesSupported.push(EMA_ID_JAG_GRANT_PROFILE);
     }
 
     const metadata = {
@@ -3004,7 +3005,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const mapped = validateEmaMapperResult(mapperOutput);
     if (!mapped.ok) return mapped;
 
-    const ttl = clampEmaAccessTokenTTL({
+    const ttl = computeEmaAccessTokenTTL({
       configuredDefaultSeconds: this.options.accessTokenTTL ?? DEFAULT_ACCESS_TOKEN_TTL,
       assertionExp: claims.value.claims.exp,
       mapperTtl: mapped.value.accessTokenTTL,

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2967,11 +2967,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     });
     if (!claims.ok) return claims;
 
+    // Fresh clock read so the JTI KV TTL reflects the assertion's remaining
+    // lifetime at the moment of write, not at pipeline start (JWKS fetch
+    // already burned several ms; mapper hasn't run yet).
+    const markNow = Math.floor(Date.now() / 1000);
     const replay = await jtiStore.markUsed({
       issuer: claims.value.claims.iss,
       jti: claims.value.claims.jti,
       exp: claims.value.claims.exp,
-      now,
+      now: markNow,
       env,
     });
     if (!replay.ok) return replay;
@@ -3080,6 +3084,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     env: any;
     now: number;
   }): Promise<TokenResponse> {
+    // Defense-in-depth downscope: the mapper's output is filtered through the
+    // assertion's scope claim (when present) so that a mapper returning an
+    // out-of-band `admin` scope cannot escalate beyond what the IdP authorized.
+    // `parseEmaScopeParam` already downscoped the *requested* scope before
+    // the mapper saw it; this is the second layer that bounds the *mapper's*
+    // output too. When the assertion carries no scope claim, the mapper has
+    // full discretion (no ceiling to enforce).
     const tokenScopes =
       args.assertionScopes.length > 0 ? this.downscope(args.mapperScope, args.assertionScopes) : args.mapperScope;
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -24,10 +24,6 @@ export type {
   EmaClaimsMapperInput,
   EmaClaimsMapperResult,
   EmaIdJagClaims,
-  EmaJtiMarkResult,
-  EmaJtiStore,
-  EmaJwksFetchResult,
-  EmaJwksProvider,
   EmaOptions,
   EmaTrustedIssuer,
   EmaTrustedIssuerResolver,
@@ -1254,21 +1250,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private typedApiHandlers: Array<[string, TypedHandler<Env>]>;
 
-  /**
-   * Adapter used to fetch IdP JWKS for ID-JAG signature verification.
-   * Defaults to the in-memory cached fetcher (`createDefaultJwksProvider`).
-   * Deployers may supply a custom implementation via
-   * `EmaOptions.jwksProvider` (e.g. one backed by the Workers Cache API).
-   */
+  /** In-memory cached IdP JWKS fetcher used during ID-JAG signature verification. */
   private readonly jwksProvider: EmaJwksProvider;
 
-  /**
-   * Adapter used to record ID-JAG `jti` values for replay protection.
-   * Defaults to a KV-backed best-effort store (`createKvJtiStore`).
-   * Deployers may supply a Durable Object-backed implementation via
-   * `EmaOptions.jtiStore` if strict-once semantics are required under
-   * concurrent requests.
-   */
+  /** KV-backed best-effort store recording ID-JAG `jti` values for replay protection. */
   private readonly jtiStore: EmaJtiStore;
 
   /**
@@ -1340,12 +1325,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     this.validateEmaOptions(this.options.enterpriseManagedAuthorization);
 
-    this.jwksProvider =
-      this.options.enterpriseManagedAuthorization?.jwksProvider ??
-      createDefaultJwksProvider({
-        cacheTtlSeconds: this.options.enterpriseManagedAuthorization?.jwksCacheTtlSeconds,
-      });
-    this.jtiStore = this.options.enterpriseManagedAuthorization?.jtiStore ?? createKvJtiStore();
+    this.jwksProvider = createDefaultJwksProvider({
+      cacheTtlSeconds: this.options.enterpriseManagedAuthorization?.jwksCacheTtlSeconds,
+    });
+    this.jtiStore = createKvJtiStore();
   }
 
   /**

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2996,11 +2996,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const mapped = validateEmaMapperResult(mapperOutput);
     if (!mapped.ok) return mapped;
 
+    // Fresh clock read so the `exp` check inside `computeEmaAccessTokenTTL`
+    // catches assertions that crossed `exp` during JWKS fetch + mapper execution
+    // — the pipeline-start `now` is too old for this TOCTOU guard.
     const ttl = computeEmaAccessTokenTTL({
       configuredDefaultSeconds: this.options.accessTokenTTL ?? DEFAULT_ACCESS_TOKEN_TTL,
       assertionExp: claims.value.claims.exp,
       mapperTtl: mapped.value.accessTokenTTL,
-      now,
+      now: Math.floor(Date.now() / 1000),
     });
     if (!ttl.ok) return ttl;
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1,5 +1,55 @@
 import { WorkerEntrypoint } from 'cloudflare:workers';
 
+import {
+  EMA_DEFAULT_CLOCK_SKEW_SECONDS,
+  EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS,
+  EMA_DEFAULT_JWT_ALGORITHM,
+  EMA_DEFAULT_MAX_ASSERTION_LIFETIME_SECONDS,
+  EMA_ID_JAG_JWT_TYPE,
+  EMA_JWKS_FETCH_TIMEOUT_MS,
+  EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS,
+  EMA_JWKS_MAX_SIZE_BYTES,
+  EMA_MAX_JWT_BYTES,
+  EMA_SUPPORTED_JWT_ALGORITHMS,
+  type EmaSupportedAlg,
+} from './ema/constants';
+import { createKvJtiStore, jtiMarkResultToResult } from './ema/jti';
+import { createDefaultJwksProvider, jwksFetchResultToResult } from './ema/jwks';
+import { parseIdJag } from './ema/parser';
+import { emaErrorToOnErrorPayload, emaErrorToWire, err, ok, type EmaValidationError, type Result } from './ema/result';
+import { selectJwk, verifyIdJagSignature } from './ema/signature';
+export type {
+  EmaClaimsMapper,
+  EmaClaimsMapperInput,
+  EmaClaimsMapperResult,
+  EmaIdJagClaims,
+  EmaJtiMarkResult,
+  EmaJtiStore,
+  EmaJwksFetchResult,
+  EmaJwksProvider,
+  EmaOptions,
+  EmaTrustedIssuer,
+  EmaTrustedIssuerResolver,
+  EmaTrustedIssuerResolverInput,
+} from './ema/types';
+export type { EmaValidationError, EmaOnErrorPayload } from './ema/result';
+import type {
+  EmaJtiStore,
+  EmaJwksProvider,
+  EmaOptions,
+  EmaTrustedIssuer,
+  JsonWebKeySet,
+  OAuthJsonWebKey,
+} from './ema/types';
+import {
+  clampEmaAccessTokenTTL,
+  parseEmaScopeParam,
+  resolveTrustedIssuer,
+  validateEmaMapperResult,
+  validateIdJagClaims,
+  validateIdJagHeader,
+} from './ema/validators';
+
 const PROTECTED_RESOURCE_WELL_KNOWN_PREFIX = '/.well-known/oauth-protected-resource';
 
 // Log CIMD status on module load
@@ -30,6 +80,7 @@ export enum GrantType {
   AUTHORIZATION_CODE = 'authorization_code',
   REFRESH_TOKEN = 'refresh_token',
   TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange',
+  JWT_BEARER = 'urn:ietf:params:oauth:grant-type:jwt-bearer',
 }
 
 /** ExecutionContext with writable props — ctx.props is read-only in types but writable at runtime */
@@ -322,6 +373,16 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * Defaults to false.
    */
   allowTokenExchangeGrant?: boolean;
+
+  /**
+   * Experimental support for the MCP Enterprise-Managed Authorization extension.
+   * When enabled, the token endpoint accepts ID-JAG assertions using the JWT bearer
+   * grant type (`urn:ietf:params:oauth:grant-type:jwt-bearer`).
+   *
+   * This feature is opt-in because the MCP extension and underlying OAuth drafts are
+   * still evolving. Trusted issuers and a claim mapper are required.
+   */
+  enterpriseManagedAuthorization?: EmaOptions<Env>;
 
   /**
    * Controls whether public clients (clients without a secret, like SPAs) can register via the
@@ -1193,6 +1254,23 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private typedApiHandlers: Array<[string, TypedHandler<Env>]>;
 
   /**
+   * Adapter used to fetch IdP JWKS for ID-JAG signature verification.
+   * Defaults to the in-memory cached fetcher (`createDefaultJwksProvider`).
+   * Deployers may supply a custom implementation via
+   * `EmaOptions.jwksProvider` (e.g. one backed by the Workers Cache API).
+   */
+  private readonly jwksProvider: EmaJwksProvider;
+
+  /**
+   * Adapter used to record ID-JAG `jti` values for replay protection.
+   * Defaults to a KV-backed best-effort store (`createKvJtiStore`).
+   * Deployers may supply a Durable Object-backed implementation via
+   * `EmaOptions.jtiStore` if strict-once semantics are required under
+   * concurrent requests.
+   */
+  private readonly jtiStore: EmaJtiStore;
+
+  /**
    * Creates a new OAuth provider instance
    * @param options - Configuration options for the provider
    */
@@ -1258,6 +1336,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         console.warn(`OAuth error response: ${status} ${code} - ${description}`),
       ...options,
     };
+
+    this.validateEmaOptions(this.options.enterpriseManagedAuthorization);
+
+    this.jwksProvider =
+      this.options.enterpriseManagedAuthorization?.jwksProvider ??
+      createDefaultJwksProvider({
+        cacheTtlSeconds: this.options.enterpriseManagedAuthorization?.jwksCacheTtlSeconds,
+      });
+    this.jtiStore = this.options.enterpriseManagedAuthorization?.jtiStore ?? createKvJtiStore();
   }
 
   /**
@@ -1303,6 +1390,47 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     throw new TypeError(
       `${name} must be either an ExportedHandler object with a fetch method or a class extending WorkerEntrypoint`
     );
+  }
+
+  /**
+   * Validates MCP Enterprise-Managed Authorization configuration at construction time.
+   *
+   * Presence of `enterpriseManagedAuthorization` on options enables the feature —
+   * there is no separate `enabled` flag (which would silently disable EMA when
+   * forgotten). Configuration is checked structurally; runtime concerns
+   * (JWKS reachability etc.) are checked when assertions arrive.
+   */
+  private validateEmaOptions(options: EmaOptions<Env> | undefined): void {
+    if (!options) {
+      return;
+    }
+
+    if (typeof options.trustedIssuers !== 'function') {
+      throw new TypeError(
+        'enterpriseManagedAuthorization.trustedIssuers must be a resolver function: (input) => EmaTrustedIssuer | null'
+      );
+    }
+
+    if (typeof options.mapClaims !== 'function') {
+      throw new TypeError('enterpriseManagedAuthorization.mapClaims must be a function');
+    }
+
+    // Defense-in-depth: an EMA-configured provider without a declared
+    // resource would accept any RFC-8707-shaped `resource` claim, sidestepping
+    // the AS-side resource pinning. Require it explicitly.
+    if (!this.options.resourceMetadata?.resource) {
+      throw new TypeError('enterpriseManagedAuthorization requires resourceMetadata.resource to be configured');
+    }
+
+    if (options.jwksCacheTtlSeconds !== undefined && options.jwksCacheTtlSeconds <= 0) {
+      throw new TypeError('enterpriseManagedAuthorization.jwksCacheTtlSeconds must be greater than 0');
+    }
+    if (options.clockSkewSeconds !== undefined && options.clockSkewSeconds < 0) {
+      throw new TypeError('enterpriseManagedAuthorization.clockSkewSeconds must be non-negative');
+    }
+    if (options.maxAssertionLifetimeSeconds !== undefined && options.maxAssertionLifetimeSeconds <= 0) {
+      throw new TypeError('enterpriseManagedAuthorization.maxAssertionLifetimeSeconds must be greater than 0');
+    }
   }
 
   /**
@@ -1365,7 +1493,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       if (parsed.isRevocationRequest) {
         response = await this.handleRevocationRequest(parsed.body, env);
       } else {
-        response = await this.handleTokenRequest(parsed.body, parsed.clientInfo, env);
+        response = await this.handleTokenRequest(parsed.body, parsed.clientInfo, env, url, request);
       }
 
       return this.addCorsHeaders(response, request);
@@ -1703,6 +1831,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
+   * Gets the authorization server issuer using the same derivation as RFC 8414 metadata.
+   */
+  private getAuthorizationServerIssuer(requestUrl: URL): string {
+    const tokenEndpoint = this.getFullEndpointUrl(this.options.tokenEndpoint, requestUrl);
+    return new URL(tokenEndpoint).origin;
+  }
+
+  /**
    * Adds CORS headers to a response
    * @param response - The response to add CORS headers to
    * @param request - The original request
@@ -1759,6 +1895,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const grantTypesSupported = [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN];
     if (this.options.allowTokenExchangeGrant) {
       grantTypesSupported.push(GrantType.TOKEN_EXCHANGE);
+    }
+    if (this.options.enterpriseManagedAuthorization) {
+      grantTypesSupported.push(GrantType.JWT_BEARER);
     }
 
     const metadata = {
@@ -1833,7 +1972,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param env - Cloudflare Worker environment variables
    * @returns Response with token data or error
    */
-  private async handleTokenRequest(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+  private async handleTokenRequest(
+    body: any,
+    clientInfo: ClientInfo,
+    env: any,
+    requestUrl: URL,
+    request: Request
+  ): Promise<Response> {
     // Handle different grant types. Any `OAuthError` thrown from below
     // (typically from `tokenExchangeCallback` or any code it calls) is
     // converted into a structured OAuth 2.0 `/token` error response.
@@ -1848,6 +1993,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         return await this.handleRefreshTokenGrant(body, clientInfo, env);
       } else if (grantType === GrantType.TOKEN_EXCHANGE && this.options.allowTokenExchangeGrant) {
         return await this.handleTokenExchangeGrant(body, clientInfo, env);
+      } else if (grantType === GrantType.JWT_BEARER) {
+        return await this.handleJwtBearerGrant(body, clientInfo, env, requestUrl, request);
       } else {
         return this.createErrorResponse('unsupported_grant_type', { description: 'Grant type not supported' });
       }
@@ -2718,6 +2865,259 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       if (response) return response;
       throw error;
     }
+  }
+
+  /**
+   * Handles the MCP Enterprise-Managed Authorization JWT-bearer grant.
+   *
+   * Acts as a thin shell around `runEmaPipeline`: gate non-EMA traffic, run
+   * the pipeline, translate the typed `EmaValidationError` Result back to a
+   * standard OAuth wire response. All validation logic lives in pure
+   * functions in `src/ema/`.
+   */
+  private async handleJwtBearerGrant(
+    body: any,
+    clientInfo: ClientInfo,
+    env: any,
+    requestUrl: URL,
+    request: Request
+  ): Promise<Response> {
+    const enterpriseOptions = this.options.enterpriseManagedAuthorization;
+    if (!enterpriseOptions) {
+      return this.createErrorResponse('unsupported_grant_type', { description: 'Grant type not supported' });
+    }
+
+    if (clientInfo.tokenEndpointAuthMethod === 'none') {
+      return this.createErrorResponse('invalid_client', {
+        description: 'Enterprise-managed authorization requires client authentication',
+        statusCode: 401,
+      });
+    }
+
+    const result = await this.runEmaPipeline({ body, clientInfo, env, requestUrl, request, enterpriseOptions });
+
+    if (!result.ok) {
+      const wire = emaErrorToWire(result.error);
+      // The standard onError hook fires inside createErrorResponse; the
+      // structured EmaValidationError reason is exposed via the typed
+      // payload helper for deployers who wire up richer diagnostics in
+      // future (the hook's signature is not yet plumbed through, but the
+      // helper gives a stable contract for that work).
+      void emaErrorToOnErrorPayload(result.error);
+      return this.createErrorResponse(wire.code, { description: wire.message });
+    }
+
+    return new Response(JSON.stringify(result.value), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  /**
+   * Runs the full EMA token-request pipeline as a chain of pure validators
+   * and adapter calls. Each step short-circuits on the first failure.
+   *
+   * Sequence:
+   *   parse → validate header → trust issuer → fetch JWKS → select key →
+   *   verify signature → validate claims → record jti → parse scope →
+   *   run mapper → validate mapper result → clamp TTL → mint token.
+   */
+  private async runEmaPipeline(args: {
+    body: any;
+    clientInfo: ClientInfo;
+    env: any;
+    requestUrl: URL;
+    request: Request;
+    enterpriseOptions: EmaOptions<Env>;
+  }): Promise<Result<TokenResponse, EmaValidationError>> {
+    const { body, clientInfo, env, requestUrl, request, enterpriseOptions } = args;
+    const now = Math.floor(Date.now() / 1000);
+
+    const parsed = parseIdJag(body.assertion, EMA_MAX_JWT_BYTES);
+    if (!parsed.ok) return parsed;
+
+    const header = validateIdJagHeader(parsed.value.header, EMA_ID_JAG_JWT_TYPE, EMA_SUPPORTED_JWT_ALGORITHMS);
+    if (!header.ok) return header;
+    const alg = header.value.alg as EmaSupportedAlg;
+
+    const trustedIssuer = await resolveTrustedIssuer({
+      iss: parsed.value.rawClaims.iss,
+      alg,
+      resolver: enterpriseOptions.trustedIssuers,
+      env,
+      request,
+      clientInfo,
+    });
+    if (!trustedIssuer.ok) return trustedIssuer;
+
+    const verified = await this.verifyAssertionSignature({
+      parsed: parsed.value,
+      header: header.value,
+      trustedIssuer: trustedIssuer.value,
+      now,
+    });
+    if (!verified.ok) return verified;
+
+    const claims = validateIdJagClaims({
+      rawClaims: parsed.value.rawClaims,
+      trustedIssuer: trustedIssuer.value,
+      expectedAudience: trustedIssuer.value.audience ?? this.getAuthorizationServerIssuer(requestUrl),
+      clientId: clientInfo.clientId,
+      configuredResource: this.options.resourceMetadata!.resource!,
+      matchOriginOnly: !!this.options.resourceMatchOriginOnly,
+      now,
+      clockSkewSeconds: enterpriseOptions.clockSkewSeconds ?? EMA_DEFAULT_CLOCK_SKEW_SECONDS,
+      maxAssertionLifetimeSeconds:
+        enterpriseOptions.maxAssertionLifetimeSeconds ?? EMA_DEFAULT_MAX_ASSERTION_LIFETIME_SECONDS,
+    });
+    if (!claims.ok) return claims;
+
+    const replay = jtiMarkResultToResult(
+      await this.jtiStore.markUsed({
+        issuer: claims.value.claims.iss,
+        jti: claims.value.claims.jti,
+        exp: claims.value.claims.exp,
+        now,
+        env,
+      }),
+      claims.value.claims.jti
+    );
+    if (!replay.ok) return replay;
+
+    const requestedScope = parseEmaScopeParam(body.scope, claims.value.assertionScopes);
+    if (!requestedScope.ok) return requestedScope;
+
+    const mapperOutput = await Promise.resolve(
+      enterpriseOptions.mapClaims({
+        claims: claims.value.claims,
+        clientInfo,
+        resource: claims.value.resource,
+        requestedScope: requestedScope.value,
+        env,
+      })
+    );
+    const mapped = validateEmaMapperResult(mapperOutput);
+    if (!mapped.ok) return mapped;
+
+    const ttl = clampEmaAccessTokenTTL({
+      configuredDefaultSeconds: this.options.accessTokenTTL ?? DEFAULT_ACCESS_TOKEN_TTL,
+      assertionExp: claims.value.claims.exp,
+      mapperTtl: mapped.value.accessTokenTTL,
+      now,
+    });
+    if (!ttl.ok) return ttl;
+
+    return ok(
+      await this.issueEmaAccessToken({
+        clientId: clientInfo.clientId,
+        userId: mapped.value.userId,
+        mapperScope: mapped.value.scope,
+        mapperProps: mapped.value.props,
+        mapperMetadata: mapped.value.metadata,
+        assertionScopes: claims.value.assertionScopes,
+        resource: claims.value.resource,
+        accessTokenTTLSeconds: ttl.value,
+        env,
+        now,
+      })
+    );
+  }
+
+  /**
+   * Verifies the ID-JAG signature against the trusted issuer's JWKS,
+   * force-refreshing once on a `kid` miss to accommodate IdP key rotation.
+   * Delegates JWKS retrieval to `this.jwksProvider` (default impl is the
+   * in-memory cached fetcher with anti-DoS cool-down).
+   */
+  private async verifyAssertionSignature(args: {
+    parsed: { header: Record<string, unknown>; signingInput: Uint8Array; signature: Uint8Array };
+    header: { alg: string; kid?: string };
+    trustedIssuer: EmaTrustedIssuer;
+    now: number;
+  }): Promise<Result<void, EmaValidationError>> {
+    const alg = args.header.alg as EmaSupportedAlg;
+
+    const initialJwks = jwksFetchResultToResult(
+      await this.jwksProvider.fetch(args.trustedIssuer, { forceRefresh: false, now: args.now })
+    );
+    if (!initialJwks.ok) return initialJwks;
+
+    let jwk = selectJwk(initialJwks.value, alg, args.header.kid);
+    if (!jwk.ok && args.header.kid) {
+      const refreshed = jwksFetchResultToResult(
+        await this.jwksProvider.fetch(args.trustedIssuer, { forceRefresh: true, now: args.now })
+      );
+      if (!refreshed.ok) return refreshed;
+      jwk = selectJwk(refreshed.value, alg, args.header.kid);
+    }
+    if (!jwk.ok) return jwk;
+
+    const verified = await verifyIdJagSignature({
+      alg,
+      jwk: jwk.value,
+      signingInput: args.parsed.signingInput,
+      signature: args.parsed.signature,
+    });
+    if (!verified) return err({ reason: 'signature_failed' });
+
+    return ok(undefined);
+  }
+
+  /**
+   * Mints the access token for an authorized EMA request.
+   *
+   * Uses the same grant + access-token machinery as the authorization-code
+   * grant: encrypt the props, persist the grant under `grant:userId:grantId`,
+   * and create an opaque access token bound to the resource as audience.
+   */
+  private async issueEmaAccessToken(args: {
+    clientId: string;
+    userId: string;
+    mapperScope: string[];
+    mapperProps: unknown;
+    mapperMetadata: unknown;
+    assertionScopes: string[];
+    resource: string;
+    accessTokenTTLSeconds: number;
+    env: any;
+    now: number;
+  }): Promise<TokenResponse> {
+    const tokenScopes =
+      args.assertionScopes.length > 0 ? this.downscope(args.mapperScope, args.assertionScopes) : args.mapperScope;
+
+    const grantId = generateRandomString(16);
+    const { encryptedData, key: encryptionKey } = await encryptProps(args.mapperProps);
+    const grant: Grant = {
+      id: grantId,
+      clientId: args.clientId,
+      userId: args.userId,
+      scope: tokenScopes,
+      metadata: args.mapperMetadata ?? null,
+      encryptedProps: encryptedData,
+      createdAt: args.now,
+      expiresAt: args.now + args.accessTokenTTLSeconds,
+      resource: args.resource,
+    };
+    await this.saveGrantWithTTL(args.env, `grant:${args.userId}:${grantId}`, grant, args.now);
+
+    const accessToken = await this.createAccessToken({
+      userId: args.userId,
+      grantId,
+      clientId: args.clientId,
+      scope: tokenScopes,
+      encryptedProps: encryptedData,
+      encryptionKey,
+      expiresIn: args.accessTokenTTLSeconds,
+      audience: args.resource,
+      env: args.env,
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: 'bearer',
+      expires_in: args.accessTokenTTLSeconds,
+      scope: tokenScopes.join(' '),
+      resource: args.resource,
+    };
   }
 
   /**
@@ -3660,13 +4060,18 @@ const DEFAULT_PURGE_BATCH_SIZE = 50;
  */
 const TOKEN_LENGTH = 32;
 
+/**
+ * RFC 6749 Section 3.3 scope-token grammar.
+ */
+const OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+
 // Helper Functions
 /**
  * Validates a resource URI per RFC 8707 Section 2
  * @param uri - The URI string to validate
  * @returns true if valid, false otherwise
  */
-function validateResourceUri(uri: string): boolean {
+export function validateResourceUri(uri: string): boolean {
   if (!uri || typeof uri !== 'string') {
     return false;
   }
@@ -3756,7 +4161,7 @@ function parseResourceParameter(value: string | string[] | undefined): string | 
  * When originOnly is true, compares only the origin (scheme + host + port),
  * allowing path-aware resources to match origin-only grants.
  */
-function resourceMatches(requested: string, granted: string, originOnly: boolean): boolean {
+export function resourceMatches(requested: string, granted: string, originOnly: boolean): boolean {
   if (!originOnly) {
     return requested === granted;
   }
@@ -3918,6 +4323,62 @@ function isValidRedirectUri(requestUri: string, registeredUris: string[]): boole
  */
 function base64UrlEncode(str: string): string {
   return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/**
+ * Decodes a base64url-encoded string to bytes.
+ */
+export function base64UrlToBytes(base64Url: string): Uint8Array {
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+  const binaryString = atob(padded);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Parses a base64url-encoded JWT JSON part into an object.
+ */
+export function parseJwtJsonPart(encoded: string): Record<string, unknown> {
+  try {
+    const json = new TextDecoder().decode(base64UrlToBytes(encoded));
+    const parsed = JSON.parse(json);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('JWT part must be an object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error('Malformed JWT part');
+  }
+}
+
+export function isValidOAuthScopeToken(scopeToken: string): boolean {
+  return OAUTH_SCOPE_TOKEN_PATTERN.test(scopeToken);
+}
+
+/**
+ * Gets WebCrypto import and verify parameters for supported JOSE algorithms.
+ */
+export function getJwtCryptoAlgorithms(alg: string): {
+  importAlgorithm: Parameters<SubtleCrypto['importKey']>[2];
+  verifyAlgorithm: Parameters<SubtleCrypto['verify']>[0];
+} {
+  if (alg === 'RS256') {
+    const algorithm = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' };
+    return { importAlgorithm: algorithm, verifyAlgorithm: algorithm };
+  }
+
+  if (alg === 'ES256') {
+    return {
+      importAlgorithm: { name: 'ECDSA', namedCurve: 'P-256' },
+      verifyAlgorithm: { name: 'ECDSA', hash: 'SHA-256' },
+    };
+  }
+
+  throw new Error(`Unsupported JWT alg: ${alg}`);
 }
 
 /**

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -14,6 +14,16 @@ import { createDefaultJwksProvider } from './ema/jwks';
 import { parseIdJag } from './ema/parser';
 import { emaErrorToWire, err, ok, type EmaValidationError, type Result } from './ema/result';
 import { selectJwk, verifyIdJagSignature } from './ema/signature';
+import type { EmaJtiStore, EmaJwksProvider, EmaOptions, EmaTrustedIssuer } from './ema/types';
+import {
+  computeEmaAccessTokenTTL,
+  parseEmaScopeParam,
+  resolveTrustedIssuer,
+  validateEmaMapperResult,
+  validateIdJagClaims,
+  validateIdJagHeader,
+} from './ema/validators';
+
 export type {
   EmaClaimsMapper,
   EmaClaimsMapperInput,
@@ -25,15 +35,6 @@ export type {
   EmaTrustedIssuerResolverInput,
 } from './ema/types';
 export type { EmaValidationError } from './ema/result';
-import type { EmaJtiStore, EmaJwksProvider, EmaOptions, EmaTrustedIssuer } from './ema/types';
-import {
-  computeEmaAccessTokenTTL,
-  parseEmaScopeParam,
-  resolveTrustedIssuer,
-  validateEmaMapperResult,
-  validateIdJagClaims,
-  validateIdJagHeader,
-} from './ema/validators';
 
 const PROTECTED_RESOURCE_WELL_KNOWN_PREFIX = '/.well-known/oauth-protected-resource';
 
@@ -2993,14 +2994,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const mapped = validateEmaMapperResult(mapperOutput);
     if (!mapped.ok) return mapped;
 
-    // Fresh clock read so the `exp` check inside `computeEmaAccessTokenTTL`
-    // catches assertions that crossed `exp` during JWKS fetch + mapper execution
-    // — the pipeline-start `now` is too old for this TOCTOU guard.
+    // Fresh clock read so both the TTL TOCTOU guard and the grant `createdAt`
+    // reflect post-mapper time — the pipeline-start `now` is stale by the
+    // time we reach this point (JWKS fetch + mapper invocation may take
+    // hundreds of ms).
+    const issueNow = Math.floor(Date.now() / 1000);
     const ttl = computeEmaAccessTokenTTL({
       configuredDefaultSeconds: this.options.accessTokenTTL ?? DEFAULT_ACCESS_TOKEN_TTL,
       assertionExp: claims.value.claims.exp,
       mapperTtl: mapped.value.accessTokenTTL,
-      now: Math.floor(Date.now() / 1000),
+      now: issueNow,
     });
     if (!ttl.ok) return ttl;
 
@@ -3015,7 +3018,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         resource: claims.value.resource,
         accessTokenTTLSeconds: ttl.value,
         env,
-        now,
+        now: issueNow,
       })
     );
   }

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -17,7 +17,7 @@ import {
 import { createKvJtiStore, jtiMarkResultToResult } from './ema/jti';
 import { createDefaultJwksProvider, jwksFetchResultToResult } from './ema/jwks';
 import { parseIdJag } from './ema/parser';
-import { emaErrorToOnErrorPayload, emaErrorToWire, err, ok, type EmaValidationError, type Result } from './ema/result';
+import { emaErrorToWire, err, ok, type EmaValidationError, type Result } from './ema/result';
 import { selectJwk, verifyIdJagSignature } from './ema/signature';
 export type {
   EmaClaimsMapper,
@@ -29,7 +29,7 @@ export type {
   EmaTrustedIssuerResolver,
   EmaTrustedIssuerResolverInput,
 } from './ema/types';
-export type { EmaValidationError, EmaOnErrorPayload } from './ema/result';
+export type { EmaValidationError } from './ema/result';
 import type {
   EmaJtiStore,
   EmaJwksProvider,
@@ -414,16 +414,22 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   resolveExternalToken?: (input: ResolveExternalTokenInput) => Promise<ResolveExternalTokenResult | null>;
 
   /**
-   * Optional callback function that is called whenever the OAuthProvider returns an error response
+   * Optional callback function that is called whenever the OAuthProvider returns an error response.
    * This allows the client to emit notifications or perform other actions when an error occurs.
    *
    * If the function returns a Response, that will be used in place of the OAuthProvider's default one.
+   *
+   * `internal` (when present) carries a tagged, server-side-only reason that the library
+   * deliberately did NOT put on the wire — used for richer diagnostics where the public
+   * response must stay generic (e.g. JWT validation failures on the EMA path). Backwards
+   * compatible: existing callbacks ignoring this field continue to work unchanged.
    */
   onError?: (error: {
     code: string;
     description: string;
     status: number;
     headers: Record<string, string>;
+    internal?: { category: string; reason: string; detail?: unknown };
   }) => Response | void;
 
   /**
@@ -2888,13 +2894,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     if (!result.ok) {
       const wire = emaErrorToWire(result.error);
-      // The standard onError hook fires inside createErrorResponse; the
-      // structured EmaValidationError reason is exposed via the typed
-      // payload helper for deployers who wire up richer diagnostics in
-      // future (the hook's signature is not yet plumbed through, but the
-      // helper gives a stable contract for that work).
-      void emaErrorToOnErrorPayload(result.error);
-      return this.createErrorResponse(wire.code, { description: wire.message });
+      return this.createErrorResponse(
+        wire.code,
+        { description: wire.message },
+        { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
+      );
     }
 
     return new Response(JSON.stringify(result.value), {
@@ -3897,12 +3901,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
-   * Helper function to create OAuth error responses
-   * @param code - OAuth error code (e.g., 'invalid_request', 'invalid_token')
-   * @param options - Error response options
-   * @returns A Response object with the error
+   * Helper function to create OAuth error responses.
+   *
+   * `internal` (optional) carries a tagged, server-side-only reason. It is
+   * forwarded to the deployer's `onError` hook but never placed on the wire,
+   * so the public response stays RFC-compliant and free of information leak
+   * while the deployer can still observe which check failed.
    */
-  private createErrorResponse(code: string, options: OAuthErrorOptions): Response {
+  private createErrorResponse(
+    code: string,
+    options: OAuthErrorOptions,
+    internal?: { category: string; reason: string; detail?: unknown }
+  ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
     const responseHeaders = options.headers ?? {};
@@ -3913,6 +3923,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       description,
       status: responseStatus,
       headers: responseHeaders,
+      ...(internal ? { internal } : {}),
     });
     if (customErrorResponse) return customErrorResponse;
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1896,8 +1896,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (this.options.allowTokenExchangeGrant) {
       grantTypesSupported.push(GrantType.TOKEN_EXCHANGE);
     }
+    const authorizationGrantProfilesSupported: string[] = [];
     if (this.options.enterpriseManagedAuthorization) {
       grantTypesSupported.push(GrantType.JWT_BEARER);
+      authorizationGrantProfilesSupported.push('urn:ietf:params:oauth:grant-profile:id-jag');
     }
 
     const metadata = {
@@ -1910,6 +1912,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       response_types_supported: responseTypesSupported,
       response_modes_supported: ['query'],
       grant_types_supported: grantTypesSupported,
+      // MCP Enterprise-Managed Authorization grant profile (only when EMA is configured).
+      ...(authorizationGrantProfilesSupported.length > 0
+        ? { authorization_grant_profiles_supported: authorizationGrantProfilesSupported }
+        : {}),
       // Support "none" auth method for public clients
       token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
       // not implemented: token_endpoint_auth_signing_alg_values_supported

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2,14 +2,9 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 
 import {
   EMA_DEFAULT_CLOCK_SKEW_SECONDS,
-  EMA_DEFAULT_JWKS_CACHE_TTL_SECONDS,
-  EMA_DEFAULT_JWT_ALGORITHM,
   EMA_DEFAULT_MAX_ASSERTION_LIFETIME_SECONDS,
   EMA_ID_JAG_GRANT_PROFILE,
   EMA_ID_JAG_JWT_TYPE,
-  EMA_JWKS_FETCH_TIMEOUT_MS,
-  EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS,
-  EMA_JWKS_MAX_SIZE_BYTES,
   EMA_MAX_JWT_BYTES,
   EMA_SUPPORTED_JWT_ALGORITHMS,
   type EmaSupportedAlg,
@@ -30,14 +25,7 @@ export type {
   EmaTrustedIssuerResolverInput,
 } from './ema/types';
 export type { EmaValidationError } from './ema/result';
-import type {
-  EmaJtiStore,
-  EmaJwksProvider,
-  EmaOptions,
-  EmaTrustedIssuer,
-  JsonWebKeySet,
-  OAuthJsonWebKey,
-} from './ema/types';
+import type { EmaJtiStore, EmaJwksProvider, EmaOptions, EmaTrustedIssuer } from './ema/types';
 import {
   computeEmaAccessTokenTTL,
   parseEmaScopeParam,
@@ -1256,11 +1244,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private typedApiHandlers: Array<[string, TypedHandler<Env>]>;
 
-  /** In-memory cached IdP JWKS fetcher used during ID-JAG signature verification. */
-  private readonly jwksProvider: EmaJwksProvider;
+  /** In-memory cached IdP JWKS fetcher; only constructed when EMA is configured. */
+  private readonly jwksProvider: EmaJwksProvider | undefined;
 
-  /** KV-backed best-effort store recording ID-JAG `jti` values for replay protection. */
-  private readonly jtiStore: EmaJtiStore;
+  /** KV-backed best-effort `jti` replay store; only constructed when EMA is configured. */
+  private readonly jtiStore: EmaJtiStore | undefined;
 
   /**
    * Creates a new OAuth provider instance
@@ -1331,10 +1319,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     this.validateEmaOptions(this.options.enterpriseManagedAuthorization);
 
-    this.jwksProvider = createDefaultJwksProvider({
-      cacheTtlSeconds: this.options.enterpriseManagedAuthorization?.jwksCacheTtlSeconds,
-    });
-    this.jtiStore = createKvJtiStore();
+    if (this.options.enterpriseManagedAuthorization) {
+      this.jwksProvider = createDefaultJwksProvider({
+        cacheTtlSeconds: this.options.enterpriseManagedAuthorization.jwksCacheTtlSeconds,
+      });
+      this.jtiStore = createKvJtiStore();
+    }
   }
 
   /**
@@ -2892,17 +2882,20 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     const result = await this.runEmaPipeline({ body, clientInfo, env, requestUrl, request, enterpriseOptions });
 
+    // RFC 6749 §5.1 — token endpoint responses must not be cached.
+    const noCacheHeaders = { 'Cache-Control': 'no-store', Pragma: 'no-cache' };
+
     if (!result.ok) {
       const wire = emaErrorToWire(result.error);
       return this.createErrorResponse(
         wire.code,
-        { description: wire.message },
+        { description: wire.message, headers: noCacheHeaders },
         { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
       );
     }
 
     return new Response(JSON.stringify(result.value), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...noCacheHeaders },
     });
   }
 
@@ -2913,7 +2906,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * Sequence:
    *   parse → validate header → trust issuer → fetch JWKS → select key →
    *   verify signature → validate claims → record jti → parse scope →
-   *   run mapper → validate mapper result → clamp TTL → mint token.
+   *   run mapper → validate mapper result → compute TTL → mint token.
    */
   private async runEmaPipeline(args: {
     body: any;
@@ -2924,6 +2917,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     enterpriseOptions: EmaOptions<Env>;
   }): Promise<Result<TokenResponse, EmaValidationError>> {
     const { body, clientInfo, env, requestUrl, request, enterpriseOptions } = args;
+    const { jwksProvider, jtiStore } = this;
+    // Unreachable: handleJwtBearerGrant short-circuits when enterpriseOptions is absent,
+    // and the constructor instantiates these adapters whenever enterpriseOptions is set.
+    if (!jwksProvider || !jtiStore) {
+      throw new Error('EMA pipeline invoked without configured adapters');
+    }
     const now = Math.floor(Date.now() / 1000);
 
     const parsed = parseIdJag(body.assertion, EMA_MAX_JWT_BYTES);
@@ -2947,6 +2946,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       parsed: parsed.value,
       header: header.value,
       trustedIssuer: trustedIssuer.value,
+      jwksProvider,
       now,
     });
     if (!verified.ok) return verified;
@@ -2966,7 +2966,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (!claims.ok) return claims;
 
     const replay = jtiMarkResultToResult(
-      await this.jtiStore.markUsed({
+      await jtiStore.markUsed({
         issuer: claims.value.claims.iss,
         jti: claims.value.claims.jti,
         exp: claims.value.claims.exp,
@@ -2980,15 +2980,21 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const requestedScope = parseEmaScopeParam(body.scope, claims.value.assertionScopes);
     if (!requestedScope.ok) return requestedScope;
 
-    const mapperOutput = await Promise.resolve(
-      enterpriseOptions.mapClaims({
-        claims: claims.value.claims,
-        clientInfo,
-        resource: claims.value.resource,
-        requestedScope: requestedScope.value,
-        env,
-      })
-    );
+    let mapperOutput: unknown;
+    try {
+      mapperOutput = await Promise.resolve(
+        enterpriseOptions.mapClaims({
+          claims: claims.value.claims,
+          clientInfo,
+          resource: claims.value.resource,
+          requestedScope: requestedScope.value,
+          request: args.request,
+          env,
+        })
+      );
+    } catch {
+      return err({ reason: 'mapper_threw' });
+    }
     const mapped = validateEmaMapperResult(mapperOutput);
     if (!mapped.ok) return mapped;
 
@@ -3019,26 +3025,27 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   /**
    * Verifies the ID-JAG signature against the trusted issuer's JWKS,
    * force-refreshing once on a `kid` miss to accommodate IdP key rotation.
-   * Delegates JWKS retrieval to `this.jwksProvider` (default impl is the
-   * in-memory cached fetcher with anti-DoS cool-down).
+   * Uses the in-memory cached JWKS fetcher with anti-DoS cool-down.
    */
   private async verifyAssertionSignature(args: {
     parsed: { header: Record<string, unknown>; signingInput: Uint8Array; signature: Uint8Array };
     header: { alg: string; kid?: string };
     trustedIssuer: EmaTrustedIssuer;
+    jwksProvider: EmaJwksProvider;
     now: number;
   }): Promise<Result<void, EmaValidationError>> {
     const alg = args.header.alg as EmaSupportedAlg;
+    const { jwksProvider } = args;
 
     const initialJwks = jwksFetchResultToResult(
-      await this.jwksProvider.fetch(args.trustedIssuer, { forceRefresh: false, now: args.now })
+      await jwksProvider.fetch(args.trustedIssuer, { forceRefresh: false, now: args.now })
     );
     if (!initialJwks.ok) return initialJwks;
 
     let jwk = selectJwk(initialJwks.value, alg, args.header.kid);
     if (!jwk.ok && args.header.kid) {
       const refreshed = jwksFetchResultToResult(
-        await this.jwksProvider.fetch(args.trustedIssuer, { forceRefresh: true, now: args.now })
+        await jwksProvider.fetch(args.trustedIssuer, { forceRefresh: true, now: args.now })
       );
       if (!refreshed.ok) return refreshed;
       jwk = selectJwk(refreshed.value, alg, args.header.kid);

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2982,16 +2982,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     let mapperOutput: unknown;
     try {
-      mapperOutput = await Promise.resolve(
-        enterpriseOptions.mapClaims({
-          claims: claims.value.claims,
-          clientInfo,
-          resource: claims.value.resource,
-          requestedScope: requestedScope.value,
-          request: args.request,
-          env,
-        })
-      );
+      mapperOutput = await enterpriseOptions.mapClaims({
+        claims: claims.value.claims,
+        clientInfo,
+        resource: claims.value.resource,
+        requestedScope: requestedScope.value,
+        request: args.request,
+        env,
+      });
     } catch {
       return err({ reason: 'mapper_threw' });
     }

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2919,9 +2919,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }): Promise<Result<TokenResponse, EmaValidationError>> {
     const { body, clientInfo, env, requestUrl, request, enterpriseOptions } = args;
     const { jwksProvider, jtiStore } = this;
+    const configuredResource = this.options.resourceMetadata?.resource;
     // Unreachable: handleJwtBearerGrant short-circuits when enterpriseOptions is absent,
-    // and the constructor instantiates these adapters whenever enterpriseOptions is set.
-    if (!jwksProvider || !jtiStore) {
+    // and validateEmaOptions enforces these invariants at construction time.
+    if (!jwksProvider || !jtiStore || !configuredResource) {
       throw new Error('EMA pipeline invoked without configured adapters');
     }
     const now = Math.floor(Date.now() / 1000);
@@ -2957,7 +2958,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       trustedIssuer: trustedIssuer.value,
       expectedAudience: trustedIssuer.value.audience ?? this.getAuthorizationServerIssuer(requestUrl),
       clientId: clientInfo.clientId,
-      configuredResource: this.options.resourceMetadata!.resource!,
+      configuredResource,
       matchOriginOnly: !!this.options.resourceMatchOriginOnly,
       now,
       clockSkewSeconds: enterpriseOptions.clockSkewSeconds ?? EMA_DEFAULT_CLOCK_SKEW_SECONDS,


### PR DESCRIPTION
## Summary

Adds support for MCP [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) (EMA / ID-JAG) via the RFC 7523 `urn:ietf:params:oauth:grant-type:jwt-bearer` token endpoint grant. Purely additive — no existing API or behavior changes. EMA only activates when the new `enterpriseManagedAuthorization` option is configured.

Builds on the protocol work in #203 (closed), restructured into focused modules under `src/ema/` with a `Result`-typed pipeline of pure validators. Diff vs `main`: +3091 / -11.

## What this adds

### New token-endpoint grant
At `POST /token`, accepts `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` with `assertion=<ID-JAG>`. The flow:

1. Parse compact JWT, enforce 16 KiB cap (`parser.ts`)
2. Validate JOSE header — `typ=oauth-id-jag+jwt`, allow-listed `alg` (`validators.validateIdJagHeader`)
3. Resolve `iss` through the deployer-supplied `trustedIssuers` resolver (`validators.resolveTrustedIssuer`)
4. Fetch + cache the issuer's JWKS, select the matching JWK, verify the signature with WebCrypto (`jwks.ts`, `signature.ts`)
5. Validate every required claim: `iss / sub / aud / resource / client_id / jti / exp / iat / nbf? / scope?` (`validators.validateIdJagClaims`)
6. Record the `jti` in the KV-backed replay store (`jti.ts`)
7. Invoke `mapClaims` to translate IdP identity → AS user + props + scope (`validators.validateEmaMapperResult`)
8. Mint and return an access token; refresh tokens are intentionally not issued (the ID-JAG itself is the renewable grant)

### New `src/ema/` modules

| File | Purpose |
|------|---------|
| `constants.ts` | All `EMA_*` constants co-located, including `EMA_ID_JAG_GRANT_PROFILE` |
| `result.ts` | `Result<T,E>` + 27-variant `EmaValidationError` + `emaErrorToWire` |
| `types.ts` | Public + internal types — `EmaOptions`, `EmaTrustedIssuer`, `EmaClaimsMapper`, etc. |
| `parser.ts` | `parseIdJag` (pure, Result-returning) |
| `validators.ts` | Pure validators: header / issuer resolve / claims / scope / mapper / TTL |
| `signature.ts` | `selectJwk` + `verifyIdJagSignature` (WebCrypto) |
| `jwks.ts` | `EmaJwksProvider` interface + default fetcher with anti-DoS cool-down |
| `jti.ts` | `EmaJtiStore` interface + default KV-backed impl |
| `util.ts` | `sha256Hex` |

The handler is a ~120-line `runEmaPipeline` orchestrator chaining the validators with explicit `if (!r.ok) return r;`. No library, no hidden control flow.

### AS metadata advertising

`/.well-known/oauth-authorization-server` now advertises (when EMA is configured):
- `urn:ietf:params:oauth:grant-type:jwt-bearer` in `grant_types_supported`
- `urn:ietf:params:oauth:grant-profile:id-jag` in `authorization_grant_profiles_supported`

### Public API surface

```ts
new OAuthProvider({
  // ... existing options ...
  enterpriseManagedAuthorization: {
    trustedIssuers: async ({ iss, env, request, clientInfo }) => /* EmaTrustedIssuer | null */,
    mapClaims: async ({ claims, env, request, clientInfo }) => ({
      userId: 'user-123',
      scope: ['read', 'write'],
      props: { /* per-request props */ },
      accessTokenTTL: 86_400, // optional, falls back to AS default
    }),
    jwksCacheTtlSeconds: 300,         // optional
    clockSkewSeconds: 60,             // optional
    maxAssertionLifetimeSeconds: 300, // optional
  },
});
```

Both callbacks are `Promise`-returning — locked to async so KV/D1/IdP federation lookups don't require a later API expansion. For a fixed list, write a one-line closure with `async ({ iss }) => list.find(...) ?? null`.

The existing top-level `onError` hook on `OAuthProviderOptions` fires for EMA failures too — the typed `EmaValidationError` reason flows via the new (backwards-compatible) `error.internal: { category, reason, detail? }` field, which the wire response never sees.

### Security properties

- **Confused-deputy guard** on the resolver — `resolved.issuer === iss` is enforced
- **Per-request structural validation** of resolver output — HTTPS `issuer` AND `jwksUri` (RFC 8414 §2), supported algorithm
- **JWKS force-refresh cool-down** — per-issuer 30s default rate-limit. Defends against an attacker sending many assertions with random `kid` values to amplify load on the IdP
- **`nbf` claim support** per RFC 7523 §3 rule 5
- **`exp`, `iat`, `nbf` all honor `clockSkewSeconds`** (RFC 7523 §3 rule 4)
- **`alg=none` rejected**; algorithm allowlist enforced (`RS256`, `ES256`); JWK `kty` must match the header `alg`
- **Resource pinning** at construction time — EMA requires `resourceMetadata.resource` to be declared, preventing an EMA-configured provider from accepting any RFC 8707-shaped `resource` claim
- **`mapClaims` exceptions caught** — translated to `invalid_grant: Assertion was not authorized`, not 500
- **`Cache-Control: no-store` + `Pragma: no-cache`** on every EMA token response (RFC 6749 §5.1)
- **Wire-level errors collapse to generic `invalid_grant: Invalid assertion`** (RFC 6749 §5.2) — the rich tagged reason flows server-side to the deployer's `onError.internal` sink for debugging/alerting

### Why a `Result` type instead of throws

Throwing across 18 sites with `OAuthError('invalid_grant', 'Invalid assertion')` makes the validation path harder to audit. The Result pipeline keeps the same wire-level behavior (generic error) but makes each check inspectable in isolation. Two helpers (`ok` / `err`), zero new dependencies.

## Tests

| | |
|---|---|
| Total | **435 passing** |
| Integration (`__tests__/oauth-provider.test.ts`) | 379 — includes new EMA construction-time checks, metadata advertising, end-to-end ID-JAG exchange, `mapper_threw`, and `onError.internal` smoke test |
| EMA unit (`__tests__/ema-validators.test.ts`) | 56 — each pure validator pinned without spinning up `OAuthProvider`, mocking fetch, or seeding KV |

## Compatibility

- **No breaking changes** — every existing API is unchanged
- Feature is **opt-in** via the new `enterpriseManagedAuthorization` option
- New AS metadata fields appear only when EMA is configured
- Followup: [#211](https://github.com/cloudflare/workers-oauth-provider/issues/211) tracks rolling the new `onError.internal` shape out to other generic-error paths

## Test plan

- [x] `npm run check` — 435/435 tests pass
- [ ] Review the `trustedIssuers` resolver-only API
- [ ] Review the anti-DoS JWKS cool-down (30s default)
- [ ] End-to-end exchange against a real IdP
