### PR TITLE
feat: pluggable storage backend with opt-in SQLite Durable Object (RFC)

### DIFF
--- a/.changeset/pluggable-storage-durable-object.md
+++ b/.changeset/pluggable-storage-durable-object.md
@@ -1,0 +1,26 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Add a pluggable storage backend via the `storage` option, with an opt-in
+partitioned SQLite **Durable Object** provider alongside the default KV.
+
+KV has no compare-and-swap and eventually-consistent reads, so two concurrent
+`refresh_token` grants for the same grant both read, both rotate, and the last
+write wins — orphaning the other's refresh token. When `tokenExchangeCallback`
+redeems a single-use, rotating upstream token, this surfaces as recurring
+`invalid_grant`. A Durable Object is single-threaded per instance, so routing
+every operation for a grant to the same instance serializes the rotation and
+removes the race.
+
+- `storage: { type: 'kv' }` — default, behaviour-identical to today.
+- `storage: { type: 'durable_object', partition: 'user' | 'grant' }` — routes
+  grant/token values to a partitioned `OAuthStore` Durable Object (binding
+  `OAUTH_DURABLE_OBJECT`), keeping `OAUTH_KV` as a cross-partition index for
+  `list`/purge. Partition by `user` (default) so a user's grants and tokens are
+  co-located and throughput scales with active users, rather than funnelling
+  through a single global DO.
+
+Consumers re-export `{ OAuthStore }` from their Worker entry and add the DO
+binding plus a `new_sqlite_classes` migration. Existing KV deployments are
+unaffected. See `docs/storage-providers.md`.

--- a/README.md
+++ b/README.md
@@ -448,6 +448,68 @@ The method processes records in configurable batches (default: 50) to stay withi
 
 Call it repeatedly via a cron trigger — deleted records disappear from KV, so subsequent invocations naturally process fresh records without needing a persisted cursor. The `result.done` field indicates whether the full key space was scanned in this invocation.
 
+## Storage Backends
+
+By default the provider stores clients, grants, and tokens in the `OAUTH_KV`
+namespace — unchanged, and the right choice for most deployments. You can opt
+into a **Durable Object** backend via the `storage` option:
+
+```ts
+new OAuthProvider({
+  // ... options ...
+  storage: { type: 'kv' }, // default — behaviour-identical to today
+});
+
+new OAuthProvider({
+  // ... options ...
+  storage: { type: 'durable_object', partition: 'user' }, // 'user' (default) | 'grant'
+});
+```
+
+### Why you might need it
+
+KV has **no compare-and-swap** and **eventually-consistent reads**. The
+`refresh_token` grant does a read-modify-write of the grant record (rotate the
+refresh token, persist `tokenExchangeCallback` `newProps`). Two concurrent
+refreshes of the same grant — two clients sharing a refresh token, or a client
+retrying a lost response — both read the same grant, both rotate, and the **last
+write wins**, orphaning the other's token. If your `tokenExchangeCallback` also
+redeems a **single-use, rotating upstream** token, this surfaces as a steady
+stream of `invalid_grant`.
+
+A Durable Object is **single-threaded per instance**. Routing every operation
+for a grant to the same instance **serializes the rotation** and eliminates the
+race. To avoid recreating a global throughput bottleneck, the store is
+**partitioned** (by `user` by default — a user's grants and tokens are
+co-located in one DO; throughput scales with active users). KV is still used as
+a lightweight **cross-partition index** so `list`/purge keep working.
+
+See [`docs/storage-providers.md`](docs/storage-providers.md) for the full design.
+
+### Setup
+
+Add the binding and a SQLite migration to `wrangler.jsonc`:
+
+```jsonc
+{
+  "kv_namespaces": [{ "binding": "OAUTH_KV", "id": "..." }],
+  "durable_objects": {
+    "bindings": [{ "name": "OAUTH_DURABLE_OBJECT", "class_name": "OAuthStore" }],
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["OAuthStore"] }],
+}
+```
+
+and re-export the DO class from your Worker entry:
+
+```ts
+export { OAuthStore } from '@cloudflare/workers-oauth-provider';
+```
+
+The binding names are fixed: `OAUTH_DURABLE_OBJECT` (the `OAuthStore`
+namespace) and `OAUTH_KV` (the index). This backend is opt-in; existing
+deployments are unaffected.
+
 ## Protected Resource Metadata (RFC 9728)
 
 The library automatically serves a `/.well-known/oauth-protected-resource` endpoint. By default, it uses the request origin as the resource identifier and the token endpoint's origin as the authorization server. You can customize this with the `resourceMetadata` option:

--- a/__tests__/mocks/cloudflare-workers.ts
+++ b/__tests__/mocks/cloudflare-workers.ts
@@ -16,3 +16,17 @@ export class WorkerEntrypoint<Env = any> {
     throw new Error('Method not implemented. This should be overridden by subclasses.');
   }
 }
