### PR TITLE
fix: simplify DCR callback rejection shape

### DIFF
--- a/.changeset/dcr-callback-reject-shape.md
+++ b/.changeset/dcr-callback-reject-shape.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Simplify `clientRegistrationCallback` to be an allow-or-reject policy hook. Returning `undefined` allows registration; returning an object rejects registration with optional `code`, `description`, and `status`. Metadata override behavior has been removed.

--- a/.changeset/dcr-callback.md
+++ b/.changeset/dcr-callback.md
@@ -2,9 +2,9 @@
 '@cloudflare/workers-oauth-provider': minor
 ---
 
-Add `clientRegistrationCallback` for validating or rejecting dynamic client registrations before storage. Follows the same pattern as `tokenExchangeCallback`. Closes #162.
+Add `clientRegistrationCallback` for validating or rejecting dynamic client registrations before storage. Return `undefined`/nothing to allow registration, or return an object to reject it. Closes #162.
 
-- Default rejection error follows RFC 7591 §3.2.2 (`invalid_client_metadata` / 400). Callbacks rejecting for non-metadata reasons (missing IAT, untrusted origin) should override `rejectCode` and `rejectStatus` explicitly.
+- Default rejection error follows RFC 7591 §3.2.2 (`invalid_client_metadata` / 400). Callbacks rejecting for non-metadata reasons (missing IAT, untrusted origin) should override `code` and `status` explicitly.
 - The `request` passed to the callback is cloned before the library reads the body, so callbacks may consume the body (e.g. to verify a signature over the raw bytes).
 - Callback exceptions are caught and surfaced as `500 server_error`.
 - `software_statement` (RFC 7591 §3.1.1) JWTs are not processed by the library; callbacks wishing to honor them must verify the JWT and apply its claims themselves.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1040,7 +1040,7 @@ describe('OAuthProvider', () => {
       );
     });
 
