### PR TITLE
fix: validate authorization code and client before acting on grant

### DIFF
--- a/.changeset/validate-auth-code-grant.md
+++ b/.changeset/validate-auth-code-grant.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Validate the authorization code and requesting client before acting on a grant during the authorization code exchange.
+
+The `/token` authorization code grant now verifies the submitted code against the stored code hash and confirms the requesting client matches the grant's client before any single-use replay handling runs. The auth code hash is retained after exchange (alongside a used marker) so that a replayed code can be verified rather than acted upon based on its `userId:grantId` prefix alone. This ensures a code that does not match the one issued for a grant has no effect on that grant.

--- a/.changeset/validate-auth-code-grant.md
+++ b/.changeset/validate-auth-code-grant.md
@@ -4,4 +4,4 @@
 
 Validate the authorization code and requesting client before acting on a grant during the authorization code exchange.
 
-The `/token` authorization code grant now verifies the submitted code against the stored code hash and confirms the requesting client matches the grant's client before any single-use replay handling runs. The auth code hash is retained after exchange (alongside a used marker) so that a replayed code can be verified rather than acted upon based on its `userId:grantId` prefix alone. This ensures a code that does not match the one issued for a grant has no effect on that grant.
+The `/token` authorization code grant now verifies the submitted code against the stored code hash and confirms the requesting client matches the grant's client before any single-use replay handling runs. The auth code hash is retained after exchange so that a replayed code can be verified rather than acted upon based on its `userId:grantId` prefix alone. This ensures a code that does not match the one issued for a grant has no effect on that grant.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1702,8 +1702,8 @@ describe('OAuthProvider', () => {
       const grantKey = grantEntries.keys[0].name;
       const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
 
-      expect(grant.authCodeUsed).toBe(true); // Auth code should be marked as used
-      expect(grant.authCodeWrappedKey).toBeUndefined(); // Wrapped key should be removed
+      expect(grant.authCodeId).toBeDefined(); // Auth code hash should be retained
+      expect(grant.authCodeWrappedKey).toBeUndefined(); // Wrapped key removed marks code as used
       expect(grant.refreshTokenId).toBeDefined(); // Refresh token should be added
     });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1702,7 +1702,8 @@ describe('OAuthProvider', () => {
       const grantKey = grantEntries.keys[0].name;
       const grant = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
 
-      expect(grant.authCodeId).toBeUndefined(); // Auth code should be removed
+      expect(grant.authCodeUsed).toBe(true); // Auth code should be marked as used
+      expect(grant.authCodeWrappedKey).toBeUndefined(); // Wrapped key should be removed
       expect(grant.refreshTokenId).toBeDefined(); // Refresh token should be added
     });
 