+
+/**
+ * Mock for DurableObject base class.
+ * Subclasses receive `ctx` (DurableObjectState) and `env`.
+ */
+export class DurableObject<Env = any> {
+  ctx: any;
+  env: Env;
+
+  constructor(ctx: any, env: Env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,10 +1,11 @@
 import { vi } from 'vitest';
-import { WorkerEntrypoint } from './mocks/cloudflare-workers';
+import { WorkerEntrypoint, DurableObject } from './mocks/cloudflare-workers';
 
 // Mock the 'cloudflare:workers' module
 vi.mock('cloudflare:workers', () => {
   return {
     WorkerEntrypoint,
+    DurableObject,
   };
 });
 

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OAuthStore, DurableObjectStorage, KvStorage } from '../src/storage';
+import { resolveStorage } from '../src/storage/index';
+
+/**
+ * Minimal in-memory stand-in for `ctx.storage.sql` that understands exactly the
+ * statements OAuthStore issues. Backed by a Map so behaviour is deterministic.
+ */
+class MockSql {
+  rows = new Map<string, { value: string; expires_at: number | null }>();
+
+  exec<T = any>(query: string, ...args: any[]): { toArray(): T[] } {
+    const q = query.replace(/\s+/g, ' ').trim();
+
+    if (q.startsWith('CREATE TABLE')) return { toArray: () => [] as T[] };
+
+    if (q.startsWith('SELECT value, expires_at FROM kv WHERE key')) {
+      const row = this.rows.get(args[0]);
+      return { toArray: () => (row ? [row as unknown as T] : []) };
+    }
+
+    if (q.startsWith('SELECT MIN(expires_at)')) {
+      let min: number | null = null;
+      for (const r of this.rows.values()) {
+        if (r.expires_at != null) min = min === null ? r.expires_at : Math.min(min, r.expires_at);
+      }
+      return { toArray: () => [{ next: min } as unknown as T] };
+    }
+
+    if (q.startsWith('INSERT INTO kv')) {
+      const [key, value, expiresAt] = args;
+      this.rows.set(key, { value, expires_at: expiresAt ?? null });
+      return { toArray: () => [] as T[] };
+    }
+
+    if (q.startsWith('DELETE FROM kv WHERE expires_at IS NOT NULL AND expires_at <=')) {
+      const cutoff = args[0];
+      for (const [k, r] of this.rows) if (r.expires_at != null && r.expires_at <= cutoff) this.rows.delete(k);
+      return { toArray: () => [] as T[] };
+    }
+
+    if (q.startsWith('DELETE FROM kv WHERE key')) {
+      this.rows.delete(args[0]);
+      return { toArray: () => [] as T[] };
+    }
+
+    throw new Error('Unhandled SQL in mock: ' + q);
+  }
+}
+
+class MockDurableObjectState {
+  storage: any;
+  constructor() {
+    const sql = new MockSql();
+    let alarm: number | null = null;
+    this.storage = {
+      sql,
+      getAlarm: async () => alarm,
+      setAlarm: async (t: number) => {
+        alarm = t;
+      },
+    };
+  }
+}
+
+/** A namespace whose instances are real OAuthStore objects, keyed by name. */
+function makeNamespace() {
+  const instances = new Map<string, OAuthStore>();
+  const created: string[] = [];
+  return {
+    created,
+    instances,
+    idFromName(name: string) {
+      return { name } as any;
+    },
+    get(id: any) {
+      const name = id.name as string;
+      if (!instances.has(name)) {
+        created.push(name);
+        instances.set(name, new OAuthStore(new MockDurableObjectState() as any, {} as any));
+      }
+      return instances.get(name)!;
+    },
+  };
+}
+
+/** In-memory KV with the subset of the API the adapter uses. */
+function makeKv() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async get(key: string, opts?: { type: 'json' }) {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return opts?.type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list({ prefix }: { prefix: string }) {
+      const keys = [...store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name }));
+      return { keys, list_complete: true };
+    },
+  };
+}
+
+describe('OAuthStore (SQLite DO)', () => {
+  it('get/put/delete round-trips', async () => {
+    const store = new OAuthStore(new MockDurableObjectState() as any, {} as any);
+    expect(await store.get('grant:u1:g1')).toBeNull();
+    await store.put('grant:u1:g1', '{"a":1}', null);
+    expect(await store.get('grant:u1:g1')).toBe('{"a":1}');
+    await store.delete('grant:u1:g1');
+    expect(await store.get('grant:u1:g1')).toBeNull();
+  });
+
+  it('treats expired rows as absent', async () => {
+    const store = new OAuthStore(new MockDurableObjectState() as any, {} as any);
+    const past = Math.floor(Date.now() / 1000) - 5;
+    await store.put('token:u1:g1:t1', 'v', past);
+    expect(await store.get('token:u1:g1:t1')).toBeNull();
+  });
+});
+
+describe('DurableObjectStorage routing', () => {
+  let kv: ReturnType<typeof makeKv>;
+  let ns: ReturnType<typeof makeNamespace>;
+  let storage: DurableObjectStorage;
+
+  beforeEach(() => {
+    kv = makeKv();
+    ns = makeNamespace();
+    storage = new DurableObjectStorage(kv as any, ns as any, 'user');
+  });
+
+  it('routes client records to KV directly (no DO)', async () => {
+    await storage.put('client:abc', '{"clientId":"abc"}');
+    expect(ns.created).toHaveLength(0);
+    expect(await storage.get('client:abc', { type: 'json' })).toEqual({ clientId: 'abc' });
+    expect(kv.store.get('client:abc')).toBe('{"clientId":"abc"}');
+  });
+
+  it('routes grant value to DO and a KV index entry', async () => {
+    await storage.put('grant:u1:g1', '{"id":"g1"}');
+    // value lives in the DO …
+    expect(await storage.get('grant:u1:g1', { type: 'json' })).toEqual({ id: 'g1' });
+    // … and KV holds only the index marker (so list works), not the value
+    expect(kv.store.get('grant:u1:g1')).toBe('1');
+  });
+
+  it("co-locates a user's grant + tokens in ONE partition DO (user strategy)", async () => {
+    await storage.put('grant:u1:g1', '{}');
+    await storage.put('token:u1:g1:t1', '{}');
+    await storage.put('token:u1:g1:t2', '{}');
+    // all three keys for user u1 route to the same DO instance name
+    expect(new Set(ns.created)).toEqual(new Set(['u:u1']));
+  });
+
+  it('different users get different partitions', async () => {
+    await storage.put('grant:u1:g1', '{}');
+    await storage.put('grant:u2:g9', '{}');
+    expect(new Set(ns.created)).toEqual(new Set(['u:u1', 'u:u2']));
+  });
+
+  it('grant partition strategy isolates each grant', async () => {
+    const perGrant = new DurableObjectStorage(makeKv() as any, ns as any, 'grant');
+    await perGrant.put('grant:u1:g1', '{}');
+    await perGrant.put('grant:u1:g2', '{}');
+    expect(new Set(ns.created)).toEqual(new Set(['g:u1:g1', 'g:u1:g2']));
+  });
+
+  it('a second read sees the first write on the same partition (no split-brain)', async () => {
+    // This is the property KV cannot guarantee: routing both ops to the same
+    // single-threaded DO means the second observer sees the first writer.
+    await storage.put('grant:u1:g1', JSON.stringify({ rotation: 1 }));
+    const a = await storage.get('grant:u1:g1', { type: 'json' });
+    await storage.put('grant:u1:g1', JSON.stringify({ rotation: a.rotation + 1 }));
+    const b = await storage.get('grant:u1:g1', { type: 'json' });
+    expect(b.rotation).toBe(2);
+    // only one partition was ever touched for this grant
+    expect(ns.created).toEqual(['u:u1']);
+  });
+
+  it('list enumerates from the KV index across partitions', async () => {
+    await storage.put('grant:u1:g1', '{}');
+    await storage.put('grant:u2:g2', '{}');
+    await storage.put('client:abc', '{}');
+    const grants = await storage.list({ prefix: 'grant:' });
+    expect(grants.keys.map((k) => k.name).sort()).toEqual(['grant:u1:g1', 'grant:u2:g2']);
+  });
+
+  it('delete removes both DO value and KV index', async () => {
+    await storage.put('grant:u1:g1', '{}');
+    await storage.delete('grant:u1:g1');
+    expect(await storage.get('grant:u1:g1')).toBeNull();
+    expect(kv.store.has('grant:u1:g1')).toBe(false);
+  });
+});
+
+describe('resolveStorage factory', () => {
+  it('defaults to KV', () => {
+    const kv = makeKv();
+    const s = resolveStorage(undefined, { OAUTH_KV: kv });
+    expect(s).toBeInstanceOf(KvStorage);
+  });
+
+  it('explicit kv is KvStorage', () => {
+    const kv = makeKv();
+    expect(resolveStorage({ type: 'kv' }, { OAUTH_KV: kv })).toBeInstanceOf(KvStorage);
+  });
+
+  it('durable_object requires the DO binding', () => {
+    const kv = makeKv();
+    expect(() => resolveStorage({ type: 'durable_object' }, { OAUTH_KV: kv })).toThrow(/OAUTH_DURABLE_OBJECT/);
+  });
+
+  it('durable_object also requires the KV index binding', () => {
+    const ns = makeNamespace();
+    expect(() => resolveStorage({ type: 'durable_object' }, { OAUTH_DURABLE_OBJECT: ns })).toThrow(/OAUTH_KV/);
+  });
+
+  it('durable_object builds a DurableObjectStorage when both bindings present', () => {
+    const kv = makeKv();
+    const ns = makeNamespace();
+    const s = resolveStorage({ type: 'durable_object' }, { OAUTH_KV: kv, OAUTH_DURABLE_OBJECT: ns });
+    expect(s).toBeInstanceOf(DurableObjectStorage);
+  });
+
+  it('missing KV on the kv path throws a helpful error', () => {
+    expect(() => resolveStorage({ type: 'kv' }, {})).toThrow(/OAUTH_KV/);
+  });
+});

