### PR TITLE
fix: never write a sub-60s expiration to KV (avoid uncaught 500s)

### DIFF
--- a/.changeset/near-expiry-refresh-kv-400.md
+++ b/.changeset/near-expiry-refresh-kv-400.md
@@ -13,7 +13,7 @@ slow callback (e.g. an upstream network refresh) that pushes the grant under the
 threshold mid-request is rejected cleanly instead of crashing when writing the rotated
 grant or the new access token (whose TTL is clamped to the grant's remaining lifetime).
 As defense-in-depth, `saveGrantWithTTL` also clamps the absolute expiration to KV's
-60-second minimum.
+60-second minimum (plus a small margin so writes stay storable under clock skew / write latency).
 
 The token exchange grant (RFC 8693) shared the same root cause: the issued token's TTL is
 clamped to the subject token's remaining lifetime, so a subject token in its final <60s (or

--- a/.changeset/near-expiry-refresh-kv-400.md
+++ b/.changeset/near-expiry-refresh-kv-400.md
@@ -20,3 +20,13 @@ clamped to the subject token's remaining lifetime, so a subject token in its fin
 a `expires_in`/`accessTokenTTL` below 60) produced an unstorable token. The exchange now
 rejects a subject token with under 60s remaining (`invalid_grant`) and a requested lifetime
 below 60s (`invalid_request`) instead of crashing.
+
+More broadly, any access token lifetime below KV's 60-second minimum is now caught instead of
+crashing with an opaque KV 400:
+
+- `accessTokenTTL` is validated at `OAuthProvider` construction (must be an integer of at
+  least 60 seconds).
+- A `tokenExchangeCallback` returning an `accessTokenTTL` below 60 on the authorization code
+  or refresh grant is rejected with `invalid_request`.
+- The enterprise-managed authorization (ID-JAG) grant rejects a mapper-supplied access token
+  TTL below 60 (`invalid_grant`, "Invalid access token TTL").

--- a/.changeset/near-expiry-refresh-kv-400.md
+++ b/.changeset/near-expiry-refresh-kv-400.md
@@ -1,0 +1,10 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Fix uncaught 500 when refreshing a near-expiry grant. A refresh arriving in the final
+<60s of a grant's life previously passed the expiry check and then crashed with
+"KV PUT failed: 400 Invalid expiration" because Cloudflare KV rejects absolute
+expirations less than 60 seconds in the future. Such grants are now treated as expired
+(returning `invalid_grant`), and `saveGrantWithTTL` clamps the absolute expiration to
+KV's 60-second minimum as defense-in-depth.

--- a/.changeset/near-expiry-refresh-kv-400.md
+++ b/.changeset/near-expiry-refresh-kv-400.md
@@ -6,5 +6,11 @@ Fix uncaught 500 when refreshing a near-expiry grant. A refresh arriving in the 
 <60s of a grant's life previously passed the expiry check and then crashed with
 "KV PUT failed: 400 Invalid expiration" because Cloudflare KV rejects absolute
 expirations less than 60 seconds in the future. Such grants are now treated as expired
-(returning `invalid_grant`), and `saveGrantWithTTL` clamps the absolute expiration to
-KV's 60-second minimum as defense-in-depth.
+(returning `invalid_grant`).
+
+The refresh handler also re-checks expiry after the `tokenExchangeCallback` runs, so a
+slow callback (e.g. an upstream network refresh) that pushes the grant under the 60-second
+threshold mid-request is rejected cleanly instead of crashing when writing the rotated
+grant or the new access token (whose TTL is clamped to the grant's remaining lifetime).
+As defense-in-depth, `saveGrantWithTTL` also clamps the absolute expiration to KV's
+60-second minimum.

--- a/.changeset/near-expiry-refresh-kv-400.md
+++ b/.changeset/near-expiry-refresh-kv-400.md
@@ -14,3 +14,9 @@ threshold mid-request is rejected cleanly instead of crashing when writing the r
 grant or the new access token (whose TTL is clamped to the grant's remaining lifetime).
 As defense-in-depth, `saveGrantWithTTL` also clamps the absolute expiration to KV's
 60-second minimum.
+
+The token exchange grant (RFC 8693) shared the same root cause: the issued token's TTL is
+clamped to the subject token's remaining lifetime, so a subject token in its final <60s (or
+a `expires_in`/`accessTokenTTL` below 60) produced an unstorable token. The exchange now
+rejects a subject token with under 60s remaining (`invalid_grant`) and a requested lifetime
+below 60s (`invalid_request`) instead of crashing.

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -430,6 +430,7 @@ describe('computeEmaAccessTokenTTL', () => {
       assertionExp: 2_000_000_000,
       mapperTtl: undefined,
       now: 1_999_999_700,
+      minTtlSeconds: 60,
     });
     // Assertion has 300s left but the issued access token follows the AS's
     // configured TTL (3600s) — the assertion is a one-shot grant, not a
@@ -443,6 +444,7 @@ describe('computeEmaAccessTokenTTL', () => {
       assertionExp: 2_000_000_000,
       mapperTtl: 86_400,
       now: 1_999_999_700,
+      minTtlSeconds: 60,
     });
     expect(r).toMatchObject({ ok: true, value: 86_400 });
   });