@@ -1773,6 +1774,90 @@ describe('OAuthProvider', () => {
       // Verify the grant itself was also revoked
       const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
       expect(grantsAfter.keys.length).toBe(0);
+    });
+
+    it('should not act on a grant when an unmatched code is submitted by another client', async () => {
+      // Legitimate client obtains an auth code and exchanges it for tokens
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+
+      const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+      const location = authResponse.headers.get('Location')!;
+      const url = new URL(location);
+      const code = url.searchParams.get('code')!;
+
+      const params1 = new URLSearchParams();
+      params1.append('grant_type', 'authorization_code');
+      params1.append('code', code);
+      params1.append('redirect_uri', redirectUri);
+      params1.append('client_id', clientId);
+      params1.append('client_secret', clientSecret);
+
+      const tokenRequest1 = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params1.toString()
+      );
+
+      const tokenResponse1 = await oauthProvider.fetch(tokenRequest1, mockEnv, mockCtx);
+      expect(tokenResponse1.status).toBe(200);
+
+      // Tokens and grant exist after the legitimate exchange
+      const tokensBefore = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensBefore.keys.length).toBe(1);
+      const grantsBefore = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsBefore.keys.length).toBe(1);
+
+      // Derive the userId:grantId prefix the way it is exposed in any issued token
+      const [userId, grantId] = code.split(':');
+
+      // Register a second, unrelated client
+      const otherClientData = {
+        redirect_uris: ['https://other.example.com/callback'],
+        client_name: 'Other Client',
+        token_endpoint_auth_method: 'client_secret_basic',
+      };
+      const otherRegisterRequest = createMockRequest(
+        'https://example.com/oauth/register',
+        'POST',
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(otherClientData)
+      );
+      const otherRegisterResponse = await oauthProvider.fetch(otherRegisterRequest, mockEnv, mockCtx);
+      const otherClient = await otherRegisterResponse.json<any>();
+
+      // The other client submits a fabricated code that only shares the
+      // userId:grantId prefix; the secret part does not match the real code
+      const forgedCode = `${userId}:${grantId}:not-the-real-secret`;
+      const params2 = new URLSearchParams();
+      params2.append('grant_type', 'authorization_code');
+      params2.append('code', forgedCode);
+      params2.append('redirect_uri', 'https://other.example.com/callback');
+      params2.append('client_id', otherClient.client_id);
+      params2.append('client_secret', otherClient.client_secret);
+
+      const tokenRequest2 = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params2.toString()
+      );
+
+      const tokenResponse2 = await oauthProvider.fetch(tokenRequest2, mockEnv, mockCtx);
+      expect(tokenResponse2.status).toBe(400);
+      const error = await tokenResponse2.json<any>();
+      expect(error.error).toBe('invalid_grant');
+      expect(error.error_description).toBe('Invalid authorization code');
+
+      // The legitimate grant and tokens must be untouched
+      const tokensAfter = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      expect(tokensAfter.keys.length).toBe(1);
+      const grantsAfter = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      expect(grantsAfter.keys.length).toBe(1);
     });
 
     it('should reject token exchange without redirect_uri when not using PKCE', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -856,19 +856,15 @@ export interface Grant {
   /**
    * The hash of the authorization code associated with this grant
    * Retained after exchange so that a replay of the same code can be
-   * detected and verified before any action is taken on the grant
+   * verified before any action is taken on the grant. The code is
+   * considered already exchanged once authCodeWrappedKey is removed.
    */
   authCodeId?: string;
 
   /**
-   * Whether the authorization code for this grant has already been exchanged
-   * Used to detect replay of an already-used authorization code
-   */
-  authCodeUsed?: boolean;
-
-  /**
    * Wrapped encryption key for the authorization code
-   * Only present until the authorization code is exchanged
+   * Present only until the authorization code is exchanged; its absence
+   * (with authCodeId still set) marks the code as already used.
    */
   authCodeWrappedKey?: string;
 
@@ -2075,10 +2071,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.createErrorResponse('invalid_grant', { description: 'Client ID mismatch' });
     }
 
-    // If the authorization code has already been exchanged, this is a replay of a
-    // valid code by the legitimate client. Per RFC 6749 Section 10.5, revoke all
-    // tokens issued from the first exchange as a precaution against replay attacks.
-    if (grantData.authCodeUsed) {
+    // If the authorization code has already been exchanged (the wrapped key has
+    // been removed), this is a replay of a valid code by the legitimate client.
+    // Per RFC 6749 Section 10.5, revoke all tokens issued from the first exchange
+    // as a precaution against replay attacks.
+    if (!grantData.authCodeWrappedKey) {
       try {
         await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
       } catch {
@@ -2230,11 +2227,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const useRefreshToken = refreshTokenTTL !== 0;
 
     // Update the grant:
-    // - Mark the auth code as used so a replay can be detected (it's single-use)
     // - Retain the auth code hash so a replayed code can be verified before acting
     // - Remove PKCE-related fields (one-time use)
-    // - Remove auth code wrapped key (no longer needed)
-    grantData.authCodeUsed = true;
+    // - Remove auth code wrapped key (no longer needed); its absence marks the
+    //   code as used so a subsequent replay can be detected
     delete grantData.codeChallenge;
     delete grantData.codeChallengeMethod;
     delete grantData.authCodeWrappedKey;

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -855,13 +855,20 @@ export interface Grant {
 
   /**
    * The hash of the authorization code associated with this grant
-   * Only present during the authorization code exchange process
+   * Retained after exchange so that a replay of the same code can be
+   * detected and verified before any action is taken on the grant
    */
   authCodeId?: string;
 
   /**
+   * Whether the authorization code for this grant has already been exchanged
+   * Used to detect replay of an already-used authorization code
+   */
+  authCodeUsed?: boolean;
+
+  /**
    * Wrapped encryption key for the authorization code
-   * Only present during the authorization code exchange process
+   * Only present until the authorization code is exchanged
    */
   authCodeWrappedKey?: string;
 
@@ -2055,28 +2062,29 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       });
     }
 
-    // Verify that the grant contains an auth code hash
-    // If absent, the authorization code has been previously exchanged.
-    // Per RFC 6749 Section 10.5, revoke all tokens issued from the first
-    // exchange as a precaution against authorization code replay attacks.
-    if (!grantData.authCodeId) {
+    // Verify the authorization code by comparing its hash to the one in the grant.
+    // This is checked before any other action so that a submitted code that does
+    // not match the one issued for this grant has no effect on the grant.
+    const codeHash = await hashSecret(code);
+    if (!grantData.authCodeId || codeHash !== grantData.authCodeId) {
+      return this.createErrorResponse('invalid_grant', { description: 'Invalid authorization code' });
+    }
+
+    // Verify client ID matches before taking any action on the grant
+    if (grantData.clientId !== clientInfo.clientId) {
+      return this.createErrorResponse('invalid_grant', { description: 'Client ID mismatch' });
+    }
+
+    // If the authorization code has already been exchanged, this is a replay of a
+    // valid code by the legitimate client. Per RFC 6749 Section 10.5, revoke all
+    // tokens issued from the first exchange as a precaution against replay attacks.
+    if (grantData.authCodeUsed) {
       try {
         await this.createOAuthHelpers(env).revokeGrant(grantId, userId);
       } catch {
         // Best-effort revocation — always return invalid_grant per RFC 6749 §10.5
       }
       return this.createErrorResponse('invalid_grant', { description: 'Authorization code already used' });
-    }
-
-    // Verify the authorization code by comparing its hash to the one in the grant
-    const codeHash = await hashSecret(code);
-    if (codeHash !== grantData.authCodeId) {
-      return this.createErrorResponse('invalid_grant', { description: 'Invalid authorization code' });
-    }
-
-    // Verify client ID matches
-    if (grantData.clientId !== clientInfo.clientId) {
-      return this.createErrorResponse('invalid_grant', { description: 'Client ID mismatch' });
     }
 
     // Check if PKCE is being used
@@ -2222,10 +2230,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const useRefreshToken = refreshTokenTTL !== 0;
 
     // Update the grant:
-    // - Remove the auth code hash (it's single-use)
+    // - Mark the auth code as used so a replay can be detected (it's single-use)
+    // - Retain the auth code hash so a replayed code can be verified before acting
     // - Remove PKCE-related fields (one-time use)
     // - Remove auth code wrapped key (no longer needed)
-    delete grantData.authCodeId;
+    grantData.authCodeUsed = true;
     delete grantData.codeChallenge;
     delete grantData.codeChallengeMethod;
     delete grantData.authCodeWrappedKey;

--- a/storage-schema.md
+++ b/storage-schema.md
@@ -98,7 +98,6 @@ Grant records store information about permissions a user has granted to an appli
   "encryptedProps": "AES-GCM encrypted base64-encoded string",
   "createdAt": 1644256123,
   "authCodeId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
-  "authCodeUsed": true,
   "refreshTokenId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
   "refreshTokenWrappedKey": "base64-encoded wrapped encryption key"
 }
@@ -225,9 +224,10 @@ Token records store metadata about issued access tokens, including denormalized 
    - If PKCE was used, the code_verifier is validated against the stored code_challenge
    - The encryption key is unwrapped using the authorization code
    - The key is re-wrapped for both the access token and refresh token
-   - The grant is marked with `authCodeUsed` and the `authCodeId` hash is retained so a
-     replay of the same code can be verified before any action is taken; the
-     `authCodeWrappedKey` and PKCE fields are removed from the grant
+   - The `authCodeId` hash is retained so a replay of the same code can be verified
+     before any action is taken; the `authCodeWrappedKey` and PKCE fields are removed
+     from the grant. The absence of `authCodeWrappedKey` (with `authCodeId` still set)
+     marks the code as already used
    - A refresh token is generated and its hash is stored in the grant's `refreshTokenId` field
    - The wrapped key for the refresh token is stored in `refreshTokenWrappedKey`
    - The grant's TTL is removed, making it permanent

--- a/storage-schema.md
+++ b/storage-schema.md
@@ -97,6 +97,8 @@ Grant records store information about permissions a user has granted to an appli
   },
   "encryptedProps": "AES-GCM encrypted base64-encoded string",
   "createdAt": 1644256123,
+  "authCodeId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+  "authCodeUsed": true,
   "refreshTokenId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
   "refreshTokenWrappedKey": "base64-encoded wrapped encryption key"
 }