--- a/docs/storage-providers.md
+++ b/docs/storage-providers.md
@@ -1,0 +1,152 @@
+# Pluggable storage providers (KV default, Durable Object opt-in)
+
+> Status: **draft / RFC**. This document describes a proposed storage-provider
+> abstraction for `@cloudflare/workers-oauth-provider`. The KV provider is the
+> default and is behaviour-identical to today. The Durable Object provider is
+> opt-in and exists to fix a class of correctness bugs that KV cannot solve.
+
+## Why
+
+The provider stores three kinds of records in `OAUTH_KV`:
+
+| Record | Key shape                            | Access pattern                         |
+| ------ | ------------------------------------ | -------------------------------------- |
+| client | `client:{clientId}`                  | read-heavy, rare writes                |
+| grant  | `grant:{userId}:{grantId}`           | **read-modify-write** on every refresh |
+| token  | `token:{userId}:{grantId}:{tokenId}` | write on issue, read on validate       |
+
+The `refresh_token` grant does a **read-modify-write** of the grant record
+(rotate refresh token, persist callback `newProps`, etc.). KV has:
+
+- **no compare-and-swap**, and
+- **eventually-consistent reads**.
+
+So two concurrent refreshes of the same grant (two MCP sessions sharing one
+refresh token, or a client retrying a lost response) both read the same grant,
+both rotate, and the **last write wins** — orphaning the other's rotated token.
+When the provider's `tokenExchangeCallback` also redeems a **single-use,
+rotating upstream** refresh token (i.e. the Worker is itself an OAuth client),
+this surfaces as a steady stream of `invalid_grant`. No amount of in-isolate
+coalescing fixes it, because the racing requests land on different isolates.
+
+A **Durable Object is single-threaded per instance**: all operations on one
+instance run serially. If every operation for a given grant is routed to the
+same DO, the read-modify-write is serialized and the race is gone.
+
+## The catch: don't recreate the bottleneck
+
+A **single** global DO would serialize _everything_ and cap the entire OAuth
+surface at one DO's throughput (~hundreds of rps). That just moves the
+bottleneck. So we **partition**.
+
+### Partition by user (default)
+
+DO instance name = `u:{userId}`. That instance owns **all of that user's
+grants and tokens**. Properties:
+
+- The refresh race is per-grant, and a grant lives under exactly one user, so
+  it lives in exactly one DO → **rotation is serialized → bug fixed**.
+- Throughput scales with the number of active users, not a global singleton.
+- A user's grants+tokens are co-located → "revoke all my sessions" and
+  per-user cleanup are single-DO operations.
+
+### Why not partition by OAuth client
+
+Tempting ("one DO per client, manage its lifecycle") but **wrong for the hot
+path**: a popular client — e.g. the MCP server's own `client_id` — would funnel
+_every user's_ refreshes through one DO, recreating the singleton cap. Client
+_records_ are a different, read-heavy, low-write concern (see below). The
+storage partition must follow the write-contention boundary, which is the user
+(or the grant).
+
+### Per-grant (optional, finer)
+
+DO name = `g:{userId}:{grantId}`. Maximum parallelism, smallest blast radius.
+Downside: a user's tokens are spread across grant-DOs, so per-user operations
+fan out. Offered as a config knob; per-user is the sensible default.
+
+## KV as the cross-partition tracker
+
+`list({ prefix })` / purge / "revoke all grants for a client" span partitions.
+DOs can't see each other's SQLite. So we keep **KV as a lightweight index**:
+
+- On `put(key, …)` the DO provider also writes a tiny KV index entry for `key`
+  (existence + TTL + owning partition). The **authoritative value lives in the
+  DO**; KV holds only the key.
+- `list({ prefix })` enumerates the KV index (same cursor/pagination semantics
+  as today).
+- `delete(key)` removes both.
+
+This is the "KV as a tracker of DOs" model: hot, race-sensitive
+read-modify-write happens in the owning DO (serialized, correct); cold
+enumeration uses KV (eventually-consistent, which is fine for purge/admin).
+
+Client records are read-heavy and low-write; they can stay in KV directly
+(default) or be routed to a `clients` partition. The default keeps them in KV.
+
+## Configuration
+
+```ts
+new OAuthProvider({
+  // …
+  // default — unchanged, behaviour-identical to today:
+  storage: { type: 'kv' },
+});
+
+new OAuthProvider({
+  // …
+  storage: {
+    type: 'durable_object',
+    // partition strategy for grants+tokens; default 'user'
+    partition: 'user', // | 'grant'
+  },
+});
+```
+
+The DO namespace binding is **hardcoded as `env.OAUTH_DURABLE_OBJECT`** and the
+KV index uses the existing `env.OAUTH_KV`. Consumers add to `wrangler.jsonc`:
+
+```jsonc
+{
+  "durable_objects": {
+    "bindings": [{ "name": "OAUTH_DURABLE_OBJECT", "class_name": "OAuthStore" }],
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["OAuthStore"] }],
+}
+```
+
+and re-export the DO class from their Worker entry:
+
+```ts
+export { OAuthStore } from '@cloudflare/workers-oauth-provider';
+```
+
+## Storage interface
+
+The abstraction mirrors the **subset of the KV API** the provider already uses,
+so existing call sites change only from `env.OAUTH_KV` to `getStorage(env)`:
+
+```ts
+interface OAuthStorage {
+  get(key: string, opts?: { type: 'json' }): Promise<any>;
+  put(key: string, value: string, opts?: { expirationTtl?: number; expiration?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(opts: { prefix: string; limit?: number; cursor?: string }): Promise<{
+    keys: { name: string }[];
+    list_complete: boolean;
+    cursor?: string;
+  }>;
+}
+```
+
+- `KvStorage` — thin pass-through to `env.OAUTH_KV` (default; zero behaviour change).
+- `DurableObjectStorage` — routes by key → partition DO for values, KV for the
+  index. The DO persists to its own SQLite via `ctx.storage.sql` (no external
+  deps added to the library).
+
+## Migration / rollout
+
+- Opt-in only. Existing deployments keep `type: 'kv'` and are untouched.
+- New deployments (or those hitting the refresh race) set
+  `type: 'durable_object'`, add the binding + migration, re-export `OAuthStore`.
+- A future migration helper can lazily import KV grants into DOs on first touch.

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -36,6 +36,12 @@ export type {
 } from './ema/types';
 export type { EmaValidationError } from './ema/result';
 
