### PR TITLE
fix: prevent caching of token, credential, and error responses (RFC 6749 §5.1/§5.2)

### DIFF
--- a/.changeset/cache-control-no-store.md
+++ b/.changeset/cache-control-no-store.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': patch
 ---
 
-Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses that contain tokens or credentials, per RFC 6749 §5.1 (token endpoint responses and dynamic client registration responses carrying `client_secret`).
+Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses that carry tokens, credentials, or OAuth state, matching the response examples in RFC 6749 §5.1/§5.2: token endpoint responses (success and error), dynamic client registration responses carrying `client_secret`, and EMA JWT-bearer token responses.

--- a/.changeset/cache-control-no-store.md
+++ b/.changeset/cache-control-no-store.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses carrying tokens, credentials, or other sensitive authorization data.

--- a/.changeset/cache-control-no-store.md
+++ b/.changeset/cache-control-no-store.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': patch
 ---
 
-Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses carrying tokens, credentials, or other sensitive authorization data.
+Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses that contain tokens or credentials, per RFC 6749 §5.1 (token endpoint responses and dynamic client registration responses carrying `client_secret`).

--- a/.changeset/cache-control-no-store.md
+++ b/.changeset/cache-control-no-store.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': patch
 ---
 
-Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses that carry tokens, credentials, or OAuth state, per RFC 6749 §5.1: token endpoint success responses, dynamic client registration responses carrying `client_secret`, and OAuth error responses.
+Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses that contain tokens or credentials, per RFC 6749 §5.1 (token endpoint responses and dynamic client registration responses carrying `client_secret`).

--- a/.changeset/cache-control-no-store.md
+++ b/.changeset/cache-control-no-store.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': patch
 ---
 
-Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses that contain tokens or credentials, per RFC 6749 §5.1 (token endpoint responses and dynamic client registration responses carrying `client_secret`).
+Add `Cache-Control: no-store` and `Pragma: no-cache` to OAuth responses that carry tokens, credentials, or OAuth state, per RFC 6749 §5.1: token endpoint success responses, dynamic client registration responses carrying `client_secret`, and OAuth error responses.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ const defaultHandler = {
 
       // After the user has granted consent, the application calls `env.OAUTH_PROVIDER.completeAuthorization()` to
       // grant the authorization.
-      let { redirectTo } = await env.OAUTH_PROVIDER.completeAuthorization({
+      let { redirectTo, headers } = await env.OAUTH_PROVIDER.completeAuthorization({
         // The application passes back the original OAuth request info that was returned by
         // `parseAuthRequest()` earlier.
         request: oauthReqInfo,
@@ -192,8 +192,15 @@ const defaultHandler = {
       // `completeAuthorization()` will have returned the URL to which the user should be redirected
       // in order to complete the authorization flow. This is the requesting client's OAuth
       // redirect_uri with the appropriate query parameters added to complete the flow and obtain
-      // tokens.
-      return Response.redirect(redirectTo, 302);
+      // tokens. Apply the returned headers so intermediaries do not cache the redirect carrying
+      // authorization credentials.
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: redirectTo,
+          ...headers,
+        },
+      });
     }
 
     // ... the application can implement other non-API HTTP endpoints here ...

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ const defaultHandler = {
 
       // After the user has granted consent, the application calls `env.OAUTH_PROVIDER.completeAuthorization()` to
       // grant the authorization.
-      let { redirectTo, headers } = await env.OAUTH_PROVIDER.completeAuthorization({
+      let { redirectTo } = await env.OAUTH_PROVIDER.completeAuthorization({
         // The application passes back the original OAuth request info that was returned by
         // `parseAuthRequest()` earlier.
         request: oauthReqInfo,
@@ -192,15 +192,8 @@ const defaultHandler = {
       // `completeAuthorization()` will have returned the URL to which the user should be redirected
       // in order to complete the authorization flow. This is the requesting client's OAuth
       // redirect_uri with the appropriate query parameters added to complete the flow and obtain
-      // tokens. Apply the returned headers so intermediaries do not cache the redirect carrying
-      // authorization credentials.
-      return new Response(null, {
-        status: 302,
-        headers: {
-          Location: redirectTo,
-          ...headers,
-        },
-      });
+      // tokens.
+      return Response.redirect(redirectTo, 302);
     }
 
     // ... the application can implement other non-API HTTP endpoints here ...

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -162,12 +162,13 @@ const testDefaultHandler = {
   },
 };
 
-// Helper function to create mock requests
-function expectSensitiveResponseCacheHeaders(response: Response): void {
+// Asserts a response carries the RFC 6749 §5.1 no-cache headers
+function expectNoCacheHeaders(response: Response): void {
   expect(response.headers.get('Cache-Control')).toBe('no-store');
   expect(response.headers.get('Pragma')).toBe('no-cache');
 }
 
+// Helper function to create mock requests
 function createMockRequest(
   url: string,
   method: string = 'GET',
@@ -3346,7 +3347,7 @@ describe('OAuthProvider', () => {
       );
 
       expect(response.status).toBe(400);
-      expectSensitiveResponseCacheHeaders(response);
+      expectNoCacheHeaders(response);
       expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
 
@@ -5532,7 +5533,7 @@ describe('OAuthProvider', () => {
       const { client, response } = await registerClient();
 
       expect(client.client_secret).toBeDefined();
-      expectSensitiveResponseCacheHeaders(response);
+      expectNoCacheHeaders(response);
     });
 
     it('adds no-store and no-cache to authorization code token responses', async () => {
@@ -5541,7 +5542,7 @@ describe('OAuthProvider', () => {
 
       expect(tokens.access_token).toBeDefined();
       expect(tokens.refresh_token).toBeDefined();
-      expectSensitiveResponseCacheHeaders(response);
+      expectNoCacheHeaders(response);
     });
 
     it('adds no-store and no-cache to refresh token responses', async () => {
@@ -5565,7 +5566,7 @@ describe('OAuthProvider', () => {
       );
 
       expect(response.status).toBe(200);
-      expectSensitiveResponseCacheHeaders(response);
+      expectNoCacheHeaders(response);
     });
 
     it('adds no-store and no-cache to token exchange responses', async () => {
@@ -5591,7 +5592,7 @@ describe('OAuthProvider', () => {
       );
 
       expect(response.status).toBe(200);
-      expectSensitiveResponseCacheHeaders(response);
+      expectNoCacheHeaders(response);
     });
   });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3347,9 +3347,6 @@ describe('OAuthProvider', () => {
       );
 
       expect(response.status).toBe(400);
-      // EMA error responses are not in RFC 6749 §5.1 scope (no token/credential), so no no-cache headers.
-      expect(response.headers.get('Cache-Control')).toBeNull();
-      expect(response.headers.get('Pragma')).toBeNull();
       expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -147,7 +147,7 @@ const testDefaultHandler = {
       const clientInfo = await env.OAUTH_PROVIDER!.lookupClient(oauthReqInfo.clientId);
 
       // Mock user consent flow - automatically grant consent
-      const { redirectTo } = await env.OAUTH_PROVIDER!.completeAuthorization({
+      const { redirectTo, headers } = await env.OAUTH_PROVIDER!.completeAuthorization({
         request: oauthReqInfo,
         userId: 'test-user-123',
         metadata: { testConsent: true },
@@ -155,7 +155,13 @@ const testDefaultHandler = {
         props: { userId: 'test-user-123', username: 'TestUser' },
       });
 
-      return Response.redirect(redirectTo, 302);
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: redirectTo,
+          ...headers,
+        },
+      });
     }
 
     return new Response('Default handler', { status: 200 });
@@ -163,6 +169,11 @@ const testDefaultHandler = {
 };
 
 // Helper function to create mock requests
+function expectSensitiveResponseCacheHeaders(response: Response): void {
+  expect(response.headers.get('Cache-Control')).toBe('no-store');
+  expect(response.headers.get('Pragma')).toBe('no-cache');
+}
+
 function createMockRequest(
   url: string,
   method: string = 'GET',
@@ -3341,7 +3352,7 @@ describe('OAuthProvider', () => {
       );
 
       expect(response.status).toBe(400);
-      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expectSensitiveResponseCacheHeaders(response);
       expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
 
@@ -5458,6 +5469,159 @@ describe('OAuthProvider', () => {
       expect(tokenResponse.status).toBe(400);
       const error = await tokenResponse.json<any>();
       expect(error.error).toBe('invalid_target');
+    });
+  });
+
+  describe('Sensitive response cache headers (RFC 6749 §5.1)', () => {
+    async function registerClient(): Promise<{ client: any; response: Response }> {
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Cache Header Test Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      return { client: await response.json<any>(), response };
+    }
+
+    async function authorize(clientId: string): Promise<{ code: string; response: Response; redirectUri: string }> {
+      const redirectUri = 'https://client.example.com/callback';
+      const authUrl = new URL('https://example.com/authorize');
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', clientId);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('scope', 'read write');
+      authUrl.searchParams.set('state', 'state-123');
+
+      const response = await oauthProvider.fetch(createMockRequest(authUrl.toString()), mockEnv, mockCtx);
+      const location = response.headers.get('Location');
+      expect(location).toBeTruthy();
+      const code = new URL(location!).searchParams.get('code');
+      expect(code).toBeTruthy();
+
+      return { code: code!, response, redirectUri };
+    }
+
+    async function exchangeAuthorizationCode(client: any): Promise<{ tokens: any; response: Response }> {
+      const { code, redirectUri } = await authorize(client.client_id);
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', client.client_id);
+      params.append('client_secret', client.client_secret);
+
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(200);
+      return { tokens: await response.json<any>(), response };
+    }
+
+    it('adds no-store and no-cache to dynamic client registration responses', async () => {
+      const { client, response } = await registerClient();
+
+      expect(client.client_secret).toBeDefined();
+      expectSensitiveResponseCacheHeaders(response);
+    });
+
+    it('adds no-store and no-cache to authorization redirects containing credentials', async () => {
+      const { client } = await registerClient();
+      const { response } = await authorize(client.client_id);
+
+      expect(response.status).toBe(302);
+      expectSensitiveResponseCacheHeaders(response);
+    });
+
+    it('adds no-store and no-cache to authorization code token responses', async () => {
+      const { client } = await registerClient();
+      const { tokens, response } = await exchangeAuthorizationCode(client);
+
+      expect(tokens.access_token).toBeDefined();
+      expect(tokens.refresh_token).toBeDefined();
+      expectSensitiveResponseCacheHeaders(response);
+    });
+
+    it('adds no-store and no-cache to refresh token responses', async () => {
+      const { client } = await registerClient();
+      const { tokens } = await exchangeAuthorizationCode(client);
+      const params = new URLSearchParams();
+      params.append('grant_type', 'refresh_token');
+      params.append('refresh_token', tokens.refresh_token);
+      params.append('client_id', client.client_id);
+      params.append('client_secret', client.client_secret);
+
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(200);
+      expectSensitiveResponseCacheHeaders(response);
+    });
+
+    it('adds no-store and no-cache to token exchange responses', async () => {
+      const { client } = await registerClient();
+      const { tokens } = await exchangeAuthorizationCode(client);
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
+      params.append('subject_token', tokens.access_token);
+      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append('client_id', client.client_id);
+      params.append('client_secret', client.client_secret);
+
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(200);
+      expectSensitiveResponseCacheHeaders(response);
+    });
+
+    it('adds no-store and no-cache to OAuth JSON error responses', async () => {
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          'grant_type=authorization_code&code=invalid'
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(401);
+      expectSensitiveResponseCacheHeaders(response);
     });
   });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3347,7 +3347,9 @@ describe('OAuthProvider', () => {
       );
 
       expect(response.status).toBe(400);
-      expectNoCacheHeaders(response);
+      // EMA error responses are not in RFC 6749 §5.1 scope (no token/credential), so no no-cache headers.
+      expect(response.headers.get('Cache-Control')).toBeNull();
+      expect(response.headers.get('Pragma')).toBeNull();
       expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -5594,6 +5594,22 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(200);
       expectNoCacheHeaders(response);
     });
+
+    it('adds no-store and no-cache to token endpoint error responses', async () => {
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          'grant_type=authorization_code&code=invalid'
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(401);
+      expectNoCacheHeaders(response);
+    });
   });
 
   describe('CORS Support', () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -147,7 +147,7 @@ const testDefaultHandler = {
       const clientInfo = await env.OAUTH_PROVIDER!.lookupClient(oauthReqInfo.clientId);
 
       // Mock user consent flow - automatically grant consent
-      const { redirectTo, headers } = await env.OAUTH_PROVIDER!.completeAuthorization({
+      const { redirectTo } = await env.OAUTH_PROVIDER!.completeAuthorization({
         request: oauthReqInfo,
         userId: 'test-user-123',
         metadata: { testConsent: true },
@@ -155,13 +155,7 @@ const testDefaultHandler = {
         props: { userId: 'test-user-123', username: 'TestUser' },
       });
 
-      return new Response(null, {
-        status: 302,
-        headers: {
-          Location: redirectTo,
-          ...headers,
-        },
-      });
+      return Response.redirect(redirectTo, 302);
     }
 
     return new Response('Default handler', { status: 200 });
@@ -5538,14 +5532,6 @@ describe('OAuthProvider', () => {
       const { client, response } = await registerClient();
 
       expect(client.client_secret).toBeDefined();
-      expectSensitiveResponseCacheHeaders(response);
-    });
-
-    it('adds no-store and no-cache to authorization redirects containing credentials', async () => {
-      const { client } = await registerClient();
-      const { response } = await authorize(client.client_id);
-
-      expect(response.status).toBe(302);
       expectSensitiveResponseCacheHeaders(response);
     });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -5594,22 +5594,6 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(200);
       expectNoCacheHeaders(response);
     });
-
-    it('adds no-store and no-cache to token endpoint error responses', async () => {
-      const response = await oauthProvider.fetch(
-        createMockRequest(
-          'https://example.com/oauth/token',
-          'POST',
-          { 'Content-Type': 'application/x-www-form-urlencoded' },
-          'grant_type=authorization_code&code=invalid'
-        ),
-        mockEnv,
-        mockCtx
-      );
-
-      expect(response.status).toBe(401);
-      expectNoCacheHeaders(response);
-    });
   });
 
   describe('CORS Support', () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -5593,22 +5593,6 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(200);
       expectSensitiveResponseCacheHeaders(response);
     });
-
-    it('adds no-store and no-cache to OAuth JSON error responses', async () => {
-      const response = await oauthProvider.fetch(
-        createMockRequest(
-          'https://example.com/oauth/token',
-          'POST',
-          { 'Content-Type': 'application/x-www-form-urlencoded' },
-          'grant_type=authorization_code&code=invalid'
-        ),
-        mockEnv,
-        mockCtx
-      );
-
-      expect(response.status).toBe(401);
-      expectSensitiveResponseCacheHeaders(response);
-    });
   });
 
   describe('CORS Support', () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -5593,6 +5593,22 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(200);
       expectNoCacheHeaders(response);
     });
+
+    it('adds no-store and no-cache to token endpoint error responses', async () => {
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          'grant_type=authorization_code&code=invalid'
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(401);
+      expectNoCacheHeaders(response);
+    });
   });
 
   describe('CORS Support', () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -37,6 +37,7 @@ export type {
 export type { EmaValidationError } from './ema/result';
 
 const PROTECTED_RESOURCE_WELL_KNOWN_PREFIX = '/.well-known/oauth-protected-resource';
+const SENSITIVE_RESPONSE_HEADERS = { 'Cache-Control': 'no-store', Pragma: 'no-cache' } as const;
 
 // Log CIMD status on module load
 const hasStrictlyPublicFetch =
@@ -501,9 +502,9 @@ export interface OAuthHelpers {
   /**
    * Completes an authorization request by creating a grant and authorization code
    * @param options - Options specifying the grant details
-   * @returns A Promise resolving to an object containing the redirect URL
+   * @returns A Promise resolving to the redirect URL and headers to apply to the redirect response
    */
-  completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }>;
+  completeAuthorization(options: CompleteAuthorizationOptions): Promise<CompleteAuthorizationResult>;
 
   /**
    * Creates a new OAuth client
@@ -750,8 +751,21 @@ export interface ClientInfo {
 }
 
 /**
- * Options for completing an authorization request
+ * Result of completing an authorization request
  */
+export interface CompleteAuthorizationResult {
+  /**
+   * URL to redirect the user-agent to after authorization.
+   */
+  redirectTo: string;
+
+  /**
+   * Headers that should be applied to the redirect response because it contains
+   * an authorization code or access token.
+   */
+  headers: Record<string, string>;
+}
+
 export interface CompleteAuthorizationOptions {
   /**
    * The original parsed authorization request
@@ -2309,9 +2323,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       tokenResponse.resource = audience;
     }
 
-    // Return the tokens
+    // RFC 6749 §5.1 — responses containing tokens must not be cached.
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
     });
   }
 
@@ -2595,9 +2609,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       tokenResponse.resource = audience;
     }
 
-    // Return the tokens
+    // RFC 6749 §5.1 — responses containing tokens must not be cached.
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
     });
   }
 
@@ -2852,9 +2866,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         env
       );
 
-      // Return the token
+      // RFC 6749 §5.1 — responses containing tokens must not be cached.
       return new Response(JSON.stringify(tokenResponse), {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
       });
     } catch (error) {
       // Convert OAuth errors into structured `/token` error responses,
@@ -2903,19 +2917,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const result = await this.runEmaPipeline({ body, clientInfo, env, requestUrl, request, enterpriseOptions });
 
     // RFC 6749 §5.1 — token endpoint responses must not be cached.
-    const noCacheHeaders = { 'Cache-Control': 'no-store', Pragma: 'no-cache' };
-
     if (!result.ok) {
       const wire = emaErrorToWire(result.error);
       return this.createErrorResponse(
         wire.code,
-        { description: wire.message, headers: noCacheHeaders },
+        { description: wire.message, headers: { ...SENSITIVE_RESPONSE_HEADERS } },
         { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
       );
     }
 
     return new Response(JSON.stringify(result.value), {
-      headers: { 'Content-Type': 'application/json', ...noCacheHeaders },
+      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
     });
   }
 
@@ -3406,7 +3418,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     return new Response(JSON.stringify(response), {
       status: 201,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
     });
   }
 
@@ -4049,7 +4061,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
-    const responseHeaders = options.headers ?? {};
+    const responseHeaders = { ...(options.headers ?? {}), ...SENSITIVE_RESPONSE_HEADERS };
 
     // Notify the user of the error and allow them to override the response
     const customErrorResponse = this.options.onError?.({
@@ -4792,9 +4804,9 @@ class OAuthHelpersImpl implements OAuthHelpers {
    * - For authorization code flow: generating an authorization code
    * - For implicit flow: generating an access token directly
    * @param options - Options specifying the grant details
-   * @returns A Promise resolving to an object containing the redirect URL
+   * @returns A Promise resolving to the redirect URL and headers to apply to the redirect response
    */
-  async completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }> {
+  async completeAuthorization(options: CompleteAuthorizationOptions): Promise<CompleteAuthorizationResult> {
     const { clientId, redirectUri } = options.request;
 
     if (!clientId || !redirectUri) {
@@ -4918,7 +4930,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }
 
-      return { redirectTo: redirectUrl.toString() };
+      return { redirectTo: redirectUrl.toString(), headers: { ...SENSITIVE_RESPONSE_HEADERS } };
     } else {
       // Standard authorization code flow
       // Generate an authorization code with embedded user and grant IDs
@@ -4969,7 +4981,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }
 
-      return { redirectTo: redirectUrl.toString() };
+      return { redirectTo: redirectUrl.toString(), headers: { ...SENSITIVE_RESPONSE_HEADERS } };
     }
   }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2903,16 +2903,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     const result = await this.runEmaPipeline({ body, clientInfo, env, requestUrl, request, enterpriseOptions });
 
-    // RFC 6749 §5.1 — token endpoint responses must not be cached.
     if (!result.ok) {
       const wire = emaErrorToWire(result.error);
       return this.createErrorResponse(
         wire.code,
-        { description: wire.message, headers: NO_CACHE_HEADERS },
+        { description: wire.message },
         { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
       );
     }
 
+    // RFC 6749 §5.1 — responses containing tokens must not be cached.
     return new Response(JSON.stringify(result.value), {
       headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2908,7 +2908,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       const wire = emaErrorToWire(result.error);
       return this.createErrorResponse(
         wire.code,
-        { description: wire.message, headers: { ...NO_CACHE_HEADERS } },
+        { description: wire.message, headers: NO_CACHE_HEADERS },
         { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
       );
     }

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2903,16 +2903,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     const result = await this.runEmaPipeline({ body, clientInfo, env, requestUrl, request, enterpriseOptions });
 
+    // RFC 6749 §5.1 — token endpoint responses must not be cached.
     if (!result.ok) {
       const wire = emaErrorToWire(result.error);
       return this.createErrorResponse(
         wire.code,
-        { description: wire.message },
+        { description: wire.message, headers: NO_CACHE_HEADERS },
         { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
       );
     }
 
-    // RFC 6749 §5.1 — responses containing tokens must not be cached.
     return new Response(JSON.stringify(result.value), {
       headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });
@@ -4048,9 +4048,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
-    // RFC 6749 §5.1 — error responses on the token endpoint expose OAuth
-    // state, so prevent intermediaries from caching them too.
-    const responseHeaders = { ...NO_CACHE_HEADERS, ...(options.headers ?? {}) };
+    const responseHeaders = options.headers ?? {};
 
     // Notify the user of the error and allow them to override the response
     const customErrorResponse = this.options.onError?.({

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2903,16 +2903,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     const result = await this.runEmaPipeline({ body, clientInfo, env, requestUrl, request, enterpriseOptions });
 
-    // RFC 6749 §5.1 — token endpoint responses must not be cached.
     if (!result.ok) {
       const wire = emaErrorToWire(result.error);
       return this.createErrorResponse(
         wire.code,
-        { description: wire.message, headers: NO_CACHE_HEADERS },
+        { description: wire.message },
         { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
       );
     }
 
+    // RFC 6749 §5.1 — responses containing tokens must not be cached.
     return new Response(JSON.stringify(result.value), {
       headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });
@@ -4048,7 +4048,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
-    const responseHeaders = options.headers ?? {};
+    // RFC 6749 §5.1 — error responses on the token endpoint expose OAuth
+    // state, so prevent intermediaries from caching them too.
+    const responseHeaders = { ...NO_CACHE_HEADERS, ...(options.headers ?? {}) };
 
     // Notify the user of the error and allow them to override the response
     const customErrorResponse = this.options.onError?.({

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -4048,7 +4048,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
-    const responseHeaders = { ...(options.headers ?? {}), ...NO_CACHE_HEADERS };
+    const responseHeaders = options.headers ?? {};
 
     // Notify the user of the error and allow them to override the response
     const customErrorResponse = this.options.onError?.({

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -502,9 +502,9 @@ export interface OAuthHelpers {
   /**
    * Completes an authorization request by creating a grant and authorization code
    * @param options - Options specifying the grant details
-   * @returns A Promise resolving to the redirect URL and headers to apply to the redirect response
+   * @returns A Promise resolving to an object containing the redirect URL
    */
-  completeAuthorization(options: CompleteAuthorizationOptions): Promise<CompleteAuthorizationResult>;
+  completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }>;
 
   /**
    * Creates a new OAuth client
@@ -751,21 +751,8 @@ export interface ClientInfo {
 }
 
 /**
- * Result of completing an authorization request
+ * Options for completing an authorization request
  */
-export interface CompleteAuthorizationResult {
-  /**
-   * URL to redirect the user-agent to after authorization.
-   */
-  redirectTo: string;
-
-  /**
-   * Headers that should be applied to the redirect response because it contains
-   * an authorization code or access token.
-   */
-  headers: Record<string, string>;
-}
-
 export interface CompleteAuthorizationOptions {
   /**
    * The original parsed authorization request
@@ -4804,9 +4791,9 @@ class OAuthHelpersImpl implements OAuthHelpers {
    * - For authorization code flow: generating an authorization code
    * - For implicit flow: generating an access token directly
    * @param options - Options specifying the grant details
-   * @returns A Promise resolving to the redirect URL and headers to apply to the redirect response
+   * @returns A Promise resolving to an object containing the redirect URL
    */
-  async completeAuthorization(options: CompleteAuthorizationOptions): Promise<CompleteAuthorizationResult> {
+  async completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }> {
     const { clientId, redirectUri } = options.request;
 
     if (!clientId || !redirectUri) {
@@ -4930,7 +4917,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }
 
-      return { redirectTo: redirectUrl.toString(), headers: { ...NO_CACHE_HEADERS } };
+      return { redirectTo: redirectUrl.toString() };
     } else {
       // Standard authorization code flow
       // Generate an authorization code with embedded user and grant IDs
@@ -4981,7 +4968,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }
 
-      return { redirectTo: redirectUrl.toString(), headers: { ...NO_CACHE_HEADERS } };
+      return { redirectTo: redirectUrl.toString() };
     }
   }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -4048,7 +4048,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
-    const responseHeaders = options.headers ?? {};
+    // RFC 6749 §5.2 / OAuth 2.1 §3.2.4 show `Cache-Control: no-store` on error
+    // responses; mirror that so OAuth state isn't cached by intermediaries.
+    // Caller-supplied headers (e.g. Retry-After, WWW-Authenticate) take precedence.
+    const responseHeaders = { ...NO_CACHE_HEADERS, ...(options.headers ?? {}) };
 
     // Notify the user of the error and allow them to override the response
     const customErrorResponse = this.options.onError?.({

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -37,7 +37,7 @@ export type {
 export type { EmaValidationError } from './ema/result';
 
 const PROTECTED_RESOURCE_WELL_KNOWN_PREFIX = '/.well-known/oauth-protected-resource';
-const SENSITIVE_RESPONSE_HEADERS = { 'Cache-Control': 'no-store', Pragma: 'no-cache' } as const;
+const NO_CACHE_HEADERS = { 'Cache-Control': 'no-store', Pragma: 'no-cache' } as const;
 
 // Log CIMD status on module load
 const hasStrictlyPublicFetch =
@@ -2325,7 +2325,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // RFC 6749 §5.1 — responses containing tokens must not be cached.
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
+      headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });
   }
 
@@ -2611,7 +2611,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // RFC 6749 §5.1 — responses containing tokens must not be cached.
     return new Response(JSON.stringify(tokenResponse), {
-      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
+      headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });
   }
 
@@ -2868,7 +2868,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
       // RFC 6749 §5.1 — responses containing tokens must not be cached.
       return new Response(JSON.stringify(tokenResponse), {
-        headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
+        headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
       });
     } catch (error) {
       // Convert OAuth errors into structured `/token` error responses,
@@ -2921,13 +2921,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       const wire = emaErrorToWire(result.error);
       return this.createErrorResponse(
         wire.code,
-        { description: wire.message, headers: { ...SENSITIVE_RESPONSE_HEADERS } },
+        { description: wire.message, headers: { ...NO_CACHE_HEADERS } },
         { category: 'enterprise-managed-authorization', reason: result.error.reason, detail: result.error }
       );
     }
 
     return new Response(JSON.stringify(result.value), {
-      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
+      headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });
   }
 
@@ -3418,7 +3418,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     return new Response(JSON.stringify(response), {
       status: 201,
-      headers: { 'Content-Type': 'application/json', ...SENSITIVE_RESPONSE_HEADERS },
+      headers: { 'Content-Type': 'application/json', ...NO_CACHE_HEADERS },
     });
   }
 
@@ -4061,7 +4061,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
-    const responseHeaders = { ...(options.headers ?? {}), ...SENSITIVE_RESPONSE_HEADERS };
+    const responseHeaders = { ...(options.headers ?? {}), ...NO_CACHE_HEADERS };
 
     // Notify the user of the error and allow them to override the response
     const customErrorResponse = this.options.onError?.({
@@ -4930,7 +4930,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }
 
-      return { redirectTo: redirectUrl.toString(), headers: { ...SENSITIVE_RESPONSE_HEADERS } };
+      return { redirectTo: redirectUrl.toString(), headers: { ...NO_CACHE_HEADERS } };
     } else {
       // Standard authorization code flow
       // Generate an authorization code with embedded user and grant IDs
@@ -4981,7 +4981,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         // Best-effort revocation — new grant is already stored, don't fail the authorization
       }
 
-      return { redirectTo: redirectUrl.toString(), headers: { ...SENSITIVE_RESPONSE_HEADERS } };
+      return { redirectTo: redirectUrl.toString(), headers: { ...NO_CACHE_HEADERS } };
     }
   }
 


### PR DESCRIPTION
## Summary

Supersedes #186, rebuilt on current `main`.

RFC 6749 §5.1 requires `Cache-Control: no-store` (and `Pragma: no-cache`) on **any response containing tokens, credentials, or other sensitive information**, so intermediaries don't cache them. The §5.2 error-response and RFC 7591 DCR examples show the same headers. This applies them to the provider-emitted OAuth responses.

## Scope

Headers added to:

- token endpoint **success** responses — authorization-code, refresh-token, RFC 8693 token-exchange (RFC 6749 §5.1 MUST)
- enterprise-managed authorization (EMA) JWT-bearer **success** response (EMA draft §5.2; shares the single `NO_CACHE_HEADERS` constant)
- dynamic client registration responses (carry `client_secret`)
- **all OAuth error responses** — applied centrally in `createErrorResponse`. RFC 6749 §5.2 has no normative MUST/SHOULD for this, but its error example (and OAuth 2.1 §3.2.4) shows `Cache-Control: no-store`; adding it is harmless defense-in-depth so OAuth state (`error`/`error_description`) isn't cached by any intermediary.

Deliberately **out of scope**:

- metadata discovery / protected-resource metadata (public, normally cacheable)
- the `completeAuthorization()` API and the authorization redirect — left unchanged

## Notes

- Cloudflare's own CDN doesn't cache JSON by default and only caches a narrow set of status codes (200/206/301, 302/303, 404/410), so this is primarily protection against other intermediaries/CDNs.
- `createErrorResponse` merges `{ ...NO_CACHE_HEADERS, ...callerHeaders }`, so caller-supplied headers (e.g. `Retry-After`, `WWW-Authenticate`) still take precedence.

## Implementation

- Single shared `NO_CACHE_HEADERS = { 'Cache-Control': 'no-store', Pragma: 'no-cache' }` constant.
- No public API changes.

## Tests

- New `expectNoCacheHeaders()` assertion helper.
- Coverage for DCR, authorization-code, refresh-token, token-exchange, and error responses.

Verification:

- `npm run typecheck`
- `npm run check` (typecheck + full vitest, 485 tests)
- `npx prettier --check` on touched files
