### PR TITLE
Preserve RFC 7591 §2.2 internationalized client metadata variants

### DIFF
--- a/.changeset/i18n-client-metadata-variants.md
+++ b/.changeset/i18n-client-metadata-variants.md
@@ -1,0 +1,19 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Preserve RFC 7591 §2.2 internationalized client metadata variants.
+
+Localized variants of the human-readable client metadata fields — expressed
+with a `#<BCP 47 language tag>` suffix on the member name (e.g.
+`client_name#ja`, `tos_uri#fr`) — were previously dropped during client
+registration. They are now captured for `client_name`, `client_uri`,
+`logo_uri`, `tos_uri`, and `policy_uri`, stored on the client record under a
+new optional `i18n` map (keyed by the raw `field#tag` name), and echoed back in
+the registration response alongside their canonical fields. The same handling
+applies to Client ID Metadata Document ingestion.
+
+Localized values are validated with the same rules as their canonical field:
+URI variants must be absolute `http:` or `https:` URLs, and all variants must
+be strings. Fields that are not part of RFC 7591 §2.2 (such as `jwks_uri` and
+`redirect_uris`) are not collected.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -813,6 +813,166 @@ describe('OAuthProvider', () => {
         });
       });
     });
+
+    describe('RFC 7591 §2.2 internationalized metadata variants', () => {
+      it('persists localized variants and echoes them in the response', async () => {
+        const clientData = {
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Test Client',
+          'client_name#ja': 'テストクライアント',
+          'client_name#fr': 'Client de test',
+          client_uri: 'https://client.example.com',
+          'client_uri#ja': 'https://client.example.com/ja',
+          'tos_uri#fr': 'https://client.example.com/fr/terms',
+          'policy_uri#de': 'https://client.example.com/de/privacy',
+          'logo_uri#ja': 'https://client.example.com/ja/logo.png',
+          token_endpoint_auth_method: 'none',
+        };
+
+        const request = createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(clientData)
+        );
+
+        const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+        expect(response.status).toBe(201);
+
+        const registeredClient = await response.json<any>();
+        // Canonical values still present
+        expect(registeredClient.client_name).toBe('Test Client');
+        expect(registeredClient.client_uri).toBe('https://client.example.com');
+        // Localized variants echoed back as top-level `field#tag` members
+        expect(registeredClient['client_name#ja']).toBe('テストクライアント');
+        expect(registeredClient['client_name#fr']).toBe('Client de test');
+        expect(registeredClient['client_uri#ja']).toBe('https://client.example.com/ja');
+        expect(registeredClient['tos_uri#fr']).toBe('https://client.example.com/fr/terms');
+        expect(registeredClient['policy_uri#de']).toBe('https://client.example.com/de/privacy');
+        expect(registeredClient['logo_uri#ja']).toBe('https://client.example.com/ja/logo.png');
+
+        // Stored under the flat `i18n` map keyed by raw `field#tag`
+        const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+        expect(savedClient.i18n).toEqual({
+          'client_name#ja': 'テストクライアント',
+          'client_name#fr': 'Client de test',
+          'client_uri#ja': 'https://client.example.com/ja',
+          'tos_uri#fr': 'https://client.example.com/fr/terms',
+          'policy_uri#de': 'https://client.example.com/de/privacy',
+          'logo_uri#ja': 'https://client.example.com/ja/logo.png',
+        });
+      });
+
+      it('preserves case of BCP 47 language tags', async () => {
+        const clientData = {
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Test Client',
+          'client_name#ja-Jpan-JP': 'テスト',
+          token_endpoint_auth_method: 'none',
+        };
+
+        const request = createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(clientData)
+        );
+
+        const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+        expect(response.status).toBe(201);
+        const registeredClient = await response.json<any>();
+        expect(registeredClient['client_name#ja-Jpan-JP']).toBe('テスト');
+      });
+
+      it('omits the i18n map when no localized variants are present', async () => {
+        const clientData = {
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Test Client',
+          token_endpoint_auth_method: 'none',
+        };
+
+        const request = createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(clientData)
+        );
+
+        const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+        const registeredClient = await response.json<any>();
+        const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+        expect(savedClient.i18n).toBeUndefined();
+      });
+
+      it('only captures the RFC §2.2 human-readable fields, ignoring others', async () => {
+        const clientData = {
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Test Client',
+          'client_name#ja': 'テスト',
+          // Not a §2.2 human-readable field — must be ignored, not stored
+          'jwks_uri#ja': 'https://client.example.com/ja/jwks.json',
+          'contacts#ja': 'ignored',
+          token_endpoint_auth_method: 'none',
+        };
+
+        const request = createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(clientData)
+        );
+
+        const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+        expect(response.status).toBe(201);
+        const registeredClient = await response.json<any>();
+        const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+        expect(savedClient.i18n).toEqual({ 'client_name#ja': 'テスト' });
+        expect(registeredClient['jwks_uri#ja']).toBeUndefined();
+        expect(registeredClient['contacts#ja']).toBeUndefined();
+      });
+
+      it('applies http(s) scheme validation to localized URI variants', async () => {
+        const clientData = {
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Test Client',
+          'tos_uri#fr': 'javascript:alert(1)',
+          token_endpoint_auth_method: 'none',
+        };
+
+        const request = createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(clientData)
+        );
+
+        const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+        expect(response.status).toBe(400);
+        const body = await response.json<any>();
+        expect(body.error).toBe('invalid_client_metadata');
+      });
+
+      it('rejects non-string localized variant values', async () => {
+        const clientData = {
+          redirect_uris: ['https://client.example.com/callback'],
+          client_name: 'Test Client',
+          'client_name#ja': 123,
+          token_endpoint_auth_method: 'none',
+        };
+
+        const request = createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(clientData)
+        );
+
+        const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+        expect(response.status).toBe(400);
+        const body = await response.json<any>();
+        expect(body.error).toBe('invalid_client_metadata');
+      });
+    });
   });
 
   describe('Authorization Code Flow', () => {
@@ -7880,6 +8040,50 @@ describe('OAuthProvider', () => {
         const metadata = await metadataResponse.json<any>();
 
         expect(metadata.client_id_metadata_document_supported).toBe(true);
+      });
+
+      it('should accept a CIMD document with localized metadata variants', async () => {
+        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+        const validMetadata = {
+          client_id: cimdUrl,
+          client_name: 'CIMD Test Client',
+          'client_name#ja': 'テストクライアント',
+          'tos_uri#fr': 'https://client.example.com/fr/terms',
+          redirect_uris: ['https://client.example.com/callback'],
+          token_endpoint_auth_method: 'none',
+        };
+
+        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+
+        const authRequest = createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
+          'GET'
+        );
+
+        const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+        expect(authResponse.status).toBe(302);
+      });
+
+      it('should reject a CIMD document whose localized URI variant uses an unsafe scheme', async () => {
+        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+        const maliciousMetadata = {
+          client_id: cimdUrl,
+          client_name: 'CIMD Test Client',
+          'tos_uri#fr': 'javascript:alert(1)',
+          redirect_uris: ['https://client.example.com/callback'],
+          token_endpoint_auth_method: 'none',
+        };
+
+        globalThis.fetch = vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(createMockFetchResponse(maliciousMetadata)));
+
+        const authRequest = createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
+          'GET'
+        );
+
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
       });
     });
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -3375,10 +3375,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       token_endpoint_auth_method: clientInfo.tokenEndpointAuthMethod,
       registration_client_uri: `${this.options.clientRegistrationEndpoint}/${clientId}`,
       client_id_issued_at: clientInfo.registrationDate,