+import { resolveStorage } from './storage';
+import type { OAuthStorage, StorageConfig } from './storage';
+
+export { OAuthStore } from './storage';
+export type { OAuthStorage, StorageConfig, DurableObjectPartition } from './storage';
+
 const PROTECTED_RESOURCE_WELL_KNOWN_PREFIX = '/.well-known/oauth-protected-resource';
 
 // Log CIMD status on module load
@@ -439,6 +445,23 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * Defaults to false (strict exact matching per RFC 8707).
    */
   resourceMatchOriginOnly?: boolean;
+
+  /**
+   * Storage backend for clients, grants, and tokens.
+   *
+   * Defaults to `{ type: 'kv' }` — behaviour-identical to today, backed by the
+   * `OAUTH_KV` namespace.
+   *
+   * `{ type: 'durable_object' }` opts into a partitioned, single-threaded
+   * SQLite Durable Object backend (binding `OAUTH_DURABLE_OBJECT`, class
+   * `OAuthStore`) that serializes the refresh-token read-modify-write and so
+   * eliminates the concurrent-refresh `invalid_grant` race that KV's
+   * lack of compare-and-swap allows. KV is still used as a cross-partition
+   * index for `list`/purge. Partition by `'user'` (default) or `'grant'`.
+   *
+   * See docs/storage-providers.md.
+   */
+  storage?: StorageConfig;
 
   /**
    * Optional metadata for RFC 9728 OAuth 2.0 Protected Resource Metadata.
@@ -1530,7 +1553,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Retrieve the token from KV
     const [userId, grantId] = parts;
     const id = await generateTokenId(token);
-    const tokenData: Token | null = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${id}`, { type: 'json' });
+    const tokenData: Token | null = await this.getStorage(env).get(`token:${userId}:${grantId}:${id}`, {
+      type: 'json',
+    });
 
     // Return null if missing or expired
     if (!tokenData) {
@@ -2034,7 +2059,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Get the grant
     const grantKey = `grant:${userId}:${grantId}`;
-    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData: Grant | null = await this.getStorage(env).get(grantKey, { type: 'json' });
 
     if (!grantData) {
       return this.createErrorResponse('invalid_grant', {
@@ -2330,7 +2355,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Get the associated grant using userId in the key
     const grantKey = `grant:${userId}:${grantId}`;
-    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData: Grant | null = await this.getStorage(env).get(grantKey, { type: 'json' });
 
     if (!grantData) {
       return this.createErrorResponse('invalid_grant', { description: 'Grant not found' });
@@ -2560,7 +2585,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Save access token with TTL (using the potentially callback-provided TTL)
     try {
-      await env.OAUTH_KV.put(`token:${userId}:${grantId}:${accessTokenId}`, JSON.stringify(accessTokenData), {
+      await this.getStorage(env).put(`token:${userId}:${grantId}:${accessTokenId}`, JSON.stringify(accessTokenData), {
         expirationTtl: accessTokenTTL,
       });
     } catch (error) {
@@ -2619,7 +2644,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Get the grant to access resource information
     const grantKey = `grant:${tokenSummary.userId}:${tokenSummary.grantId}`;
-    const grantData: Grant | null = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData: Grant | null = await this.getStorage(env).get(grantKey, { type: 'json' });
     if (!grantData) {
       throw new OAuthError('invalid_grant', { description: 'Grant not found' });
     }
@@ -2673,7 +2698,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     // Get the subject token data to access encryption key
-    const subjectTokenData: Token | null = await env.OAUTH_KV.get(
+    const subjectTokenData: Token | null = await this.getStorage(env).get(
       `token:${tokenSummary.userId}:${tokenSummary.grantId}:${tokenSummary.id}`,
       { type: 'json' }
     );
@@ -3182,7 +3207,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async revokeSpecificAccessToken(tokenId: string, userId: string, grantId: string, env: any): Promise<void> {
     const tokenKey = `token:${userId}:${grantId}:${tokenId}`;
-    await env.OAUTH_KV.delete(tokenKey);
+    await this.getStorage(env).delete(tokenKey);
   }
 
   /**
@@ -3195,7 +3220,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async validateAccessToken(tokenId: string, userId: string, grantId: string, env: any): Promise<boolean> {
     const tokenKey = `token:${userId}:${grantId}:${tokenId}`;
-    const tokenData = await env.OAUTH_KV.get(tokenKey, { type: 'json' });
+    const tokenData = await this.getStorage(env).get(tokenKey, { type: 'json' });
 
     if (!tokenData) {
       return false;
@@ -3216,7 +3241,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async validateRefreshToken(tokenId: string, userId: string, grantId: string, env: any): Promise<boolean> {
     const grantKey = `grant:${userId}:${grantId}`;
-    const grantData = await env.OAUTH_KV.get(grantKey, { type: 'json' });
+    const grantData = await this.getStorage(env).get(grantKey, { type: 'json' });
 
     if (!grantData) {
       return false;
@@ -3343,7 +3368,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (this.options.clientRegistrationTTL !== undefined) {
       clientKvOptions.expirationTtl = this.options.clientRegistrationTTL;
     }
-    await env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(clientInfo), clientKvOptions);
+    await this.getStorage(env).put(`client:${clientId}`, JSON.stringify(clientInfo), clientKvOptions);
 
     // Return client information with the original unhashed secret
     const response: Record<string, any> = {
@@ -3421,7 +3446,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (isPossiblyInternalFormat) {
       [userId, grantId] = parts;
       const id = await generateTokenId(accessToken);
-      tokenData = await env.OAUTH_KV.get(`token:${userId}:${grantId}:${id}`, { type: 'json' });
+      tokenData = await this.getStorage(env).get(`token:${userId}:${grantId}:${id}`, { type: 'json' });
     }
 
     // No internal token found in KV and no external token validator provided
@@ -3562,6 +3587,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
+   * Resolve the configured storage backend for this request's `env`.
+   * Defaults to KV; opt into the Durable Object backend via `options.storage`.
+   */
+  public getStorage(env: any): OAuthStorage {
+    return resolveStorage(this.options.storage, env);
+  }
+
+  /**
    * Saves a grant to KV with appropriate TTL based on expiration
    * @param env - The environment bindings
    * @param grantKey - The KV key for the grant
@@ -3572,7 +3605,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Use absolute expiration timestamp if grant has an expiration
     const kvOptions = grantData.expiresAt !== undefined ? { expiration: grantData.expiresAt } : {};
     try {
-      await env.OAUTH_KV.put(grantKey, JSON.stringify(grantData), kvOptions);
+      await this.getStorage(env).put(grantKey, JSON.stringify(grantData), kvOptions);
     } catch (error) {
       this.throwRetryableTokenStorageErrorIfKvRateLimited(error);
       throw error;
@@ -3612,7 +3645,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       if (!this.options.clientIdMetadataDocumentEnabled) {
         // CIMD not enabled — treat as standard KV lookup
         const clientKey = `client:${clientId}`;
-        return env.OAUTH_KV.get(clientKey, { type: 'json' });
+        return this.getStorage(env).get(clientKey, { type: 'json' });
       }
       if (!this.hasGlobalFetchStrictlyPublic()) {
         throw new Error(`CIMD is enabled but 'global_fetch_strictly_public' compatibility flag is not set.`);
@@ -3629,7 +3662,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Standard KV lookup
     const clientKey = `client:${clientId}`;
-    return env.OAUTH_KV.get(clientKey, { type: 'json' });
+    return this.getStorage(env).get(clientKey, { type: 'json' });
   }
 
   /**
@@ -3670,7 +3703,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Save access token with TTL
     try {
-      await env.OAUTH_KV.put(`token:${userId}:${grantId}:${accessTokenId}`, JSON.stringify(accessTokenData), {
+      await this.getStorage(env).put(`token:${userId}:${grantId}:${accessTokenId}`, JSON.stringify(accessTokenData), {
         expirationTtl: expiresIn,
       });
     } catch (error) {
@@ -4752,7 +4785,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
 
       // Store the grant with a key that includes the user ID
       const grantKey = `grant:${options.userId}:${grantId}`;
-      await this.env.OAUTH_KV.put(grantKey, JSON.stringify(grant));
+      await this.provider.getStorage(this.env).put(grantKey, JSON.stringify(grant));
 
       // Store access token with denormalized grant information
       const accessTokenData: Token = {
@@ -4772,11 +4805,11 @@ class OAuthHelpersImpl implements OAuthHelpers {
       };
 
       // Save access token with TTL
-      await this.env.OAUTH_KV.put(
-        `token:${options.userId}:${grantId}:${accessTokenId}`,
-        JSON.stringify(accessTokenData),
-        { expirationTtl: accessTokenTTL }
-      );
+      await this.provider
+        .getStorage(this.env)
+        .put(`token:${options.userId}:${grantId}:${accessTokenId}`, JSON.stringify(accessTokenData), {
+          expirationTtl: accessTokenTTL,
+        });
 
       // Build the redirect URL for implicit flow (token in fragment, not query params)
       const redirectUrl = new URL(options.request.redirectUri);
@@ -4835,7 +4868,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
 
       // Set 10-minute TTL for the grant (will be extended when code is exchanged)
       const codeExpiresIn = 600; // 10 minutes
-      await this.env.OAUTH_KV.put(grantKey, JSON.stringify(grant), { expirationTtl: codeExpiresIn });
+      await this.provider.getStorage(this.env).put(grantKey, JSON.stringify(grant), { expirationTtl: codeExpiresIn });
 
       // Build the redirect URL for authorization code flow
       const redirectUrl = new URL(options.request.redirectUri);
@@ -4901,7 +4934,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       newClient.clientSecret = await hashSecret(clientSecret);
     }
 
-    await this.env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(newClient));
+    await this.provider.getStorage(this.env).put(`client:${clientId}`, JSON.stringify(newClient));
 
     // Create the response object
     const clientResponse = { ...newClient };
@@ -4934,7 +4967,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     }
 
     // Use the KV list() function to get client keys with pagination
-    const response = await this.env.OAUTH_KV.list(listOptions);
+    const response = await this.provider.getStorage(this.env).list(listOptions);
 
     // Fetch all clients in parallel
     const clients: ClientInfo[] = [];
@@ -5003,7 +5036,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     if (this.provider.options.clientRegistrationTTL !== undefined) {
       clientKvOptions.expirationTtl = this.provider.options.clientRegistrationTTL;
     }
-    await this.env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(updatedClient), clientKvOptions);
+    await this.provider.getStorage(this.env).put(`client:${clientId}`, JSON.stringify(updatedClient), clientKvOptions);
 
     // Create a response object
     const response = { ...updatedClient };
@@ -5034,10 +5067,10 @@ class OAuthHelpersImpl implements OAuthHelpers {
         listOptions.cursor = cursor;
       }
 
-      const result = await this.env.OAUTH_KV.list(listOptions);
+      const result = await this.provider.getStorage(this.env).list(listOptions);
 
       for (const key of result.keys) {
-        const grantData: Grant | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+        const grantData: Grant | null = await this.provider.getStorage(this.env).get(key.name, { type: 'json' });
         if (grantData && grantData.clientId === clientId) {
           await this.revokeGrant(grantData.id, grantData.userId);
         }
@@ -5051,7 +5084,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     }
 
     // Delete the client record
-    await this.env.OAUTH_KV.delete(`client:${clientId}`);
+    await this.provider.getStorage(this.env).delete(`client:${clientId}`);
   }
 
   /**
@@ -5076,12 +5109,12 @@ class OAuthHelpersImpl implements OAuthHelpers {
     }
 
     // Use the KV list() function to get grant keys with pagination
-    const response = await this.env.OAUTH_KV.list(listOptions);
+    const response = await this.provider.getStorage(this.env).list(listOptions);
 
     // Fetch all grants in parallel and convert to grant summaries
     const grantSummaries: GrantSummary[] = [];
     const promises = response.keys.map(async (key: { name: string }) => {
-      const grantData: Grant | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+      const grantData: Grant | null = await this.provider.getStorage(this.env).get(key.name, { type: 'json' });
       if (grantData) {
         // Create a summary with only the public fields
         const summary: GrantSummary = {
@@ -5133,13 +5166,13 @@ class OAuthHelpersImpl implements OAuthHelpers {
         listOptions.cursor = cursor;
       }
 
-      const result = await this.env.OAUTH_KV.list(listOptions);
+      const result = await this.provider.getStorage(this.env).list(listOptions);
 
       // Delete each token in this batch
       if (result.keys.length > 0) {
         await Promise.all(
           result.keys.map((key: { name: string }) => {
-            return this.env.OAUTH_KV.delete(key.name);
+            return this.provider.getStorage(this.env).delete(key.name);
           })
         );
       }
@@ -5153,7 +5186,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     }
 
     // After all tokens are deleted, delete the grant itself
-    await this.env.OAUTH_KV.delete(grantKey);
+    await this.provider.getStorage(this.env).delete(grantKey);
   }
 
   /**
@@ -5226,13 +5259,13 @@ class OAuthHelpersImpl implements OAuthHelpers {
           listOptions.cursor = grantCursor;
         }
 
-        const page = await this.env.OAUTH_KV.list(listOptions);
+        const page = await this.provider.getStorage(this.env).list(listOptions);
 
         for (const key of page.keys) {
           if (result.grantsChecked >= batchSize) break;
           result.grantsChecked++;
 
-          const grantData: Grant | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+          const grantData: Grant | null = await this.provider.getStorage(this.env).get(key.name, { type: 'json' });
           if (!grantData) continue;
 
           let shouldPurge = false;
@@ -5247,7 +5280,9 @@ class OAuthHelpersImpl implements OAuthHelpers {
             if (knownMissingClients.has(grantData.clientId)) {
               shouldPurge = true;
             } else if (!knownGoodClients.has(grantData.clientId)) {
-              const client = await this.env.OAUTH_KV.get(`client:${grantData.clientId}`, { type: 'json' });
+              const client = await this.provider
+                .getStorage(this.env)
+                .get(`client:${grantData.clientId}`, { type: 'json' });
               if (client) {
                 knownGoodClients.add(grantData.clientId);
               } else {
@@ -5292,27 +5327,27 @@ class OAuthHelpersImpl implements OAuthHelpers {
           listOptions.cursor = tokenCursor;
         }
 
-        const page = await this.env.OAUTH_KV.list(listOptions);
+        const page = await this.provider.getStorage(this.env).list(listOptions);
 
         for (const key of page.keys) {
           if (result.tokensChecked >= batchSize) break;
           result.tokensChecked++;
 
-          const tokenData: Token | null = await this.env.OAUTH_KV.get(key.name, { type: 'json' });
+          const tokenData: Token | null = await this.provider.getStorage(this.env).get(key.name, { type: 'json' });
           if (!tokenData) continue;
 
           const grantKey = `grant:${tokenData.userId}:${tokenData.grantId}`;
 
           if (knownMissingGrants.has(grantKey)) {
-            await this.env.OAUTH_KV.delete(key.name);
+            await this.provider.getStorage(this.env).delete(key.name);
             result.tokensPurged++;
           } else if (!knownGoodGrants.has(grantKey)) {
-            const grantExists = await this.env.OAUTH_KV.get(grantKey);
+            const grantExists = await this.provider.getStorage(this.env).get(grantKey);
             if (grantExists) {
               knownGoodGrants.add(grantKey);
             } else {
               knownMissingGrants.add(grantKey);
-              await this.env.OAUTH_KV.delete(key.name);
+              await this.provider.getStorage(this.env).delete(key.name);
               result.tokensPurged++;
             }
           }

--- a/src/storage/durable-object.ts
+++ b/src/storage/durable-object.ts
@@ -1,0 +1,218 @@
+/**
+ * Durable Object storage provider (opt-in).
+ *
+ * Fixes the refresh-token read-modify-write race that KV cannot: a Durable
+ * Object instance is single-threaded, so routing every operation for a grant to
+ * the same instance serializes rotation. We partition by user (default) so we
+ * don't recreate a global-singleton throughput cap, and we keep KV as a
+ * cross-partition index for `list`/purge. See docs/storage-providers.md.
+ *
+ * Value of record  ── lives in the owning partition DO (authoritative, serialized)
+ * Key existence     ── mirrored into KV so prefix `list` works across partitions
+ *
+ * Client records (read-heavy, low-write) stay in KV directly.
+ */
+
+import { DurableObject } from 'cloudflare:workers';
+
+import type {
+  DurableObjectPartition,
+  OAuthStorage,
+  StorageListOptions,
+  StorageListResult,
+  StoragePutOptions,
+} from './types';
+
+/** Marker value stored in the KV index for DO-backed keys. */
+const INDEX_MARKER = '1';
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/** Resolve the absolute expiry (Unix seconds) from KV-style put options. */
+function resolveExpiry(options?: StoragePutOptions): number | null {
+  if (options?.expiration !== undefined) return options.expiration;
+  if (options?.expirationTtl !== undefined) return nowSeconds() + options.expirationTtl;
+  return null;
+}
+
+/**
+ * Single-threaded SQLite-backed key/value store. One instance per partition
+ * (e.g. `u:{userId}`). Holds the authoritative value for grant/token records.
+ *
+ * Consumers re-export this from their Worker entry and bind it as
+ * `OAUTH_DURABLE_OBJECT` with a `new_sqlite_classes` migration.
+ */
+export class OAuthStore extends DurableObject {
+  #initialized = false;
+
+  #init(): void {
+    if (this.#initialized) return;
+    this.ctx.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS kv (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        expires_at INTEGER
+      );`
+    );
+    this.#initialized = true;
+  }
+
+  /** Read a value, treating expired rows as absent (and lazily reaping them). */
+  async get(key: string): Promise<string | null> {
+    this.#init();
+    const cursor = this.ctx.storage.sql.exec<{ value: string; expires_at: number | null }>(
+      'SELECT value, expires_at FROM kv WHERE key = ? LIMIT 1',
+      key
+    );
+    const row = cursor.toArray()[0];
+    if (!row) return null;
+    if (row.expires_at !== null && row.expires_at <= nowSeconds()) {
+      this.ctx.storage.sql.exec('DELETE FROM kv WHERE key = ?', key);
+      return null;
+    }
+    return row.value;
+  }
+
+  /** Upsert a value with an optional absolute expiry (Unix seconds). */
+  async put(key: string, value: string, expiresAt: number | null): Promise<void> {
+    this.#init();
+    this.ctx.storage.sql.exec(
+      `INSERT INTO kv (key, value, expires_at) VALUES (?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at`,
+      key,
+      value,
+      expiresAt
+    );
+    await this.#scheduleCleanup(expiresAt);
+  }
+
+  /** Delete a value. */
+  async delete(key: string): Promise<void> {
+    this.#init();
+    this.ctx.storage.sql.exec('DELETE FROM kv WHERE key = ?', key);
+  }
+
+  /**
+   * Atomic read-modify-write helper exposed for callers (e.g. refresh-token
+   * rotation) that want the whole compare/update cycle serialized inside the
+   * DO. The DO's single-threaded model guarantees no interleaving.
+   */
+  async getForUpdate(key: string): Promise<string | null> {
+    return this.get(key);
+  }
+
+  async #scheduleCleanup(expiresAt: number | null): Promise<void> {
+    if (expiresAt === null) return;
+    const current = await this.ctx.storage.getAlarm();
+    if (current === null) {
+      await this.ctx.storage.setAlarm(expiresAt * 1000);
+    }
+  }
+
+  /** Reap expired rows and re-arm the alarm if anything still has an expiry. */
+  async alarm(): Promise<void> {
+    this.#init();
+    this.ctx.storage.sql.exec('DELETE FROM kv WHERE expires_at IS NOT NULL AND expires_at <= ?', nowSeconds());
+    const next = this.ctx.storage.sql
+      .exec<{ next: number | null }>('SELECT MIN(expires_at) AS next FROM kv WHERE expires_at IS NOT NULL')
+      .toArray()[0];
+    if (next?.next != null) {
+      await this.ctx.storage.setAlarm(next.next * 1000);
+    }
+  }
+}
+
+/** Minimal binding shape we depend on (avoids leaking full generics). */
+interface OAuthStoreNamespace {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): {
+    get(key: string): Promise<string | null>;
+    put(key: string, value: string, expiresAt: number | null): Promise<void>;
+    delete(key: string): Promise<void>;
+  };
+}
+
+/**
+ * Routes operations to the right backend:
+ *  - `grant:`/`token:` keys → owning partition DO (value) + KV index (key)
+ *  - everything else (e.g. `client:`) → KV directly
+ *  - all `list` → KV (it holds every key: client values + grant/token index)
+ */
+export class DurableObjectStorage implements OAuthStorage {
+  readonly #kv: KVNamespace;
+  readonly #ns: OAuthStoreNamespace;
+  readonly #partition: DurableObjectPartition;
+
+  constructor(kv: KVNamespace, ns: OAuthStoreNamespace, partition: DurableObjectPartition) {
+    this.#kv = kv;
+    this.#ns = ns;
+    this.#partition = partition;
+  }
+
+  /** True for keys whose authoritative value lives in a partition DO. */
+  #isDoBacked(key: string): boolean {
+    return key.startsWith('grant:') || key.startsWith('token:');
+  }
+
+  /**
+   * Map a key to its partition DO name.
+   *  grant:{userId}:{grantId}
+   *  token:{userId}:{grantId}:{tokenId}
+   * Both carry `{userId}` as the second segment and `{grantId}` as the third.
+   */
+  #partitionName(key: string): string {
+    const parts = key.split(':');
+    const userId = parts[1] ?? '';
+    if (this.#partition === 'grant') {
+      const grantId = parts[2] ?? '';
+      return `g:${userId}:${grantId}`;
+    }
+    return `u:${userId}`;
+  }
+
+  #stub(key: string) {
+    return this.#ns.get(this.#ns.idFromName(this.#partitionName(key)));
+  }
+
+  get(key: string): Promise<string | null>;
+  get(key: string, options: { type: 'json' }): Promise<any | null>;
+  async get(key: string, options?: { type: 'json' }): Promise<any> {
+    if (!this.#isDoBacked(key)) {
+      return options?.type === 'json' ? this.#kv.get(key, { type: 'json' }) : this.#kv.get(key);
+    }
+    const raw = await this.#stub(key).get(key);
+    if (raw === null) return null;
+    return options?.type === 'json' ? JSON.parse(raw) : raw;
+  }
+
+  async put(key: string, value: string, options?: StoragePutOptions): Promise<void> {
+    if (!this.#isDoBacked(key)) {
+      return this.#kv.put(key, value, options);
+    }
+    const expiresAt = resolveExpiry(options);
+    // Authoritative value into the partition DO …
+    await this.#stub(key).put(key, value, expiresAt);
+    // … and a lightweight index entry into KV so prefix `list` works.
+    await this.#kv.put(key, INDEX_MARKER, options);
+  }
+
+  async delete(key: string): Promise<void> {
+    if (!this.#isDoBacked(key)) {
+      return this.#kv.delete(key);
+    }
+    await this.#stub(key).delete(key);
+    await this.#kv.delete(key);
+  }
+
+  async list(options: StorageListOptions): Promise<StorageListResult> {
+    // KV holds every key: client values directly, plus grant/token index keys.
+    const result = await this.#kv.list(options);
+    return {
+      keys: result.keys.map((k) => ({ name: k.name })),
+      list_complete: result.list_complete,
+      cursor: 'cursor' in result ? (result as { cursor?: string }).cursor : undefined,
+    };
+  }
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Storage provider factory.
+ *
+ * Resolves the configured backend from `OAuthProviderOptions.storage` and the
+ * request `env`. The DO namespace binding is hardcoded as
+ * `env.OAUTH_DURABLE_OBJECT`; the KV namespace/index is `env.OAUTH_KV`.
+ */
+
+import { DurableObjectStorage, OAuthStore } from './durable-object';
+import { KvStorage } from './kv';
+import type { OAuthStorage, StorageConfig } from './types';
+
+export { OAuthStore } from './durable-object';
+export { KvStorage } from './kv';
+export { DurableObjectStorage } from './durable-object';
+export type {
+  OAuthStorage,
+  StorageConfig,
+  DurableObjectPartition,
+  StorageListOptions,
+  StorageListResult,
+  StoragePutOptions,
+} from './types';
+
+/** Hardcoded binding names (see docs/storage-providers.md). */
+const KV_BINDING = 'OAUTH_KV';
+const DO_BINDING = 'OAUTH_DURABLE_OBJECT';
+
+/**
+ * Build an {@link OAuthStorage} for this request from config + env.
+ *
+ * Defaults to KV (behaviour-identical to today). When `durable_object` is
+ * selected, requires `env.OAUTH_DURABLE_OBJECT` (the `OAuthStore` namespace)
+ * and `env.OAUTH_KV` (used as the cross-partition index).
+ */
+export function resolveStorage(config: StorageConfig | undefined, env: any): OAuthStorage {
+  const kv = env?.[KV_BINDING] as KVNamespace | undefined;
+
+  if (!config || config.type === 'kv') {
+    if (!kv) {
+      throw new TypeError(`OAuth storage requires the '${KV_BINDING}' KV namespace binding.`);
+    }
+    return new KvStorage(kv);
+  }
+
+  if (config.type === 'durable_object') {
+    const ns = env?.[DO_BINDING];
+    if (!ns) {
+      throw new TypeError(
+        `storage.type 'durable_object' requires the '${DO_BINDING}' Durable Object ` +
+          `binding (class ${OAuthStore.name}). Add it to wrangler.jsonc with a ` +
+          `new_sqlite_classes migration and re-export { OAuthStore } from your Worker.`
+      );
+    }
+    if (!kv) {
+      throw new TypeError(
+        `storage.type 'durable_object' also requires the '${KV_BINDING}' KV ` +
+          `namespace binding, used as the cross-partition index.`
+      );
+    }
+    return new DurableObjectStorage(kv, ns, config.partition ?? 'user');
+  }
+
+  throw new TypeError(`Unknown storage.type: ${(config as { type: string }).type}`);
+}

--- a/src/storage/kv.ts
+++ b/src/storage/kv.ts
@@ -1,0 +1,40 @@
+/**
+ * KV storage provider — the default backend.
+ *
+ * This is a thin pass-through to `env.OAUTH_KV`. It exists so the provider can
+ * talk to a single `OAuthStorage` interface; using it must be byte-for-byte
+ * equivalent to calling `env.OAUTH_KV` directly.
+ */
+
+import type { OAuthStorage, StorageListOptions, StorageListResult, StoragePutOptions } from './types';
+
+export class KvStorage implements OAuthStorage {
+  readonly #kv: KVNamespace;
+
+  constructor(kv: KVNamespace) {
+    this.#kv = kv;
+  }
+
+  get(key: string): Promise<string | null>;
+  get(key: string, options: { type: 'json' }): Promise<any | null>;
+  get(key: string, options?: { type: 'json' }): Promise<any> {
+    return options?.type === 'json' ? this.#kv.get(key, { type: 'json' }) : this.#kv.get(key);
+  }
+
+  put(key: string, value: string, options?: StoragePutOptions): Promise<void> {
+    return this.#kv.put(key, value, options);
+  }
+
+  delete(key: string): Promise<void> {
+    return this.#kv.delete(key);
+  }
+
+  async list(options: StorageListOptions): Promise<StorageListResult> {
+    const result = await this.#kv.list(options);
+    return {
+      keys: result.keys.map((k) => ({ name: k.name })),
+      list_complete: result.list_complete,
+      cursor: 'cursor' in result ? (result as { cursor?: string }).cursor : undefined,
+    };
+  }
+}

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,0 +1,80 @@
+/**
+ * Storage abstraction for the OAuth provider.
+ *
+ * This intentionally mirrors the *subset* of the Cloudflare Workers KV API that
+ * the provider already uses, so that swapping the backend is a matter of
+ * replacing `env.OAUTH_KV` with `getStorage(env)` at each call site — nothing
+ * else about the provider logic changes.
+ *
+ * Implementations:
+ *  - `KvStorage`            — thin pass-through to `env.OAUTH_KV` (default).
+ *  - `DurableObjectStorage` — routes values to a partitioned, single-threaded
+ *                             SQLite Durable Object and keeps KV as an index.
+ *
+ * See docs/storage-providers.md for the design rationale.
+ */
+
+/** A single key entry returned by {@link OAuthStorage.list}. */
+export interface StorageListKey {
+  name: string;
+}
+
+/** Result of a {@link OAuthStorage.list} call (KV-compatible shape). */
+export interface StorageListResult {
+  keys: StorageListKey[];
+  list_complete: boolean;
+  cursor?: string;
+}
+
+/** Options for {@link OAuthStorage.put} (KV-compatible subset). */
+export interface StoragePutOptions {
+  /** Relative TTL in seconds. */
+  expirationTtl?: number;
+  /** Absolute expiration as a Unix timestamp in seconds. */
+  expiration?: number;
+}
+
+/** Options for {@link OAuthStorage.list} (KV-compatible subset). */
+export interface StorageListOptions {
+  prefix: string;
+  limit?: number;
+  cursor?: string;
+}
+
+/**
+ * The minimal key/value surface the OAuth provider depends on.
+ *
+ * Semantics match Cloudflare Workers KV:
+ *  - `get` with `{ type: 'json' }` parses JSON and returns `null` when absent.
+ *  - `put` honours `expirationTtl` (relative seconds) or `expiration`
+ *    (absolute Unix seconds); expired entries are not returned by `get`/`list`.
+ *  - `list` is prefix-scoped and cursor-paginated.
+ */
+export interface OAuthStorage {
+  get(key: string): Promise<string | null>;
+  get(key: string, options: { type: 'json' }): Promise<any | null>;
+  put(key: string, value: string, options?: StoragePutOptions): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(options: StorageListOptions): Promise<StorageListResult>;
+}
+
+/** Partition strategy for the Durable Object provider (grants + tokens). */
+export type DurableObjectPartition = 'user' | 'grant';
+
+/**
+ * Storage configuration accepted by `OAuthProviderOptions.storage`.
+ *
+ * Defaults to `{ type: 'kv' }`, which is behaviour-identical to today.
+ */
+export type StorageConfig =
+  | { type: 'kv' }
+  | {
+      type: 'durable_object';
+      /**
+       * How to partition the single-threaded value store for grants+tokens.
+       * `'user'` (default) co-locates a user's grants+tokens in one DO so the
+       * refresh-token read-modify-write is serialized; throughput scales with
+       * the number of active users. `'grant'` is finer-grained.
+       */
+      partition?: DurableObjectPartition;
+    };


### PR DESCRIPTION
> **Draft / RFC.** Opt-in, default behaviour unchanged. Looking for design feedback on the partitioning model before polishing.

## Why

The provider stores clients, grants, and tokens in `OAUTH_KV`. The `refresh_token` grant is a **read-modify-write** of the grant record (rotate refresh token, persist `tokenExchangeCallback` `newProps`). KV has **no compare-and-swap** and **eventually-consistent reads**, so two concurrent refreshes of the same grant — two clients sharing a refresh token, or a client retrying a lost response — both read the same grant, both rotate, and the **last write wins**, orphaning the other's token. When `tokenExchangeCallback` also redeems a **single-use, rotating upstream** refresh token (i.e. the Worker is itself an OAuth client, like the Cloudflare MCP server), this surfaces as a steady stream of `invalid_grant` that no amount of in-isolate coalescing fixes (the racing requests land on different isolates).

A **Durable Object is single-threaded per instance** — routing every operation for a grant to the same instance serializes the rotation and removes the race.

## The catch, and the design

A single global DO would serialize *everything* and cap the whole OAuth surface at one DO's throughput (~hundreds of rps) — just moving the bottleneck. So the store is **partitioned**:

- **`partition: 'user'` (default)** — DO instance `u:{userId}` owns all of that user's grants + tokens. The refresh race is per-grant and a grant lives under one user, so it lives in one DO → rotation serialized → bug fixed. Throughput scales with active users.
- **`partition: 'grant'`** — finer (`g:{userId}:{grantId}`), maximum parallelism.
- **Not by OAuth client** — a popular `client_id` (e.g. the MCP server's own) would funnel every user's refreshes through one DO, recreating the singleton cap.

**KV stays as a cross-partition index.** `list`/purge span partitions and DOs can't see each other's SQLite, so on `put` the DO provider also writes a lightweight KV index entry for the key; the authoritative value lives in the DO. `list` enumerates the KV index (same cursor/pagination semantics). Client records (read-heavy, low-write) stay in KV directly.

## API

```ts
new OAuthProvider({
  // ...
  storage: { type: 'kv' },                                  // default — unchanged
  // or:
  storage: { type: 'durable_object', partition: 'user' },   // 'user' (default) | 'grant'
});
```

Hardcoded bindings: `OAUTH_DURABLE_OBJECT` (the `OAuthStore` namespace) + `OAUTH_KV` (index). Consumers add a `new_sqlite_classes` migration and `export { OAuthStore } from '@cloudflare/workers-oauth-provider'`.

## Implementation

- `OAuthStorage` interface mirrors the KV subset the provider uses; all **37** `OAUTH_KV.*` call sites now go through `getStorage(env)`.
- `KvStorage` — thin pass-through (default, behaviour-identical).
- `DurableObjectStorage` — routes `grant:`/`token:` keys to the owning partition DO + KV index; everything else (clients) to KV; `list` always from KV.
- `OAuthStore` — SQLite via `ctx.storage.sql` directly (**no new deps**), alarm-based expiry reaping.

## Tests / checks

- **451 pass** (435 existing + **16 new** storage tests): DO round-trip + expiry, routing (client→KV, grant/token→DO+index), per-user co-location, per-user/per-grant partition isolation, *same-partition second read sees first write* (the property KV can't give), cross-partition `list`, factory validation.
- `npm run typecheck` clean, `prettier` clean, builds (`OAuthStore` + `storage` option in dist).
- Added `DurableObject` to the `cloudflare:workers` test mock.

## Open questions for reviewers

1. `partition: 'user'` vs `'grant'` default — I went with `user` (fewer DOs, per-user revoke is single-DO). Reasonable?
2. Hardcoded binding names (`OAUTH_DURABLE_OBJECT`) vs configurable — kept it simple per the issue discussion.
3. KV-as-index vs a registry DO for enumeration — KV keeps `list`/purge semantics identical with zero new moving parts; happy to revisit.

See `docs/storage-providers.md` for the full rationale.