-    it('should reject registration with RFC 7591 §3.2.2 defaults when callback returns reject: true', async () => {
+    it('should reject registration with RFC 7591 §3.2.2 defaults when callback returns an object', async () => {
       const provider = new OAuthProvider({
         apiRoute: '/api/',
         apiHandler: TestApiHandler,
@@ -1049,8 +1049,7 @@ describe('OAuthProvider', () => {
         tokenEndpoint: '/oauth/token',
         clientRegistrationEndpoint: '/oauth/register',
         clientRegistrationCallback: () => ({
-          reject: true,
-          rejectDescription: 'Registration requires approval',
+          description: 'Registration requires approval',
         }),
       });
 
@@ -1089,10 +1088,9 @@ describe('OAuthProvider', () => {
         tokenEndpoint: '/oauth/token',
         clientRegistrationEndpoint: '/oauth/register',
         clientRegistrationCallback: () => ({
-          reject: true,
-          rejectCode: 'invalid_client_metadata',
-          rejectDescription: 'client_name is required by policy',
-          rejectStatus: 400,
+          code: 'invalid_client_metadata',
+          description: 'client_name is required by policy',
+          status: 400,
         }),
       });
 
@@ -1114,90 +1112,6 @@ describe('OAuthProvider', () => {
       const body = await response.json<any>();
       expect(body.error).toBe('invalid_client_metadata');
       expect(body.error_description).toBe('client_name is required by policy');
-    });
-
-    it('should apply clientMetadataOverrides before storing', async () => {
-      const provider = new OAuthProvider({
-        apiRoute: '/api/',
-        apiHandler: TestApiHandler,
-        defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        clientRegistrationCallback: () => ({
-          clientMetadataOverrides: {
-            clientName: 'Overridden Name',
-            contacts: ['admin@example.com'],
-          },
-        }),
-      });
-
-      const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Original Name',
-        token_endpoint_auth_method: 'client_secret_basic',
-      };
-
-      const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
-      );
-
-      const response = await provider.fetch(request, mockEnv, mockCtx);
-
-      expect(response.status).toBe(201);
-      const registeredClient = await response.json<any>();
-
-      // Response body must reflect overrides — clients depend on this per
-      // RFC 7591 §3.2.1 to determine if registration is sufficient for use.
-      expect(registeredClient.client_name).toBe('Overridden Name');
-      expect(registeredClient.contacts).toEqual(['admin@example.com']);
-
-      // Verify overrides were also applied in KV
-      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
-      expect(savedClient.clientName).toBe('Overridden Name');
-      expect(savedClient.contacts).toEqual(['admin@example.com']);
-    });
-
-    it('should reject invalid URI overrides before storing', async () => {
-      const provider = new OAuthProvider({
-        apiRoute: '/api/',
-        apiHandler: TestApiHandler,
-        defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        clientRegistrationEndpoint: '/oauth/register',
-        clientRegistrationCallback: () => ({
-          clientMetadataOverrides: {
-            logoUri: 'javascript:alert(1)',
-          },
-        }),
-      });
-
-      const clientData = {
-        redirect_uris: ['https://client.example.com/callback'],
-        client_name: 'Original Name',
-        token_endpoint_auth_method: 'client_secret_basic',
-      };
-
-      const request = createMockRequest(
-        'https://example.com/oauth/register',
-        'POST',
-        { 'Content-Type': 'application/json' },
-        JSON.stringify(clientData)
-      );
-
-      const response = await provider.fetch(request, mockEnv, mockCtx);
-
-      expect(response.status).toBe(400);
-      const body = await response.json<any>();
-      expect(body.error).toBe('invalid_client_metadata');
-      expect(body.error_description).toBe('Invalid logoUri: must be an absolute http: or https: URL');
-
-      const keys = await mockEnv.OAUTH_KV.list({ prefix: 'client:' });
-      expect(keys.keys.length).toBe(0);
     });
 
     it('should return 500 server_error when callback throws', async () => {
@@ -1288,10 +1202,9 @@ describe('OAuthProvider', () => {
           const authHeader = request.headers.get('Authorization');
           if (!authHeader || authHeader !== 'Bearer valid-initial-token') {
             return {
-              reject: true,
-              rejectCode: 'invalid_token',
-              rejectStatus: 401,
-              rejectDescription: 'Valid initial access token required',
+              code: 'invalid_token',
+              status: 401,
+              description: 'Valid initial access token required',
             };
           }
         },

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -230,33 +230,26 @@ export interface ClientRegistrationCallbackOptions {
 
 /**
  * Result of the client registration callback.
+ *
+ * Return `undefined`/nothing to allow registration. Return an object to reject
+ * registration. By default, rejection follows RFC 7591 §3.2.2:
+ * `invalid_client_metadata` with HTTP 400.
  */
 export interface ClientRegistrationCallbackResult {
   /**
-   * Override non-security-critical client metadata fields (allowlist).
-   * Security fields (clientId, clientSecret, redirectUris, tokenEndpointAuthMethod,
-   * registrationDate, grantTypes, responseTypes) cannot be overridden. Override
-   * values are revalidated before storage.
+   * OAuth error code when rejecting. Defaults to `invalid_client_metadata`.
+   * For non-metadata rejections (e.g. missing initial access token, untrusted
+   * origin), set this to a more specific code such as `access_denied` or
+   * `invalid_token`.
    */
-  clientMetadataOverrides?: Partial<
-    Pick<ClientInfo, 'clientName' | 'logoUri' | 'clientUri' | 'policyUri' | 'tosUri' | 'jwksUri' | 'contacts'>
-  >;
-  /** Set true to reject the registration. */
-  reject?: boolean;
-  /**
-   * OAuth error code when rejecting. Defaults to `invalid_client_metadata`
-   * (RFC 7591 §3.2.2). For non-metadata rejections (e.g. missing initial access
-   * token, untrusted origin), set this to a more specific code such as
-   * `access_denied` or `invalid_token`.
-   */
-  rejectCode?: string;
+  code?: string;
   /** Error description when rejecting. */
-  rejectDescription?: string;
+  description?: string;
   /**
-   * HTTP status code when rejecting. Defaults to 400 (RFC 7591 §3.2.2). Override
-   * for auth-style failures (e.g. 401 for missing IAT, 403 for policy denial).
+   * HTTP status code when rejecting. Defaults to 400. Override for auth-style
+   * failures (e.g. 401 for missing IAT, 403 for policy denial).
    */
-  rejectStatus?: number;
+  status?: number;
 }
 
 /**
@@ -431,8 +424,8 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   disallowPublicClientRegistration?: boolean;
 
   /**
-   * Called during DCR (RFC 7591) before the client is stored. Return `{ reject: true }` to
-   * deny, `{ clientMetadataOverrides }` to modify, or void to allow.
+   * Called during DCR (RFC 7591) before the client is stored. Return void/undefined
+   * to allow registration, or return an object to reject it.
    */
   clientRegistrationCallback?: (
     options: ClientRegistrationCallbackOptions
@@ -3471,46 +3464,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         });
       }
 
-      if (callbackResult?.reject) {
+      if (callbackResult !== undefined) {
         // Default to RFC 7591 §3.2.2 — `invalid_client_metadata` / 400. Callbacks
         // rejecting for non-metadata reasons (missing IAT, policy denial) should
-        // override `rejectCode` / `rejectStatus` explicitly.
-        return this.createErrorResponse(callbackResult.rejectCode || 'invalid_client_metadata', {
-          description: callbackResult.rejectDescription || 'Client registration denied',
-          statusCode: callbackResult.rejectStatus ?? 400,
+        // override `code` / `status` explicitly.
+        return this.createErrorResponse(callbackResult.code || 'invalid_client_metadata', {
+          description: callbackResult.description || 'Client registration denied',
+          statusCode: callbackResult.status ?? 400,
         });
-      }
-
-      if (callbackResult?.clientMetadataOverrides) {
-        const overrides = callbackResult.clientMetadataOverrides;
-        try {
-          // Runtime allowlist and validation (defense in depth — matches the Pick<> type constraint).
-          if ('clientName' in overrides) {
-            clientInfo.clientName = OAuthProviderImpl.validateStringField(overrides.clientName, 'clientName');
-          }
-          if ('logoUri' in overrides) {
-            clientInfo.logoUri = OAuthProviderImpl.validateOptionalUriField(overrides.logoUri, 'logoUri');
-          }
-          if ('clientUri' in overrides) {
-            clientInfo.clientUri = OAuthProviderImpl.validateOptionalUriField(overrides.clientUri, 'clientUri');
-          }
-          if ('policyUri' in overrides) {
-            clientInfo.policyUri = OAuthProviderImpl.validateOptionalUriField(overrides.policyUri, 'policyUri');
-          }
-          if ('tosUri' in overrides) {
-            clientInfo.tosUri = OAuthProviderImpl.validateOptionalUriField(overrides.tosUri, 'tosUri');
-          }
-          if ('jwksUri' in overrides) {
-            clientInfo.jwksUri = OAuthProviderImpl.validateOptionalUriField(overrides.jwksUri, 'jwksUri');
-          }
-          if ('contacts' in overrides) {
-            clientInfo.contacts = OAuthProviderImpl.validateStringArray(overrides.contacts, 'contacts');
-          }
-        } catch (error) {
-          return this.createErrorResponse('invalid_client_metadata', {
-            description: error instanceof Error ? error.message : 'Invalid client metadata override',
-          });
-        }
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #184. Simplifies `clientRegistrationCallback` into an allow-or-reject policy hook:

- return `undefined` / nothing to allow registration
- return `{ code?, description?, status? }` to reject registration
- removes metadata override behavior entirely
- updates the existing DCR callback changeset wording
- adds a minor changeset for the API shape change

This better matches the intended use case: inspect client-supplied DCR metadata/request details (redirect URIs, auth headers, tenant policy, etc.) and decide whether to allow registration.

## Verification

- `npm run check` ✅ — 496 tests passing
- `npm run build` ✅
- `npx prettier --check src/oauth-provider.ts __tests__/oauth-provider.test.ts .changeset/dcr-callback.md .changeset/dcr-callback-reject-shape.md` ✅

## Note

Do not merge without Matt's explicit approval.