@@ -453,8 +455,20 @@ describe('computeEmaAccessTokenTTL', () => {
       assertionExp: 1_999_999_700,
       mapperTtl: undefined,
       now: 1_999_999_800,
+      minTtlSeconds: 60,
     });
     expect(r).toMatchObject({ ok: false, error: { reason: 'assertion_expired_after_processing' } });
+  });
+
+  it('rejects a mapper-supplied TTL below the storable minimum', () => {
+    const r = computeEmaAccessTokenTTL({
+      configuredDefaultSeconds: 3600,
+      assertionExp: 2_000_000_000,
+      mapperTtl: 30, // below KV's 60s minimum
+      now: 1_999_999_700,
+      minTtlSeconds: 60,
+    });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_mapped_ttl' } });
   });
 });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -4605,6 +4605,83 @@ describe('OAuthProvider', () => {
       expect(error.error_description).toBe('Refresh token has expired');
     });
 
+    it('should reject (not crash) when a slow tokenExchangeCallback pushes the grant under 60s remaining', async () => {
+      // Companion to the near-expiry regression test: the expiry check runs before the
+      // tokenExchangeCallback, but the access token (and grant) are written after it. A
+      // slow callback (e.g. an upstream network refresh) can drop the grant under KV's
+      // 60s minimum while the callback runs, which would otherwise produce a KV 400 on
+      // the write. It should resolve to a clean invalid_grant instead.
+      const providerWithSlowCallback = new OAuthProvider({
+        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        accessTokenTTL: 3600,
+        refreshTokenTTL: 7200,
+        tokenExchangeCallback: async (options) => {
+          if (options.grantType === 'refresh_token') {
+            // Simulate a slow upstream refresh that elapses real time.
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+          }
+          return {};
+        },
+      });
+
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+      const authResponse = await providerWithSlowCallback.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+      const tokens = await (await providerWithSlowCallback.fetch(tokenRequest, mockEnv, mockCtx)).json<any>();
+      const refreshToken = tokens.refresh_token;
+
+      // Place the grant just past the 60s threshold so it passes the pre-callback check,
+      // then the 2s callback pushes it under 60s before the writes happen.
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantKey = grantEntries.keys[0].name;
+      const grantData = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      grantData.expiresAt = Math.floor(Date.now() / 1000) + 61;
+      await mockEnv.OAUTH_KV.put(grantKey, JSON.stringify(grantData));
+
+      const refreshParams = new URLSearchParams();
+      refreshParams.append('grant_type', 'refresh_token');
+      refreshParams.append('refresh_token', refreshToken);
+      refreshParams.append('client_id', clientId);
+      refreshParams.append('client_secret', clientSecret);
+      const refreshRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        refreshParams.toString()
+      );
+
+      const refreshResponse = await providerWithSlowCallback.fetch(refreshRequest, mockEnv, mockCtx);
+
+      // Either the pre- or post-callback check may fire depending on timing; both must
+      // produce a clean 400 invalid_grant rather than a 500 from a rejected KV write.
+      expect(refreshResponse.status).toBe(400);
+      const error = await refreshResponse.json<any>();
+      expect(error.error).toBe('invalid_grant');
+      expect(error.error_description).toBe('Refresh token has expired');
+    });
+
     it('should allow overriding refresh token TTL via callback', async () => {
       // Create provider with callback that sets custom TTL
       const providerWithCallback = new OAuthProvider({

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -11,6 +11,22 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 class MockKV {
   private storage: Map<string, { value: any; expiration?: number }> = new Map();
 
+  // Offset (ms) added to the wall clock. Lets tests deterministically advance time to
+  // exercise TTL expiry without real `setTimeout` sleeps. Defaults to 0 (real time).
+  private timeOffsetMs = 0;
+
+  private now(): number {
+    return Date.now() + this.timeOffsetMs;
+  }
+
+  /**
+   * Advance the mock clock by `ms` so TTL'd entries expire deterministically.
+   * Mirrors how real KV would drop an entry once its expiration passes.
+   */
+  advanceTime(ms: number): void {
+    this.timeOffsetMs += ms;
+  }
+
   async put(
     key: string,
     value: string | ArrayBuffer,
@@ -18,12 +34,19 @@ class MockKV {
   ): Promise<void> {
     let expirationTime: number | undefined = undefined;
 
+    // Mirror Cloudflare KV's validation: both relative (`expirationTtl`) and absolute
+    // (`expiration`) expirations must be at least 60 seconds in the future, otherwise the
+    // PUT is rejected with a 400. This is what makes near-expiry/sub-60s token writes
+    // reproduce as failures here exactly as they would in production.
     if (options?.expirationTtl) {
-      expirationTime = Date.now() + options.expirationTtl * 1000;
+      if (options.expirationTtl < 60) {
+        throw new Error(
+          `KV PUT failed: 400 Invalid expiration_ttl of ${options.expirationTtl}. Expiration TTL's must be at least 60 seconds.`
+        );
+      }
+      expirationTime = this.now() + options.expirationTtl * 1000;
     } else if (options?.expiration) {
-      // Mirror Cloudflare KV's validation for absolute expirations: they must be at
-      // least 60 seconds in the future, otherwise the PUT is rejected with a 400.
-      const minExpiration = Math.floor(Date.now() / 1000) + 60;
+      const minExpiration = Math.floor(this.now() / 1000) + 60;
       if (options.expiration < minExpiration) {
         throw new Error(
           `KV PUT failed: 400 Invalid expiration of ${options.expiration}. Expiration times must be at least 60 seconds in the future.`
@@ -42,7 +65,7 @@ class MockKV {
       return null;
     }
 
-    if (item.expiration && item.expiration < Date.now()) {
+    if (item.expiration && item.expiration < this.now()) {
       this.storage.delete(key);
       return null;
     }
@@ -70,7 +93,7 @@ class MockKV {
     for (const key of this.storage.keys()) {
       if (key.startsWith(prefix)) {
         const item = this.storage.get(key);
-        if (item && (!item.expiration || item.expiration >= Date.now())) {
+        if (item && (!item.expiration || item.expiration >= this.now())) {
           allKeys.push(key);
         }
       }
@@ -91,6 +114,7 @@ class MockKV {
 
   clear() {
     this.storage.clear();
+    this.timeOffsetMs = 0;
   }
 }
 
@@ -11619,7 +11643,9 @@ describe('OAuthProvider', () => {
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         clientRegistrationEndpoint: '/oauth/register',
-        clientRegistrationTTL: 1, // 1 second
+        // Cloudflare KV (and MockKV) reject TTLs under 60s, so use the minimum and advance
+        // the mock clock past it to deterministically exercise auto-expiry without sleeping.
+        clientRegistrationTTL: 60,
       });
 
       const request = createMockRequest(
@@ -11638,8 +11664,8 @@ describe('OAuthProvider', () => {
       // Client should exist immediately
       expect(await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' })).not.toBeNull();
 
-      // Wait for expiry
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      // Advance past the TTL
+      mockEnv.OAUTH_KV.advanceTime(61_000);
 
       // Client should be auto-deleted by KV TTL
       expect(await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' })).toBeNull();
@@ -11737,7 +11763,8 @@ describe('OAuthProvider', () => {
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         clientRegistrationEndpoint: '/oauth/register',
-        clientRegistrationTTL: 1, // 1 second
+        // KV's minimum storable TTL; advance the mock clock past it below.
+        clientRegistrationTTL: 60,
       });
 
       // Register a DCR client
@@ -11768,8 +11795,8 @@ describe('OAuthProvider', () => {
       expect(stored).not.toBeNull();
       expect(stored.clientName).toBe('Updated Name');
 
-      // Wait for TTL to expire
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      // Advance past the TTL
+      mockEnv.OAUTH_KV.advanceTime(61_000);
 
       // Client should have expired (TTL was preserved on update)
       const expired = await mockEnv.OAUTH_KV.get(`client:${client.client_id}`, { type: 'json' });

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3118,6 +3118,67 @@ describe('OAuthProvider', () => {
       expect(newTokens.expires_in).toBe(1800);
     });
 
+    it('should reject (not crash) exchanging a subject token with less than 60s remaining', async () => {
+      // Same root cause as the refresh near-expiry bug (#233): the issued token's TTL is
+      // clamped to the subject token's remaining lifetime, so a subject token in its final
+      // <60s would produce an access token whose expiration KV rejects with a 400.
+      const tokenEntries = await mockEnv.OAUTH_KV.list({ prefix: 'token:' });
+      const subjectTokenKey = tokenEntries.keys[0].name;
+      const subjectTokenData = await mockEnv.OAUTH_KV.get(subjectTokenKey, { type: 'json' });
+      // Still valid (not yet expired) but inside the 60s window.
+      subjectTokenData.expiresAt = Math.floor(Date.now() / 1000) + 30;
+      await mockEnv.OAUTH_KV.put(subjectTokenKey, JSON.stringify(subjectTokenData));
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
+      params.append('subject_token', accessToken);
+      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+
+      const exchangeRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        params.toString()
+      );
+
+      const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
+
+      expect(exchangeResponse.status).toBe(400);
+      const error = await exchangeResponse.json<any>();
+      expect(error.error).toBe('invalid_grant');
+      expect(error.error_description).toBe('Subject token is too close to expiry to exchange');
+    });
+
+    it('should reject (not crash) a token exchange requesting expires_in below 60s', async () => {
+      const params = new URLSearchParams();
+      params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
+      params.append('subject_token', accessToken);
+      params.append('subject_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append('requested_token_type', 'urn:ietf:params:oauth:token-type:access_token');
+      params.append('expires_in', '30'); // below KV's 60s minimum
+
+      const exchangeRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        },
+        params.toString()
+      );
+
+      const exchangeResponse = await oauthProvider.fetch(exchangeRequest, mockEnv, mockCtx);
+
+      expect(exchangeResponse.status).toBe(400);
+      const error = await exchangeResponse.json<any>();
+      expect(error.error).toBe('invalid_request');
+      expect(error.error_description).toBe('Requested token lifetime must be at least 60 seconds');
+    });
+
     it('should reject token exchange with invalid subject token', async () => {
       const params = new URLSearchParams();
       params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -21,6 +21,14 @@ class MockKV {
     if (options?.expirationTtl) {
       expirationTime = Date.now() + options.expirationTtl * 1000;
     } else if (options?.expiration) {
+      // Mirror Cloudflare KV's validation for absolute expirations: they must be at
+      // least 60 seconds in the future, otherwise the PUT is rejected with a 400.
+      const minExpiration = Math.floor(Date.now() / 1000) + 60;
+      if (options.expiration < minExpiration) {
+        throw new Error(
+          `KV PUT failed: 400 Invalid expiration of ${options.expiration}. Expiration times must be at least 60 seconds in the future.`
+        );
+      }
       expirationTime = options.expiration * 1000;
     }
 
@@ -4521,8 +4529,80 @@ describe('OAuthProvider', () => {
       expect(refreshResponse.status).toBe(400);
       const error = await refreshResponse.json<any>();
       expect(error.error).toBe('invalid_grant');
-      // KV auto-deletes expired entries, so the grant is gone before the expiry check runs
-      expect(error.error_description).toBe('Grant not found');
+      // The grant's KV expiration is clamped to a 60s minimum (Cloudflare KV rejects
+      // shorter expirations), so the record outlives its logical expiresAt. The refresh
+      // handler's expiry check therefore runs and reports the expired refresh token.
+      expect(error.error_description).toBe('Refresh token has expired');
+    });
+
+    it('should reject a refresh when the grant has less than 60s remaining instead of throwing a KV 400', async () => {
+      // Regression test for https://github.com/cloudflare/workers-oauth-provider/issues/233
+      // Cloudflare KV rejects absolute expirations less than 60s in the future. A refresh
+      // arriving in the final <60s of a grant's life used to pass the expiry check and then
+      // crash with an uncaught "KV PUT failed: 400 Invalid expiration" when re-saving the
+      // rotated grant. It should instead be treated as an expired refresh token.
+      const providerWithTTL = new OAuthProvider({
+        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        accessTokenTTL: 3600,
+        refreshTokenTTL: 7200,
+      });
+
+      // Get an auth code and exchange it for tokens
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+      const authResponse = await providerWithTTL.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+      const tokens = await (await providerWithTTL.fetch(tokenRequest, mockEnv, mockCtx)).json<any>();
+      const refreshToken = tokens.refresh_token;
+
+      // Move the grant's expiration into the final <60s window. Write it back without a KV
+      // expiration so the record itself persists and the refresh handler's expiry check runs.
+      const grantEntries = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
+      const grantKey = grantEntries.keys[0].name;
+      const grantData = await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' });
+      grantData.expiresAt = Math.floor(Date.now() / 1000) + 30;
+      await mockEnv.OAUTH_KV.put(grantKey, JSON.stringify(grantData));
+
+      const refreshParams = new URLSearchParams();
+      refreshParams.append('grant_type', 'refresh_token');
+      refreshParams.append('refresh_token', refreshToken);
+      refreshParams.append('client_id', clientId);
+      refreshParams.append('client_secret', clientSecret);
+      const refreshRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        refreshParams.toString()
+      );
+
+      const refreshResponse = await providerWithTTL.fetch(refreshRequest, mockEnv, mockCtx);
+
+      // Should be a clean invalid_grant, not a 500 from the KV PUT failure
+      expect(refreshResponse.status).toBe(400);
+      const error = await refreshResponse.json<any>();
+      expect(error.error).toBe('invalid_grant');
+      expect(error.error_description).toBe('Refresh token has expired');
     });
 
     it('should allow overriding refresh token TTL via callback', async () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -437,6 +437,32 @@ describe('OAuthProvider', () => {
         });
       }).toThrow('Must provide either apiRoute + apiHandler OR apiHandlers');
     });
+
+    it('should throw when accessTokenTTL is below the 60-second KV minimum', () => {
+      expect(() => {
+        new OAuthProvider({
+          apiRoute: '/api/',
+          apiHandler: { fetch: () => Promise.resolve(new Response()) },
+          defaultHandler: testDefaultHandler,
+          authorizeEndpoint: '/authorize',
+          tokenEndpoint: '/oauth/token',
+          accessTokenTTL: 30,
+        });
+      }).toThrow('accessTokenTTL must be an integer of at least 60 seconds');
+    });
+
+    it('should allow accessTokenTTL exactly at the 60-second minimum', () => {
+      expect(() => {
+        new OAuthProvider({
+          apiRoute: '/api/',
+          apiHandler: { fetch: () => Promise.resolve(new Response()) },
+          defaultHandler: testDefaultHandler,
+          authorizeEndpoint: '/authorize',
+          tokenEndpoint: '/oauth/token',
+          accessTokenTTL: 60,
+        });
+      }).not.toThrow();
+    });
   });
 
   describe('OAuth Metadata Discovery', () => {
@@ -4741,6 +4767,113 @@ describe('OAuthProvider', () => {
       const error = await refreshResponse.json<any>();
       expect(error.error).toBe('invalid_grant');
       expect(error.error_description).toBe('Refresh token has expired');
+    });
+
+    it('should reject (not crash) when a callback sets accessTokenTTL below 60s on the authorization_code grant', async () => {
+      const providerWithTinyTTL = new OAuthProvider({
+        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        accessTokenTTL: 3600,
+        tokenExchangeCallback: async (options) => {
+          if (options.grantType === 'authorization_code') {
+            return { accessTokenTTL: 30 }; // below KV's 60s minimum
+          }
+          return {};
+        },
+      });
+
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+      const authResponse = await providerWithTinyTTL.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+
+      const tokenResponse = await providerWithTinyTTL.fetch(tokenRequest, mockEnv, mockCtx);
+
+      expect(tokenResponse.status).toBe(400);
+      const error = await tokenResponse.json<any>();
+      expect(error.error).toBe('invalid_request');
+      expect(error.error_description).toBe('Requested token lifetime must be at least 60 seconds');
+    });
+
+    it('should reject (not crash) when a callback sets accessTokenTTL below 60s on the refresh_token grant', async () => {
+      const providerWithTinyTTL = new OAuthProvider({
+        apiRoute: ['/api/', 'https://api.example.com/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        accessTokenTTL: 3600,
+        refreshTokenTTL: 7200,
+        tokenExchangeCallback: async (options) => {
+          // Only shorten on refresh, so the initial code exchange succeeds.
+          if (options.grantType === 'refresh_token') {
+            return { accessTokenTTL: 30 }; // below KV's 60s minimum
+          }
+          return {};
+        },
+      });
+
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+      const authResponse = await providerWithTinyTTL.fetch(authRequest, mockEnv, mockCtx);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('code', code);
+      params.append('redirect_uri', redirectUri);
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+      const tokenRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        params.toString()
+      );
+      const tokens = await (await providerWithTinyTTL.fetch(tokenRequest, mockEnv, mockCtx)).json<any>();
+
+      const refreshParams = new URLSearchParams();
+      refreshParams.append('grant_type', 'refresh_token');
+      refreshParams.append('refresh_token', tokens.refresh_token);
+      refreshParams.append('client_id', clientId);
+      refreshParams.append('client_secret', clientSecret);
+      const refreshRequest = createMockRequest(
+        'https://example.com/oauth/token',
+        'POST',
+        { 'Content-Type': 'application/x-www-form-urlencoded' },
+        refreshParams.toString()
+      );
+
+      const refreshResponse = await providerWithTinyTTL.fetch(refreshRequest, mockEnv, mockCtx);
+
+      expect(refreshResponse.status).toBe(400);
+      const error = await refreshResponse.json<any>();
+      expect(error.error).toBe('invalid_request');
+      expect(error.error_description).toBe('Requested token lifetime must be at least 60 seconds');
     });
 
     it('should allow overriding refresh token TTL via callback', async () => {

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -383,6 +383,13 @@ interface ComputeTtlInput {
   assertionExp: number;
   mapperTtl: number | undefined;
   now: number;
+  /**
+   * Minimum storable token lifetime. Cloudflare KV rejects token writes whose
+   * expiration is less than 60 seconds away, so a resolved TTL below this would
+   * make the mint fail with an opaque KV 400. The caller passes the shared
+   * `KV_MIN_EXPIRATION_TTL_SECONDS` constant.
+   */
+  minTtlSeconds: number;
 }
 
 /**
@@ -392,13 +399,21 @@ interface ComputeTtlInput {
  * TOCTOU window between claim validation and token mint.
  */
 export function computeEmaAccessTokenTTL(input: ComputeTtlInput): Result<number, EmaValidationError> {
-  const { configuredDefaultSeconds, assertionExp, mapperTtl, now } = input;
+  const { configuredDefaultSeconds, assertionExp, mapperTtl, now, minTtlSeconds } = input;
 
   if (assertionExp - now <= 0) {
     return err({ reason: 'assertion_expired_after_processing' });
   }
 
-  return ok(mapperTtl ?? configuredDefaultSeconds);
+  const ttl = mapperTtl ?? configuredDefaultSeconds;
+
+  // A mapper-supplied TTL below KV's minimum would produce an unstorable token.
+  // (The configured default is validated to be storable at OAuthProvider construction.)
+  if (ttl < minTtlSeconds) {
+    return err({ reason: 'invalid_mapped_ttl' });
+  }
+
+  return ok(ttl);
 }
 
 // ─── Local helpers (not exported) ─────────────────────────────────────────────

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2783,6 +2783,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Determine TTL for new token
     const now = Math.floor(Date.now() / 1000);
     const subjectTokenRemainingLifetime = tokenSummary.expiresAt - now;
+
+    // The issued token's TTL is clamped to the subject token's remaining lifetime below.
+    // Cloudflare KV rejects writes whose expiration is less than 60 seconds away, so a
+    // subject token in its final <60s would produce an unstorable access token and an
+    // uncaught 500. Treat such a near-expiry subject token as not exchangeable instead.
+    if (subjectTokenRemainingLifetime < KV_MIN_EXPIRATION_TTL_SECONDS) {
+      throw new OAuthError('invalid_grant', {
+        description: 'Subject token is too close to expiry to exchange',
+      });
+    }
+
     let accessTokenTTL = this.options.accessTokenTTL ?? DEFAULT_ACCESS_TOKEN_TTL;
 
     // If expiresIn is provided, use it but clamp to subject token's remaining lifetime
@@ -2860,6 +2871,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
           tokenScopes = this.downscope(callbackResult.accessTokenScope, grantData.scope);
         }
       }
+    }
+
+    // A client-requested `expires_in` (or a callback-supplied `accessTokenTTL`) may be
+    // below KV's 60-second minimum even when the subject token has ample life remaining.
+    // Reject rather than attempting an unstorable write that KV would reject with a 400.
+    if (accessTokenTTL < KV_MIN_EXPIRATION_TTL_SECONDS) {
+      throw new OAuthError('invalid_request', {
+        description: 'Requested token lifetime must be at least 60 seconds',
+      });
     }
 
     // Create and store access token

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2457,10 +2457,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.createErrorResponse('invalid_grant', { description: 'Client ID mismatch' });
     }
 
-    // Check if the refresh token has expired
+    // Check if the refresh token has expired.
+    // Cloudflare KV requires absolute expirations to be at least 60 seconds in the
+    // future. Rotating the grant re-saves it with `{ expiration: grantData.expiresAt }`,
+    // so a grant with less than 60 seconds of life remaining cannot be written back to
+    // KV and would otherwise surface as an uncaught "KV PUT failed: 400 Invalid
+    // expiration" error. Treat such near-expiry grants as already expired instead.
     if (grantData.expiresAt !== undefined) {
       const now = Math.floor(Date.now() / 1000);
-      if (now >= grantData.expiresAt) {
+      if (grantData.expiresAt - now < KV_MIN_EXPIRATION_TTL_SECONDS) {
         return this.createErrorResponse('invalid_grant', { description: 'Refresh token has expired' });
       }
     }
@@ -3739,8 +3744,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * @param now - Current timestamp in seconds
    */
   private async saveGrantWithTTL(env: any, grantKey: string, grantData: Grant, now: number): Promise<void> {
-    // Use absolute expiration timestamp if grant has an expiration
-    const kvOptions = grantData.expiresAt !== undefined ? { expiration: grantData.expiresAt } : {};
+    // Use absolute expiration timestamp if grant has an expiration.
+    // Cloudflare KV rejects expirations less than 60 seconds in the future, so clamp
+    // the absolute expiration to that minimum. This is defense-in-depth: callers that
+    // refresh near-expiry grants already treat them as expired, but clamping here also
+    // protects freshly-issued grants configured with a very short refreshTokenTTL.
+    const kvOptions =
+      grantData.expiresAt !== undefined
+        ? { expiration: Math.max(grantData.expiresAt, now + KV_MIN_EXPIRATION_TTL_SECONDS) }
+        : {};
     try {
       await env.OAUTH_KV.put(grantKey, JSON.stringify(grantData), kvOptions);
     } catch (error) {
@@ -4325,6 +4337,15 @@ const DEFAULT_REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60;
  * Default expiration time for dynamically registered clients (90 days in seconds)
  */
 const DEFAULT_CLIENT_REGISTRATION_TTL = 90 * 24 * 60 * 60;
+
+/**
+ * Minimum number of seconds an absolute KV expiration must be in the future.
+ * Cloudflare KV rejects `put` calls whose `expiration` is less than 60 seconds
+ * away with "400 Invalid expiration ... Expiration times must be at least 60
+ * seconds in the future." We use this to treat near-expiry grants as expired and
+ * to clamp absolute expirations when writing grants back to KV.
+ */
+const KV_MIN_EXPIRATION_TTL_SECONDS = 60;
 
 /**
  * Default batch size for purgeExpiredData. Conservative to stay within

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1395,6 +1395,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       ...options,
     };
 
+    // Cloudflare KV rejects token writes whose expiration is less than 60 seconds in the
+    // future, so an access token TTL below that would make every token issuance fail with
+    // an opaque KV 400 at runtime. Reject it at construction with a clear, actionable error.
+    if (
+      !Number.isInteger(this.options.accessTokenTTL) ||
+      this.options.accessTokenTTL! < KV_MIN_EXPIRATION_TTL_SECONDS
+    ) {
+      throw new TypeError(
+        `accessTokenTTL must be an integer of at least ${KV_MIN_EXPIRATION_TTL_SECONDS} seconds (Cloudflare KV's minimum expiration window).`
+      );
+    }
+
     this.validateEmaOptions(this.options.enterpriseManagedAuthorization);
 
     if (this.options.enterpriseManagedAuthorization) {
@@ -2607,6 +2619,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       }
     }
 
+    // The access token below is written with a relative `expirationTtl`, which KV rejects
+    // when under 60 seconds. With the re-check above the grant has >=60s remaining, so the
+    // only way to land here is a tokenExchangeCallback returning an `accessTokenTTL` below
+    // the minimum. Reject before rotating/saving the grant rather than crashing on the write.
+    if (accessTokenTTL < KV_MIN_EXPIRATION_TTL_SECONDS) {
+      return this.createErrorResponse('invalid_request', {
+        description: 'Requested token lifetime must be at least 60 seconds',
+      });
+    }
+
     const accessTokenExpiresAt = now + accessTokenTTL;
 
     // Wrap the access token key
@@ -3157,6 +3179,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       assertionExp: claims.value.claims.exp,
       mapperTtl: mapped.value.accessTokenTTL,
       now: issueNow,
+      minTtlSeconds: KV_MIN_EXPIRATION_TTL_SECONDS,
     });
     if (!ttl.ok) return ttl;
 
@@ -3852,6 +3875,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async createAccessToken(params: CreateAccessTokenOptions): Promise<string> {
     const { userId, grantId, clientId, scope, encryptedProps, encryptionKey, expiresIn, audience, env } = params;
+
+    // Central guard for all access-token writes: Cloudflare KV rejects an `expirationTtl`
+    // below 60 seconds, so a TTL derived from a callback override or a near-expiry source
+    // must not reach the write. Callers that clamp to a source's remaining lifetime should
+    // already have rejected this case with a more specific error; this is the backstop.
+    if (expiresIn < KV_MIN_EXPIRATION_TTL_SECONDS) {
+      throw new OAuthError('invalid_request', {
+        description: 'Requested token lifetime must be at least 60 seconds',
+      });
+    }
 
     // Generate access token
     const accessTokenSecret = generateRandomString(TOKEN_LENGTH);

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2588,6 +2588,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Calculate the access token expiration time (after callback might have updated TTL)
     const now = Math.floor(Date.now() / 1000);
 
+    // Re-check expiry against the post-callback clock. The expiry check above runs before
+    // the tokenExchangeCallback, which may take long enough (e.g. an upstream network
+    // refresh) that the grant now has less than KV's 60-second minimum remaining. Both the
+    // grant write below and the access token write (whose TTL is clamped to the grant's
+    // remaining lifetime) would then be rejected by KV with a 400. Treat the grant as
+    // expired here so we return a clean invalid_grant rather than an uncaught 500. No grant
+    // mutation or token write has happened yet, so returning now leaves no partial state.
+    if (grantData.expiresAt !== undefined && grantData.expiresAt - now < KV_MIN_EXPIRATION_TTL_SECONDS) {
+      return this.createErrorResponse('invalid_grant', { description: 'Refresh token has expired' });
+    }
+
     // Clamp access token TTL to not exceed refresh token's remaining lifetime
     if (grantData.expiresAt !== undefined) {
       const remainingRefreshTokenLifetime = grantData.expiresAt - now;

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -3799,14 +3799,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private async saveGrantWithTTL(env: any, grantKey: string, grantData: Grant, now: number): Promise<void> {
     // Use absolute expiration timestamp if grant has an expiration.
-    // Cloudflare KV rejects expirations less than 60 seconds in the future, so clamp
-    // the absolute expiration to that minimum. This is defense-in-depth: callers that
-    // refresh near-expiry grants already treat them as expired, but clamping here also
-    // protects freshly-issued grants configured with a very short refreshTokenTTL.
+    // Cloudflare KV rejects expirations less than 60 seconds in the future, so clamp the
+    // absolute expiration to that minimum plus a small margin (KV validates against its own
+    // clock at write time, so an exact `now + 60` can be rejected under latency/skew). This
+    // is defense-in-depth: callers that refresh near-expiry grants already treat them as
+    // expired, but clamping here also protects freshly-issued grants configured with a very
+    // short refreshTokenTTL.
+    const minExpiration = now + KV_MIN_EXPIRATION_TTL_SECONDS + KV_EXPIRATION_CLAMP_MARGIN_SECONDS;
     const kvOptions =
-      grantData.expiresAt !== undefined
-        ? { expiration: Math.max(grantData.expiresAt, now + KV_MIN_EXPIRATION_TTL_SECONDS) }
-        : {};
+      grantData.expiresAt !== undefined ? { expiration: Math.max(grantData.expiresAt, minExpiration) } : {};
     try {
       await env.OAUTH_KV.put(grantKey, JSON.stringify(grantData), kvOptions);
     } catch (error) {
@@ -4410,6 +4411,15 @@ const DEFAULT_CLIENT_REGISTRATION_TTL = 90 * 24 * 60 * 60;
  * to clamp absolute expirations when writing grants back to KV.
  */
 const KV_MIN_EXPIRATION_TTL_SECONDS = 60;
+
+/**
+ * Safety margin (seconds) added on top of `KV_MIN_EXPIRATION_TTL_SECONDS` when clamping an
+ * absolute KV expiration. Absolute expirations are validated against KV's clock at the
+ * moment the write is processed, so writing exactly `now + 60` can be rejected once
+ * worker→KV latency or minor clock skew is accounted for. The margin keeps clamped writes
+ * comfortably above KV's hard minimum without meaningfully extending a grant's lifetime.
+ */
+const KV_EXPIRATION_CLAMP_MARGIN_SECONDS = 5;
 
 /**
  * Default batch size for purgeExpiredData. Conservative to stay within


### PR DESCRIPTION
## Summary

Fixes #233 and the broader class of bugs behind it. Cloudflare KV rejects any write whose expiration is under 60 seconds away (`400 Invalid expiration` for absolute `expiration`; the equivalent for relative `expirationTtl`). Several paths could derive a sub-60s expiration and crash with an uncaught `500`. This PR makes every token/grant write either succeed or fail with a clean OAuth error.

### 1. Refresh token grant (the reported bug, #233)

A refresh arriving in the final `<60s` of the grant's life passed the expiry check, then `saveGrantWithTTL` re-saved the rotated grant with an absolute expiration under 60s away → KV `400` → uncaught `500`.

- Treat a grant with `<60s` remaining as expired (`invalid_grant`).
- **Re-check expiry after `tokenExchangeCallback`** — a slow callback (common upstream refresh in MCP) can push the grant under 60s between the initial check and the writes (the access-token write clamps its TTL to the grant's remaining life).
- `saveGrantWithTTL` clamps the absolute expiration to `max(expiresAt, now + 60)` as defense-in-depth.

### 2. Token exchange grant (RFC 8693)

The issued token's TTL is clamped to the subject token's remaining lifetime. A subject token in its final `<60s` produced an unstorable token.

- Reject a subject token with `<60s` remaining (`invalid_grant`).
- Reject a resulting token lifetime below 60s (`invalid_request`).

### 3. Any access token lifetime below KV's minimum

Generalised guard for the "TTL value < 60s" class so no path can crash on the write:

- **Construction validation:** `accessTokenTTL` must be an integer of at least 60 seconds.
- **`tokenExchangeCallback`:** returning an `accessTokenTTL` below 60 on the authorization code or refresh grant is rejected with `invalid_request` (central guard in `createAccessToken` + pre-rotation guard in the refresh grant).
- **EMA / ID-JAG grant:** a mapper-supplied access token TTL below 60 is rejected (`invalid_grant`, "Invalid access token TTL"). Note: a near-expiry ID-JAG *assertion* does **not** shrink the token TTL, so the EMA path was never subject to the #233 clamping race itself — only to an explicitly-too-small mapper/configured TTL.

## Notes

- **No KV schema change.** Existing access and refresh tokens remain valid. Released as a **patch**.
- The bug predates `0.8.0`: the 30-day `refreshTokenTTL` default that makes grants eligible for the `<60s` window landed in `0.5.0`.
- **Minor behavior change:** constructing `OAuthProvider` with `accessTokenTTL` below 60 (or a non-integer / explicit `undefined`) now throws a `TypeError` instead of silently misbehaving at runtime.
- Added a shared `KV_MIN_EXPIRATION_TTL_SECONDS = 60` constant (passed into the EMA validator so the value stays single-sourced).

## Test plan

- [x] `MockKV` mirrors Cloudflare KV by rejecting absolute `expiration` under 60s, so the core grant-write bug is faithfully reproducible.
- [x] Refresh: grant 30s from expiry → `invalid_grant`; slow callback pushing a 61s grant under the threshold → `invalid_grant`.
- [x] Token exchange: subject token `<60s` remaining → `invalid_grant`; `expires_in=30` → `invalid_request`.
- [x] TTL floor: construction with `accessTokenTTL: 30` throws (and `60` is accepted); authorization_code and refresh callbacks returning `accessTokenTTL: 30` → `invalid_request`; `computeEmaAccessTokenTTL` unit test for a sub-60 mapper TTL.
- [x] Updated the existing short-`refreshTokenTTL` test (clamp keeps the grant alive past its logical expiry, so the expiry check now reports "Refresh token has expired").
- [x] `npm run check` (typecheck + 519 tests) passes; `npm run prettier` clean.
- [x] Changeset added (patch).

> Test-fidelity note: `MockKV` enforces the 60s rule only for absolute `expiration`, not relative `expirationTtl` (enforcing the latter would break unrelated `clientRegistrationTTL: 1` tests). The `expirationTtl`-based tests therefore assert the new guards reject early rather than reproducing the raw KV `400`. Real KV enforces both.