### PR TITLE
Validate client metadata URI schemes during registration

### DIFF
--- a/.changeset/validate-client-metadata-uri-schemes.md
+++ b/.changeset/validate-client-metadata-uri-schemes.md
@@ -1,0 +1,16 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Validate the URI scheme of client metadata fields during client registration.
+
+The `client_uri`, `logo_uri`, `policy_uri`, `tos_uri`, and `jwks_uri` fields
+were previously only checked to be strings. They are now required to be
+absolute `http:` or `https:` URLs, consistent with how `redirect_uris` are
+already validated. Registration (and Client ID Metadata Document ingestion)
+now rejects values using other schemes with an `invalid_client_metadata`
+error.
+
+These fields are commonly surfaced in consent UIs (for example as link or
+image targets), so restricting them to standard web URLs avoids non-http(s)
+schemes flowing through to consumers.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -743,6 +743,76 @@ describe('OAuthProvider', () => {
       expect(savedClient).not.toBeNull();
       expect(savedClient.clientSecret).toBeUndefined(); // No secret stored
     });
+
+    it('should accept http(s) metadata URIs and persist them', async () => {
+      const clientData = {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Test Client',
+        client_uri: 'https://client.example.com',
+        logo_uri: 'https://client.example.com/logo.png',
+        policy_uri: 'http://client.example.com/privacy',
+        tos_uri: 'https://client.example.com/terms',
+        jwks_uri: 'https://client.example.com/.well-known/jwks.json',
+        token_endpoint_auth_method: 'none',
+      };
+
+      const request = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(clientData)
+      );
+
+      const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(201);
+
+      const registeredClient = await response.json<any>();
+      expect(registeredClient.client_uri).toBe('https://client.example.com');
+      expect(registeredClient.logo_uri).toBe('https://client.example.com/logo.png');
+      expect(registeredClient.policy_uri).toBe('http://client.example.com/privacy');
+      expect(registeredClient.tos_uri).toBe('https://client.example.com/terms');
+      expect(registeredClient.jwks_uri).toBe('https://client.example.com/.well-known/jwks.json');
+    });
+
+    describe('should reject metadata URIs with unsafe schemes', () => {
+      const uriFields = ['client_uri', 'logo_uri', 'policy_uri', 'tos_uri', 'jwks_uri'];
+      const unsafeUris = [
+        'javascript:alert(1)',
+        'javascript:1/*poc*/',
+        'data:text/html,<script>alert(1)</script>',
+        'vbscript:msgbox(1)',
+        'file:///etc/passwd',
+        'not-a-url',
+        '/relative/path',
+      ];
+
+      uriFields.forEach((field) => {
+        unsafeUris.forEach((unsafeUri) => {
+          it(`rejects ${field} = ${unsafeUri}`, async () => {
+            const clientData: Record<string, unknown> = {
+              redirect_uris: ['https://client.example.com/callback'],
+              client_name: 'Test Client',
+              token_endpoint_auth_method: 'none',
+              [field]: unsafeUri,
+            };
+
+            const request = createMockRequest(
+              'https://example.com/oauth/register',
+              'POST',
+              { 'Content-Type': 'application/json' },
+              JSON.stringify(clientData)
+            );
+
+            const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+
+            expect(response.status).toBe(400);
+            const body = await response.json<any>();
+            expect(body.error).toBe('invalid_client_metadata');
+          });
+        });
+      });
+    });
   });
 
   describe('Authorization Code Flow', () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -3312,11 +3312,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         clientId,
         redirectUris,
         clientName: OAuthProviderImpl.validateStringField(clientMetadata.client_name),
-        logoUri: OAuthProviderImpl.validateStringField(clientMetadata.logo_uri),
-        clientUri: OAuthProviderImpl.validateStringField(clientMetadata.client_uri),
-        policyUri: OAuthProviderImpl.validateStringField(clientMetadata.policy_uri),
-        tosUri: OAuthProviderImpl.validateStringField(clientMetadata.tos_uri),
-        jwksUri: OAuthProviderImpl.validateStringField(clientMetadata.jwks_uri),
+        logoUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.logo_uri, 'logo_uri'),
+        clientUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.client_uri, 'client_uri'),
+        policyUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.policy_uri, 'policy_uri'),
+        tosUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.tos_uri, 'tos_uri'),
+        jwksUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.jwks_uri, 'jwks_uri'),
         contacts: OAuthProviderImpl.validateStringArray(clientMetadata.contacts),
         grantTypes: OAuthProviderImpl.validateStringArray(clientMetadata.grant_types) || [
           GrantType.AUTHORIZATION_CODE,
@@ -3757,6 +3757,39 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
+   * Validates that a field is an optional URI string using a safe scheme.
+   *
+   * Client metadata URI fields (e.g. logo_uri, client_uri, policy_uri, tos_uri,
+   * jwks_uri) are frequently rendered into HTML attributes such as `<a href>` or
+   * `<img src>` on consent screens. Permitting non-http(s) schemes such as
+   * `javascript:` or `data:` would allow script execution in that context, so we
+   * require an absolute http: or https: URL here, matching how redirect URIs are
+   * already restricted.
+   *
+   * @param field - The field to validate
+   * @param fieldName - Name of the field for error messages
+   * @returns The validated URI string or undefined
+   * @throws Error if the field is not a string or is not an absolute http(s) URL
+   */
+  private static validateOptionalUriField(field: unknown, fieldName: string): string | undefined {
+    const value = OAuthProviderImpl.validateStringField(field, fieldName);
+    if (value === undefined) return undefined;
+
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      throw new Error(`Invalid ${fieldName}: must be an absolute http: or https: URL`);
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`Invalid ${fieldName}: must be an absolute http: or https: URL`);
+    }
+
+    return value;
+  }
+
+  /**
    * Validates that a field is a string array or undefined
    * @param arr - The array to validate
    * @param fieldName - Name of the field for error messages
@@ -3840,11 +3873,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         clientId,
         redirectUris,
         clientName: OAuthProviderImpl.validateStringField(rawMetadata.client_name, 'client_name'),
-        clientUri: OAuthProviderImpl.validateStringField(rawMetadata.client_uri, 'client_uri'),
-        logoUri: OAuthProviderImpl.validateStringField(rawMetadata.logo_uri, 'logo_uri'),
-        policyUri: OAuthProviderImpl.validateStringField(rawMetadata.policy_uri, 'policy_uri'),
-        tosUri: OAuthProviderImpl.validateStringField(rawMetadata.tos_uri, 'tos_uri'),
-        jwksUri: OAuthProviderImpl.validateStringField(rawMetadata.jwks_uri, 'jwks_uri'),
+        clientUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.client_uri, 'client_uri'),
+        logoUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.logo_uri, 'logo_uri'),
+        policyUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.policy_uri, 'policy_uri'),
+        tosUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.tos_uri, 'tos_uri'),
+        jwksUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.jwks_uri, 'jwks_uri'),
         contacts: OAuthProviderImpl.validateStringArray(rawMetadata.contacts, 'contacts'),
         grantTypes: OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
           'authorization_code',


### PR DESCRIPTION
## What

Validate the URI scheme of client metadata fields during client registration.

The `client_uri`, `logo_uri`, `policy_uri`, `tos_uri`, and `jwks_uri` fields were previously only checked to be strings. They are now required to be absolute `http:` or `https:` URLs, consistent with how `redirect_uris` are already validated via `validateRedirectUriScheme`.

This applies to both ingestion paths:
- Dynamic Client Registration (`/register`)
- Client ID Metadata Document (CIMD) fetching

Values using any other scheme (or non-absolute/malformed URLs) are now rejected with an `invalid_client_metadata` error.

## Why

These metadata fields are commonly surfaced in consent UIs as link or image targets. Restricting them to standard web URLs keeps non-`http(s)` schemes from flowing through the library to consumers, and brings their validation in line with the existing `redirect_uris` handling.

## How

- New `validateOptionalUriField` helper parses the value with `URL` and enforces an `http:`/`https:` protocol, returning `undefined` for omitted fields.
- Applied to all five metadata URI fields in both the registration and CIMD code paths.

## Tests

- Added a registration test asserting valid `http(s)` metadata URIs are accepted and persisted.
- Added a parameterized suite asserting each metadata URI field rejects unsafe/invalid values (`javascript:`, `data:`, `vbscript:`, `file:`, relative paths, non-URLs) with `invalid_client_metadata`.
- Full suite passes (`npm run check`): 471 tests.

A changeset is included (patch).
