### PR TITLE
feat(ema): add opt-in allowPublicClients for enterprise-managed authorization

### DIFF
--- a/.changeset/ema-allow-public-clients.md
+++ b/.changeset/ema-allow-public-clients.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Add an opt-in `allowPublicClients` flag to `enterpriseManagedAuthorization`.
+
+By default the enterprise-managed authorization (ID-JAG) grant requires client authentication, so public clients (`token_endpoint_auth_method: 'none'`) are rejected. Setting `allowPublicClients: true` also accepts public clients on this grant — for example clients registered via a Client ID Metadata Document (CIMD), which are always public and cannot present a client secret. The default remains `false`, preserving existing behavior.

--- a/README.md
+++ b/README.md
@@ -390,6 +390,19 @@ Setup:
 
 The AS enforces `resolved.issuer === iss` (confused-deputy guard) and validates ID-JAG `typ`, signature, audience, client binding, resource, `exp` / `iat` / `nbf`, max lifetime, and `jti` replay. Refresh tokens are not issued for this grant — the ID-JAG itself is the renewable assertion.
 
+### Public clients
+
+By default the EMA grant requires client authentication, so public clients (`token_endpoint_auth_method: 'none'`) are rejected. Set `allowPublicClients: true` to also accept them:
+
+```ts
+enterpriseManagedAuthorization: {
+  allowPublicClients: true,
+  // ... trustedIssuers, mapClaims ...
+}
+```
+
+This is useful for clients registered via a [Client ID Metadata Document (CIMD)](https://modelcontextprotocol.io/), which are always public and therefore cannot present a client secret. With this enabled, trust rests on the IdP-issued, signature-verified, short-lived, single-use ID-JAG assertion (audience-, resource-, and client-bound) rather than on a separately presented client secret. Leave it unset (default `false`) to keep the spec-default behavior of requiring client authentication.
+
 Experimental — the MCP extension is still a draft.
 
 ## Custom Error Responses

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3594,6 +3594,69 @@ describe('OAuthProvider', () => {
       expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
     });
 
+    it('should allow public clients for enterprise-managed authorization when allowPublicClients is enabled', async () => {
+      const publicClientProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        scopesSupported: ['read', 'write', 'profile'],
+        accessTokenTTL: 3600,
+        resourceMetadata: { resource },
+        enterpriseManagedAuthorization: {
+          allowPublicClients: true,
+          trustedIssuers: async () => ({ issuer, jwksUri: `${issuer}/jwks.json`, algorithms: ['RS256'] }),
+          mapClaims: async ({ claims, requestedScope }) => ({
+            userId: `enterprise-${claims.sub}`,
+            scope: requestedScope,
+            metadata: { enterpriseIssuer: claims.iss, enterpriseSubject: claims.sub },
+            props: { enterprise: true, subject: claims.sub, email: claims.email },
+          }),
+        },
+      });
+
+      const publicRegisterResponse = await publicClientProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://public.example.com/callback'],
+            client_name: 'Public Enterprise Client',
+            token_endpoint_auth_method: 'none',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const publicClient = await publicRegisterResponse.json<any>();
+      expect(publicClient.client_secret).toBeUndefined();
+
+      const assertion = await createAssertion({ client_id: publicClient.client_id });
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+      params.append('assertion', assertion);
+      params.append('client_id', publicClient.client_id);
+
+      const response = await publicClientProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(200);
+      const tokenResponse = await response.json<any>();
+      expect(tokenResponse.access_token).toBeDefined();
+      expect(tokenResponse.token_type).toBe('bearer');
+    });
+
     it('should deny issuance when mapClaims returns null', async () => {
       const denyingProvider = new OAuthProvider({
         apiRoute: ['/api/'],

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -250,6 +250,23 @@ export interface EmaOptions<Env = Cloudflare.Env> {
 
   /** Maximum accepted assertion lifetime in seconds. Defaults to 300 seconds. */
   maxAssertionLifetimeSeconds?: number;
+
+  /**
+   * Allow public clients (`token_endpoint_auth_method: 'none'`) to use the
+   * enterprise-managed authorization (ID-JAG) grant.
+   *
+   * Defaults to `false`. By default the EMA grant requires client
+   * authentication, matching the MCP enterprise-managed-authorization draft.
+   *
+   * Set to `true` to also accept public clients on this grant — for example
+   * clients registered via a Client ID Metadata Document (CIMD), which are
+   * always public (`none`) and therefore cannot present a client secret. The
+   * security trade-off is documented in the README: the trust then rests on
+   * the IdP-issued, signature-verified, short-lived, single-use ID-JAG
+   * assertion (audience-, resource-, and client-bound) rather than on a
+   * separately presented client secret.
+   */
+  allowPublicClients?: boolean;
 }
 
 // ─── Internal types (used inside the EMA pipeline) ────────────────────────────

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2887,7 +2887,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.createErrorResponse('unsupported_grant_type', { description: 'Grant type not supported' });
     }
 
-    if (clientInfo.tokenEndpointAuthMethod === 'none') {
+    // By default the EMA grant requires client authentication (per the MCP
+    // enterprise-managed-authorization draft). Deployers can opt in to also
+    // accepting public clients (e.g. CIMD clients, which are always
+    // `token_endpoint_auth_method: 'none'`) via `allowPublicClients`. In that
+    // case trust rests on the signature-verified, short-lived, single-use
+    // ID-JAG assertion rather than on a separately presented client secret.
+    if (clientInfo.tokenEndpointAuthMethod === 'none' && !enterpriseOptions.allowPublicClients) {
       return this.createErrorResponse('invalid_client', {
         description: 'Enterprise-managed authorization requires client authentication',
         statusCode: 401,


### PR DESCRIPTION
## Summary

The enterprise-managed authorization (EMA / ID-JAG) grant currently rejects public clients (`token_endpoint_auth_method: 'none'`) unconditionally, matching the MCP enterprise-managed-authorization draft which requires client authentication.

This adds an **opt-in** `allowPublicClients` flag to `enterpriseManagedAuthorization` so deployers can also accept public clients on this grant. The primary use case is clients registered via a [Client ID Metadata Document (CIMD)](https://modelcontextprotocol.io/), which are always public (`none`) and therefore cannot present a client secret.

When enabled, trust rests on the IdP-issued, signature-verified, short-lived, single-use ID-JAG assertion (audience-, resource-, and client-bound) rather than on a separately presented client secret.

## Behavior

- Default `allowPublicClients: false` — existing behavior is unchanged; public clients are still rejected on the EMA grant.
- `allowPublicClients: true` — public clients are accepted on the EMA grant; all other ID-JAG validation (issuer trust, signature, audience, resource, client binding, `exp`/`iat`/`nbf`, max lifetime, `jti` replay) is unchanged.

## Changes

- `src/ema/types.ts` — add `allowPublicClients?: boolean` to `EmaOptions`.
- `src/oauth-provider.ts` — gate the public-client rejection in the JWT-bearer grant handler on the new flag.
- `README.md` — document the flag and its security trade-off.
- Test — new case proving a public client succeeds when the flag is enabled; the existing default-rejection test stays green.

## Changeset

Patch — the change is opt-in and fully backwards-compatible.