### PR TITLE
feat: add coalesceRefreshTokenExchange for non-idempotent upstream callbacks

### DIFF
--- a/.changeset/coalesce-refresh-token-exchange.md
+++ b/.changeset/coalesce-refresh-token-exchange.md
@@ -1,0 +1,35 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Add `coalesceRefreshTokenExchange` option to harden providers whose
+`tokenExchangeCallback` performs a **non-idempotent** upstream operation during
+the `refresh_token` grant — most commonly redeeming a _single-use, rotating_
+upstream refresh token (i.e. the Worker is itself a client of another OAuth
+server, like the Cloudflare MCP server).
+
+Without this option, two concurrent refreshes that share the same downstream
+refresh token both decrypt the same upstream credentials and both invoke
+`tokenExchangeCallback`, racing to redeem the same single-use upstream token.
+One wins; the other gets `invalid_grant` from upstream. The losing client then
+retries with its (now _previous_) refresh token, which re-runs the callback
+against the freshly-rotated upstream token, redeeming it again and cascading
+further rotations — a self-sustaining stream of `invalid_grant` errors.
+
+When `coalesceRefreshTokenExchange: true`:
+
+- **Single-flight:** concurrent `refresh_token` requests presenting the same
+  refresh token within a single isolate are coalesced — the callback runs once
+  and every caller receives a clone of the same token response.
+- **Idempotent replay:** a refresh presented with the grant's _previous_ refresh
+  token is treated as a retry of the rotation that already happened. The
+  callback is skipped and a fresh access token is minted from the grant's
+  current props, without rotating the refresh token or re-touching upstream.
+
+Defaults to `false` (the callback runs on every refresh, including retries), so
+existing behaviour is unchanged unless you opt in.
+
+Note: KV is eventually-consistent with no compare-and-swap, so simultaneous
+refreshes landing on _different_ isolates before either has persisted cannot be
+fully serialized; this collapses the common same-isolate burst and makes client
+retries safe and upstream-free.

--- a/README.md
+++ b/README.md
@@ -392,6 +392,50 @@ The AS enforces `resolved.issuer === iss` (confused-deputy guard) and validates 
 
 Experimental — the MCP extension is still a draft.
 
+### Non-idempotent callbacks and single-use upstream tokens
+
+If your `tokenExchangeCallback` redeems a **single-use, rotating** upstream
+refresh token (i.e. your Worker is itself a client of another OAuth server),
+the `refresh_token` grant becomes non-idempotent: each upstream token can only
+be redeemed once. This is fragile under two common conditions:
+
+- **Shared tokens / concurrent refresh.** Two sessions (e.g. two chat windows)
+  share one downstream refresh token and refresh at the same time. Both decrypt
+  the same upstream credentials and both call your callback, racing to redeem
+  the same single-use upstream token. One wins; the other gets `invalid_grant`.
+- **Lost responses / retries.** A client never receives a refresh response and
+  retries with its previous refresh token. By default the callback runs again
+  and redeems the already-rotated upstream token, cascading further rotations
+  and a stream of `invalid_grant` errors.
+
+Set `coalesceRefreshTokenExchange: true` to harden this:
+
+```ts
+new OAuthProvider({
+  // …
+  tokenExchangeCallback: async (options) => {
+    /* redeems a single-use upstream refresh token */
+  },
+  coalesceRefreshTokenExchange: true,
+});
+```
+
+When enabled:
+
+- **Single-flight** — concurrent `refresh_token` requests presenting the same
+  refresh token within a single isolate are coalesced. The callback runs once
+  and every caller receives the same token response.
+- **Idempotent replay** — a refresh presented with the grant's _previous_
+  refresh token is treated as a retry of the rotation that already happened.
+  The callback is skipped and a fresh access token is minted from the grant's
+  current props, without rotating the refresh token or re-touching upstream.
+
+Defaults to `false`, so existing behaviour is unchanged unless you opt in. Note
+that KV is eventually-consistent with no compare-and-swap, so simultaneous
+refreshes landing on _different_ isolates before either has persisted cannot be
+fully serialized; this collapses the common same-isolate burst and makes client
+retries safe and upstream-free.
+
 ## Custom Error Responses
 
 By using the `onError` option, you can emit notifications or take other actions when an error response was to be emitted:

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -2116,6 +2116,214 @@ describe('OAuthProvider', () => {
     });
   });
 