-      // RFC 7591 §2.2: echo internationalized variants back as top-level
-      // `field#tag` members alongside their canonical counterparts.
-      ...clientInfo.i18n,
     };
+
+    // RFC 7591 §2.2: echo internationalized variants back as top-level
+    // `field#tag` members alongside their canonical counterparts. Skip any key
+    // already present so a localized variant can never shadow a canonical
+    // response member (i18n keys always contain `#`, but this stays correct
+    // even if a future canonical field name were to include one).
+    if (clientInfo.i18n) {
+      for (const [key, value] of Object.entries(clientInfo.i18n)) {
+        if (!(key in response)) response[key] = value;
+      }
+    }
 
     // Only include client_secret for confidential clients (RFC 7591 §3.2.1)
     if (clientSecret) {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -705,6 +705,19 @@ export interface ClientInfo {
   jwksUri?: string;
 
   /**
+   * RFC 7591 §2.2 internationalized variants of the human-readable client
+   * metadata fields, keyed by the raw member name including its BCP 47 language
+   * tag (e.g. `"client_name#ja"`, `"tos_uri#fr"`).
+   *
+   * Only the human-readable fields the RFC names are captured here:
+   * `client_name`, `client_uri`, `logo_uri`, `tos_uri`, and `policy_uri`.
+   * The canonical (un-tagged) values continue to live in their own typed
+   * fields above; this map holds only the locale-specific variants so that
+   * consumers can perform their own locale selection.
+   */
+  i18n?: Record<string, string>;
+
+  /**
    * List of email addresses for contacting the client developers
    */
   contacts?: string[];
@@ -3311,12 +3324,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       clientInfo = {
         clientId,
         redirectUris,
-        clientName: OAuthProviderImpl.validateStringField(clientMetadata.client_name),
+        clientName: OAuthProviderImpl.validateStringField(clientMetadata.client_name, 'client_name'),
         logoUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.logo_uri, 'logo_uri'),
         clientUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.client_uri, 'client_uri'),
         policyUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.policy_uri, 'policy_uri'),
         tosUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.tos_uri, 'tos_uri'),
         jwksUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.jwks_uri, 'jwks_uri'),