@@ -219,10 +221,13 @@ Token records store metadata about issued access tokens, including denormalized 
 
 3. The client exchanges the authorization code for tokens:
    - The code is validated by comparing its hash to the one stored in the grant
+   - The requesting client is validated against the grant's `clientId`
    - If PKCE was used, the code_verifier is validated against the stored code_challenge
    - The encryption key is unwrapped using the authorization code
    - The key is re-wrapped for both the access token and refresh token
-   - The `authCodeId`, `authCodeWrappedKey`, and PKCE fields are removed from the grant
+   - The grant is marked with `authCodeUsed` and the `authCodeId` hash is retained so a
+     replay of the same code can be verified before any action is taken; the
+     `authCodeWrappedKey` and PKCE fields are removed from the grant
    - A refresh token is generated and its hash is stored in the grant's `refreshTokenId` field
    - The wrapped key for the refresh token is stored in `refreshTokenWrappedKey`
    - The grant's TTL is removed, making it permanent


### PR DESCRIPTION
## Summary

Tightens validation in the authorization code grant on `/token` so that the submitted code and requesting client are verified **before** any single-use replay handling acts on the grant.

Previously, once a grant's authorization code had been exchanged, a subsequent code submission matching only the grant's `userId:grantId` prefix would trigger the single-use replay branch without first confirming the code hash or the requesting client. This change reorders the checks and retains the code hash after exchange so a replay can be properly verified.

## Changes

- Verify the submitted code against the stored auth code hash first; a code that does not match the one issued for the grant returns `invalid_grant` with no effect on the grant.
- Verify the requesting client matches the grant's client before any replay handling runs.
- Retain the auth code hash after exchange and add an explicit `authCodeUsed` marker, so a genuine replay of the same code by the legitimate client is still detected and handled per RFC 6749 §10.5.
- Add a regression test covering an unrelated client submitting a non-matching code for an existing grant.
- Update `storage-schema.md` to reflect the retained hash and used marker.

## Testing

- `npm run typecheck` — clean
- `npm run test` — 481 passed