+  describe('coalesceRefreshTokenExchange (non-idempotent upstream callback)', () => {
+    // Models an upstream OAuth server whose refresh tokens are single-use and
+    // rotating: each upstream token can be redeemed exactly once, after which
+    // it returns invalid_grant. This is the situation cloudflare-mcp is in.
+    function makeUpstream() {
+      const redeemed = new Set<string>();
+      let nextUpstream = 1;
+      // Seed the first upstream refresh token that the grant starts with.
+      const initialUpstream = `upstream-rt-0`;
+      const callbackCalls: string[] = [];
+
+      const tokenExchangeCallback = async (options: any) => {
+        if (options.grantType !== 'refresh_token') return undefined;
+        const current = options.props.upstreamRefreshToken as string;
+        callbackCalls.push(current);
+        // Single-use: redeeming a token twice fails, like a real provider.
+        if (redeemed.has(current)) {
+          throw new OAuthError('invalid_grant', {
+            description: 'upstream refresh token is invalid',
+          });
+        }
+        redeemed.add(current);
+        const rotated = `upstream-rt-${nextUpstream++}`;
+        return {
+          newProps: { ...options.props, upstreamRefreshToken: rotated },
+        };
+      };
+
+      return { tokenExchangeCallback, callbackCalls, initialUpstream };
+    }
+
+    async function getRefreshTokenFor(provider: OAuthProvider<TestEnv>, initialUpstream: string) {
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Test Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+      const registerResponse = await provider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(clientData)
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const client = await registerResponse.json<any>();
+      const redirectUri = 'https://client.example.com/callback';
+
+      const authResponse = await provider.fetch(
+        createMockRequest(
+          `https://example.com/authorize?response_type=code&client_id=${client.client_id}` +
+            `&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read%20write&state=xyz`
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', client.client_id);
+      params.append('client_secret', client.client_secret);
+      const tokenResponse = await provider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const tokens = await tokenResponse.json<any>();
+      return { clientId: client.client_id, clientSecret: client.client_secret, refreshToken: tokens.refresh_token };
+    }
+
+    function refreshRequest(clientId: string, clientSecret: string, refreshToken: string) {
+      const params = new URLSearchParams();
+      params.append('grant_type', 'refresh_token');
+      params.append('refresh_token', refreshToken);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+      return createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+    }
+
+    function buildProvider(tokenExchangeCallback: any, coalesce: boolean) {
+      return new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: TestApiHandler,
+        defaultHandler: {
+          async fetch(request: Request, env: TestEnv) {
+            const url = new URL(request.url);
+            if (url.pathname === '/authorize') {
+              const info = await env.OAUTH_PROVIDER!.parseAuthRequest(request);
+              const { redirectTo } = await env.OAUTH_PROVIDER!.completeAuthorization({
+                request: info,
+                userId: 'test-user-123',
+                metadata: {},
+                scope: info.scope,
+                // Seed the grant props with the initial upstream refresh token.
+                props: { userId: 'test-user-123', upstreamRefreshToken: 'upstream-rt-0' },
+              });
+              return Response.redirect(redirectTo, 302);
+            }
+            return new Response('Default handler', { status: 200 });
+          },
+        },
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        scopesSupported: ['read', 'write'],
+        accessTokenTTL: 3600,
+        tokenExchangeCallback,
+        coalesceRefreshTokenExchange: coalesce,
+      });
+    }
+
+    it('replays the previous refresh token without re-invoking the upstream callback', async () => {
+      const { tokenExchangeCallback, callbackCalls } = makeUpstream();
+      const provider = buildProvider(tokenExchangeCallback, true);
+      const { clientId, clientSecret, refreshToken } = await getRefreshTokenFor(provider, 'upstream-rt-0');
+
+      // First refresh: redeems upstream-rt-0, rotates downstream + upstream.
+      const first = await provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx);
+      expect(first.status).toBe(200);
+      const firstTokens = await first.json<any>();
+      expect(firstTokens.refresh_token).not.toBe(refreshToken);
+      expect(callbackCalls).toEqual(['upstream-rt-0']);
+
+      // Client never received firstTokens (lost response) and retries with the
+      // ORIGINAL (now 'previous') downstream token. Without the replay path
+      // this would re-redeem the already-rotated upstream token and fail.
+      const retry = await provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx);
+      expect(retry.status).toBe(200);
+      const retryTokens = await retry.json<any>();
+      // Callback was NOT called again — no second upstream redemption.
+      expect(callbackCalls).toEqual(['upstream-rt-0']);
+      // Replay hands back the same token the client presented (no rotation).
+      expect(retryTokens.refresh_token).toBe(refreshToken);
+      expect(retryTokens.access_token).toBeDefined();
+    });
+
+    it('does not rotate the grant on replay', async () => {
+      const { tokenExchangeCallback } = makeUpstream();
+      const provider = buildProvider(tokenExchangeCallback, true);
+      const { clientId, clientSecret, refreshToken } = await getRefreshTokenFor(provider, 'upstream-rt-0');
+
+      await provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx);
+
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantKey = grantEntries.keys[0].name;
+      const before = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+
+      await provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx);
+
+      const after = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      // Replay leaves rotation state untouched.
+      expect(after.refreshTokenId).toBe(before.refreshTokenId);
+      expect(after.previousRefreshTokenId).toBe(before.previousRefreshTokenId);
+    });
+
+    it('single-flights concurrent refreshes of the same token (callback runs once)', async () => {
+      const { tokenExchangeCallback, callbackCalls } = makeUpstream();
+      const provider = buildProvider(tokenExchangeCallback, true);
+      const { clientId, clientSecret, refreshToken } = await getRefreshTokenFor(provider, 'upstream-rt-0');
+
+      // Fire two concurrent refreshes with the SAME current token.
+      const [a, b] = await Promise.all([
+        provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx),
+        provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx),
+      ]);
+
+      expect(a.status).toBe(200);
+      expect(b.status).toBe(200);
+      const aTokens = await a.json<any>();
+      const bTokens = await b.json<any>();
+      // Coalesced: callback ran once, both callers got the same rotated token.
+      expect(callbackCalls).toEqual(['upstream-rt-0']);
+      expect(aTokens.refresh_token).toBe(bTokens.refresh_token);
+      expect(aTokens.access_token).toBe(bTokens.access_token);
+    });
+
+    it('without the flag, retrying with the previous token re-invokes the callback', async () => {
+      const { tokenExchangeCallback, callbackCalls } = makeUpstream();
+      const provider = buildProvider(tokenExchangeCallback, false);
+      const { clientId, clientSecret, refreshToken } = await getRefreshTokenFor(provider, 'upstream-rt-0');
+
+      const first = await provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx);
+      expect(first.status).toBe(200);
+      expect(callbackCalls).toEqual(['upstream-rt-0']);
+
+      // Retry with the now-previous token: legacy behaviour re-runs the
+      // callback, which redeems the rotated upstream token (upstream-rt-1).
+      const retry = await provider.fetch(refreshRequest(clientId, clientSecret, refreshToken), mockEnv, mockCtx);
+      expect(retry.status).toBe(200);
+      expect(callbackCalls).toEqual(['upstream-rt-0', 'upstream-rt-1']);
+    });
+  });
+
   describe('Token Exchange Flow', () => {
     let clientId: string;
     let clientSecret: string;

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -441,6 +441,37 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   resourceMatchOriginOnly?: boolean;
 
   /**
+   * Hardening for providers whose `tokenExchangeCallback` performs a
+   * **non-idempotent** upstream operation during the `refresh_token` grant
+   * — most commonly redeeming a *single-use, rotating* upstream refresh
+   * token (e.g. this Worker is itself a client of another OAuth server).
+   *
+   * Without this option, two concurrent refreshes that share the same
+   * downstream refresh token both decrypt the same upstream credentials and
+   * both invoke `tokenExchangeCallback`, so they race to redeem the same
+   * single-use upstream token. One wins; the other gets `invalid_grant`
+   * from upstream. The losing client then retries with its (now *previous*)
+   * refresh token, which re-runs the callback against the freshly-rotated
+   * upstream token, redeeming it again and cascading further rotations.
+   *
+   * When `true`:
+   *  - **Single-flight:** concurrent `refresh_token` requests presenting the
+   *    same refresh token within a single isolate are coalesced — the
+   *    callback runs once and every caller receives a clone of the same
+   *    token response. (KV is eventually-consistent with no compare-and-swap,
+   *    so cross-isolate races cannot be fully serialized; this collapses the
+   *    common same-isolate burst.)
+   *  - **Idempotent replay:** a refresh presented with the grant's *previous*
+   *    refresh token is treated as a retry of the rotation that already
+   *    happened. The callback is skipped and a fresh access token is minted
+   *    from the grant's current props, without rotating the refresh token or
+   *    re-touching upstream. This stops the retry-driven rotation cascade.
+   *
+   * Defaults to false (the callback runs on every refresh, including retries).
+   */
+  coalesceRefreshTokenExchange?: boolean;
+
+  /**
    * Optional metadata for RFC 9728 OAuth 2.0 Protected Resource Metadata.
    * Controls the response served at /.well-known/oauth-protected-resource.
    *
@@ -1250,6 +1281,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
   /** KV-backed best-effort `jti` replay store; only constructed when EMA is configured. */
   private readonly jtiStore: EmaJtiStore | undefined;
+
+  /**
+   * In-flight `refresh_token` exchanges, keyed by a hash that incorporates the
+   * presented refresh token plus the request parameters that can vary the
+   * response (scope/resource). Used to single-flight concurrent refreshes
+   * within one isolate when `coalesceRefreshTokenExchange` is enabled.
+   */
+  private inflightRefreshExchanges = new Map<string, Promise<Response>>();
 
   /**
    * Creates a new OAuth provider instance
@@ -2311,6 +2350,47 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @returns Response with token data or error
    */
   private async handleRefreshTokenGrant(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
+    // When the callback is non-idempotent (single-use upstream refresh tokens),
+    // single-flight concurrent refreshes that share the same refresh token in
+    // this isolate so the callback runs once and the upstream token is redeemed
+    // once. Each caller gets its own clone of the (single-use) Response body.
+    if (!this.options.coalesceRefreshTokenExchange) {
+      return await this.executeRefreshTokenGrant(body, clientInfo, env);
+    }
+
+    const refreshToken = body.refresh_token;
+    if (!refreshToken || typeof refreshToken !== 'string') {
+      return await this.executeRefreshTokenGrant(body, clientInfo, env);
+    }
+
+    // Key on the parameters that can vary the response so we never hand a
+    // caller a token minted for a different scope/resource request.
+    const coalesceKey = await generateTokenId(
+      `${refreshToken}\n${clientInfo.clientId}\n${JSON.stringify(body.scope ?? null)}\n${JSON.stringify(
+        body.resource ?? null
+      )}`
+    );
+
+    const existing = this.inflightRefreshExchanges.get(coalesceKey);
+    if (existing) {
+      return (await existing).clone();
+    }
+
+    const exchange = this.executeRefreshTokenGrant(body, clientInfo, env);
+    this.inflightRefreshExchanges.set(coalesceKey, exchange);
+    try {
+      const response = await exchange;
+      return response.clone();
+    } finally {
+      this.inflightRefreshExchanges.delete(coalesceKey);
+    }
+  }
+
+  /**
+   * Performs the actual `refresh_token` grant. Wrapped by
+   * {@link handleRefreshTokenGrant}, which may single-flight concurrent calls.
+   */
+  private async executeRefreshTokenGrant(body: any, clientInfo: ClientInfo, env: any): Promise<Response> {
     const refreshToken = body.refresh_token;
 
     if (!refreshToken) {
@@ -2343,6 +2423,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (!isCurrentToken && !isPreviousToken) {
       return this.createErrorResponse('invalid_grant', { description: 'Invalid refresh token' });
     }
+
+    // Idempotent replay: when the callback is non-idempotent and the client
+    // presents the *previous* refresh token, treat this as a retry of the
+    // rotation that already succeeded. Skip the (single-use) upstream callback
+    // and skip rotation — just mint a fresh access token from the grant's
+    // current props and hand back the same refresh token the client already
+    // holds. This prevents a lost/late response from re-redeeming the upstream
+    // token and cascading further rotations.
+    const replayPreviousRefresh = !!this.options.coalesceRefreshTokenExchange && isPreviousToken && !isCurrentToken;
 
     // Verify client ID matches
     if (grantData.clientId !== clientInfo.clientId) {
@@ -2388,8 +2477,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Track whether grant props changed
     let grantPropsChanged = false;
 
-    // Process token exchange callback if provided
-    if (this.options.tokenExchangeCallback) {
+    // Process token exchange callback if provided.
+    // Skipped on idempotent replay so a non-idempotent (single-use upstream)
+    // callback is not invoked again for a rotation that already happened.
+    if (this.options.tokenExchangeCallback && !replayPreviousRefresh) {
       // Decrypt the existing props to provide them to the callback
       const decryptedProps = await decryptProps(encryptionKey, grantData.encryptedProps);
 
@@ -2488,32 +2579,42 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Wrap the access token key
     const accessTokenWrappedKey = await wrapKeyWithToken(newAccessToken, accessTokenEncryptionKey);
 
-    // Generate new refresh token for rotation
-    const refreshTokenSecret = generateRandomString(TOKEN_LENGTH);
-    const newRefreshToken = `${userId}:${grantId}:${refreshTokenSecret}`;
-    const newRefreshTokenId = await generateTokenId(newRefreshToken);
-    const newRefreshTokenWrappedKey = await wrapKeyWithToken(newRefreshToken, grantEncryptionKey);
+    // The refresh token returned to the client. On idempotent replay we hand
+    // back the same token the client presented (no rotation); otherwise we
+    // rotate to a freshly-generated token below.
+    let responseRefreshToken = refreshToken;
 
-    // Update the grant with the token rotation information
-    // The token which the client used this time becomes the "previous" token, so that the client
-    // can always use the same token again next time. This might technically violate OAuth 2.1's
-    // requirement that refresh tokens be single-use. However, this requirement violates the laws
-    // of distributed systems. It's important that the client can always retry when a transient
-    // failure occurs. Under the strict requirement, if the failure occurred after the server
-    // rotated the token but before the client managed to store the updated token, then the client
-    // no longer has any valid refresh token and has effectively lost its grant. That's bad! So
-    // instead, we don't invalidate the old token until the client successfully uses a newer token.
-    // This provides most of the security benefits (tokens still rotate naturally) but without
-    // being inherently unreliable.
-    grantData.previousRefreshTokenId = providedTokenHash;
-    grantData.previousRefreshTokenWrappedKey = wrappedKeyToUse;
+    if (!replayPreviousRefresh) {
+      // Generate new refresh token for rotation
+      const refreshTokenSecret = generateRandomString(TOKEN_LENGTH);
+      const newRefreshToken = `${userId}:${grantId}:${refreshTokenSecret}`;
+      const newRefreshTokenId = await generateTokenId(newRefreshToken);
+      const newRefreshTokenWrappedKey = await wrapKeyWithToken(newRefreshToken, grantEncryptionKey);
+      responseRefreshToken = newRefreshToken;
 
-    // The newly-generated token becomes the new "current" token.
-    grantData.refreshTokenId = newRefreshTokenId;
-    grantData.refreshTokenWrappedKey = newRefreshTokenWrappedKey;
+      // Update the grant with the token rotation information
+      // The token which the client used this time becomes the "previous" token, so that the client
+      // can always use the same token again next time. This might technically violate OAuth 2.1's
+      // requirement that refresh tokens be single-use. However, this requirement violates the laws
+      // of distributed systems. It's important that the client can always retry when a transient
+      // failure occurs. Under the strict requirement, if the failure occurred after the server
+      // rotated the token but before the client managed to store the updated token, then the client
+      // no longer has any valid refresh token and has effectively lost its grant. That's bad! So
+      // instead, we don't invalidate the old token until the client successfully uses a newer token.
+      // This provides most of the security benefits (tokens still rotate naturally) but without
+      // being inherently unreliable.
+      grantData.previousRefreshTokenId = providedTokenHash;
+      grantData.previousRefreshTokenWrappedKey = wrappedKeyToUse;
 
-    // Save the updated grant with TTL if applicable
-    await this.saveGrantWithTTL(env, grantKey, grantData, now);
+      // The newly-generated token becomes the new "current" token.
+      grantData.refreshTokenId = newRefreshTokenId;
+      grantData.refreshTokenWrappedKey = newRefreshTokenWrappedKey;
+
+      // Save the updated grant with TTL if applicable
+      await this.saveGrantWithTTL(env, grantKey, grantData, now);
+    }
+    // On replay the grant is unchanged (no callback, no rotation), so there is
+    // nothing to persist — skip the write to avoid needless KV contention.
 
     // Parse and validate resource parameter (RFC 8707)
     // Validate downscoping: token request resources must be subset of grant resources
@@ -2573,7 +2674,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       access_token: newAccessToken,
       token_type: 'bearer',
       expires_in: accessTokenTTL,
-      refresh_token: newRefreshToken,
+      refresh_token: responseRefreshToken,
       scope: tokenScopes.join(' '),
     };
 


### PR DESCRIPTION
## Problem

When a Worker's `tokenExchangeCallback` redeems a **single-use, rotating** upstream refresh token (i.e. the Worker is itself a client of another OAuth server — like the Cloudflare MCP server), the `refresh_token` grant becomes non-idempotent. Two failure modes produce a constant stream of `invalid_grant` errors:

1. **Shared tokens / concurrent refresh.** Two sessions (e.g. two chat windows) share one downstream refresh token and refresh at the same time. Both decrypt the same upstream credentials and both invoke the callback, racing to redeem the same single-use upstream token. One wins; the other gets `invalid_grant` from upstream.
2. **Lost responses / retries.** A client never receives a refresh response and retries with its (now *previous*) refresh token. Today the callback runs again and redeems the already-rotated upstream token, cascading further rotations — a self-sustaining stream of errors.

## Fix

Add an opt-in `coalesceRefreshTokenExchange` provider option (default `false`, so existing behaviour is unchanged). When `true`:

- **Single-flight** — concurrent `refresh_token` requests presenting the same refresh token within a single isolate are coalesced: the callback runs once and every caller receives a clone of the same token response.
- **Idempotent replay** — a refresh presented with the grant's *previous* refresh token is treated as a retry of the rotation that already happened. The callback is skipped and a fresh access token is minted from the grant's current props, without rotating the refresh token or re-touching upstream.

## Honest limitation

KV is eventually-consistent with no compare-and-swap, so simultaneous refreshes landing on *different* isolates before either has persisted cannot be fully serialized. This change collapses the common same-isolate burst and makes client retries safe and upstream-free — it does not require a Durable Object.

## Changes

- `coalesceRefreshTokenExchange?: boolean` option, fully documented in the interface.
- `handleRefreshTokenGrant` split into a coalescing wrapper + `executeRefreshTokenGrant`; in-isolate single-flight via a `Map<key, Promise<Response>>` keyed by refresh token + client + scope/resource, with `Response.clone()` per caller.
- Idempotent-replay branch: skips the callback and rotation, returns the presented token with a fresh access token.
- 4 new tests (replay skips callback; replay doesn't rotate the grant; concurrent single-flight runs callback once; flag-off retry re-invokes callback). **357/357 tests pass, typecheck clean.**
- README section + changeset (minor).

Related: surfaced from recurring `Token refresh failed: 400 invalid_grant` in the Cloudflare MCP server, which is an OAuth client to Cloudflare upstream.