+        i18n: OAuthProviderImpl.extractI18nFields(clientMetadata),
         contacts: OAuthProviderImpl.validateStringArray(clientMetadata.contacts),
         grantTypes: OAuthProviderImpl.validateStringArray(clientMetadata.grant_types) || [
           GrantType.AUTHORIZATION_CODE,
@@ -3361,6 +3375,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       token_endpoint_auth_method: clientInfo.tokenEndpointAuthMethod,
       registration_client_uri: `${this.options.clientRegistrationEndpoint}/${clientId}`,
       client_id_issued_at: clientInfo.registrationDate,
+      // RFC 7591 §2.2: echo internationalized variants back as top-level
+      // `field#tag` members alongside their canonical counterparts.
+      ...clientInfo.i18n,
     };
 
     // Only include client_secret for confidential clients (RFC 7591 §3.2.1)
@@ -3790,6 +3807,59 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
+   * The human-readable client metadata fields that may carry RFC 7591 §2.2
+   * internationalized variants, mapped to whether the value must be a URI.
+   * URI fields are validated with the same scheme rules as their canonical
+   * counterparts; plain fields only need to be strings.
+   */
+  private static readonly I18N_FIELDS: Record<string, 'string' | 'uri'> = {
+    client_name: 'string',
+    client_uri: 'uri',
+    logo_uri: 'uri',
+    tos_uri: 'uri',
+    policy_uri: 'uri',
+  };
+
+  /**
+   * Extracts RFC 7591 §2.2 internationalized metadata variants from a raw
+   * registration payload.
+   *
+   * Localized variants are expressed by appending a `#<BCP 47 language tag>`
+   * suffix to a metadata member name (e.g. `client_name#ja`, `tos_uri#fr`).
+   * Only the human-readable fields the RFC names are considered; each value is
+   * validated with the same rules as its canonical field (URI fields must be
+   * absolute http(s) URLs). The raw `field#tag` keys are preserved verbatim so
+   * that consumers can do their own locale matching.
+   *
+   * @param raw - The parsed client metadata object
+   * @returns A map of `field#tag` to validated value, or undefined if none present
+   * @throws Error if a localized value fails its field's validation
+   */
+  private static extractI18nFields(raw: Record<string, unknown>): Record<string, string> | undefined {
+    const result: Record<string, string> = {};
+
+    for (const key of Object.keys(raw)) {
+      const hashIndex = key.indexOf('#');
+      if (hashIndex <= 0 || hashIndex === key.length - 1) continue;
+
+      const baseField = key.slice(0, hashIndex);
+      const kind = OAuthProviderImpl.I18N_FIELDS[baseField];
+      if (!kind) continue;
+
+      const validated =
+        kind === 'uri'
+          ? OAuthProviderImpl.validateOptionalUriField(raw[key], key)
+          : OAuthProviderImpl.validateStringField(raw[key], key);
+
+      if (validated !== undefined) {
+        result[key] = validated;
+      }
+    }
+
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  /**
    * Validates that a field is a string array or undefined
    * @param arr - The array to validate
    * @param fieldName - Name of the field for error messages
@@ -3878,6 +3948,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         policyUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.policy_uri, 'policy_uri'),
         tosUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.tos_uri, 'tos_uri'),
         jwksUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.jwks_uri, 'jwks_uri'),
+        i18n: OAuthProviderImpl.extractI18nFields(rawMetadata),
         contacts: OAuthProviderImpl.validateStringArray(rawMetadata.contacts, 'contacts'),
         grantTypes: OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
           'authorization_code',
@@ -4910,6 +4981,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       policyUri: clientInfo.policyUri,
       tosUri: clientInfo.tosUri,
       jwksUri: clientInfo.jwksUri,
+      i18n: clientInfo.i18n,
       contacts: clientInfo.contacts,
       grantTypes: clientInfo.grantTypes || [
         GrantType.AUTHORIZATION_CODE,

--- a/storage-schema.md
+++ b/storage-schema.md
@@ -39,6 +39,10 @@ Client records store OAuth client application information.
   "policyUri": "https://app.example.com/privacy",
   "tosUri": "https://app.example.com/terms",
   "jwksUri": null,
+  "i18n": {
+    "client_name#ja": "サンプルアプリ",
+    "tos_uri#ja": "https://app.example.com/ja/terms"
+  },
   "contacts": ["dev@example.com"],
   "grantTypes": ["authorization_code", "refresh_token"],
   "responseTypes": ["code"],
@@ -47,6 +51,8 @@ Client records store OAuth client application information.
 ```
 
 > **Note:** The `clientSecret` is stored as a SHA-256 hash, not in plaintext. The actual secret is only returned to the client when initially created or updated, and never stored.
+
+> **Note:** The optional `i18n` map holds RFC 7591 §2.2 internationalized variants of the human-readable metadata fields (`client_name`, `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`), keyed by the raw `field#<BCP 47 language tag>` member name. Canonical (un-tagged) values remain in their own fields. URI variants are validated as absolute http(s) URLs, the same as their canonical counterparts.
 
 **TTL:** Dynamically registered clients (DCR) default to 90 days. Clients created via `OAuthHelpers.createClient()` have no expiration. Configurable via the `clientRegistrationTTL` option.
 


### PR DESCRIPTION
Closes #219.

## What

Preserve RFC 7591 §2.2 internationalized client metadata variants, which were previously silently dropped during registration.

Localized variants are expressed by appending a `#<BCP 47 language tag>` suffix to a metadata member name (e.g. `client_name#ja`, `tos_uri#fr`). This PR captures them for the five human-readable fields the RFC names — `client_name`, `client_uri`, `logo_uri`, `tos_uri`, `policy_uri` — and:

- stores them on the client record under a new optional `ClientInfo.i18n` map, keyed by the raw `field#tag` name (flat representation, mirrors the wire format);
- echoes them back as top-level `field#tag` members in the registration `201` response, alongside their canonical fields;
- handles them on both ingestion paths: Dynamic Client Registration (`/register`) and Client ID Metadata Document (CIMD) fetching.

## Validation

Each localized value is validated with the same rules as its canonical field:
- URI variants (`client_uri#*`, `logo_uri#*`, `tos_uri#*`, `policy_uri#*`) must be absolute `http:`/`https:` URLs (reuses `validateOptionalUriField` from #218).
- All variants must be strings.
- Language-tag case is preserved (tags are case-insensitive per BCP 47, so consumers should compare accordingly).
- Fields **not** in §2.2 (e.g. `jwks_uri`, `redirect_uris`, `contacts`) are not collected.

## Scope notes

- `jwks_uri` and `redirect_uris` are deliberately excluded — §2.2 covers only human-readable fields.
- `updateClient` replaces the whole `i18n` map when provided (RFC 7592 update semantics = replace), via the existing spread.

## Tests

- DCR: round-trip persist + response echo, BCP 47 tag-case preservation, omission when no variants present, non-§2.2 fields ignored, unsafe-scheme rejection on localized URI variants, non-string rejection.
- CIMD: accepts a document with localized variants; rejects a localized URI variant using an unsafe scheme.
- Full suite: `npm run check` → typecheck clean + 479 tests pass (+8 new).
- Patch changeset included.
- Also folds in @ask-bonk's nit from #218: passes the field name to the `client_name` `validateStringField` call in the DCR path.
