### PR TITLE
fix(ema): allow ID-JAGs without resource claims

### DIFF
--- a/.changeset/fuzzy-seals-trade.md
+++ b/.changeset/fuzzy-seals-trade.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Allow EMA ID-JAG assertions to omit the optional `resource` claim, falling back to the provider's configured protected resource.

--- a/README.md
+++ b/README.md
@@ -393,11 +393,11 @@ new OAuthProvider({
 
 Setup:
 
-1. Configure your IdP as an ID-JAG issuer with this worker's origin as the resource and a public JWKS endpoint.
+1. Configure your IdP as an ID-JAG issuer with a public JWKS endpoint. If it includes the optional `resource` claim, configure it with the MCP endpoint URL.
 2. Set `resourceMetadata.resource` to the MCP endpoint URL (required when EMA is enabled).
 3. Implement `trustedIssuers` as a resolver — for multi-tenant deployments it can read `env` / `clientInfo` to look up per-tenant IdP config without redeploying.
 
-The AS enforces `resolved.issuer === iss` (confused-deputy guard) and validates ID-JAG `typ`, signature, audience, client binding, resource, `exp` / `iat` / `nbf`, max lifetime, and `jti` replay. Refresh tokens are not issued for this grant — the ID-JAG itself is the renewable assertion.
+The AS enforces `resolved.issuer === iss` (confused-deputy guard) and validates ID-JAG `typ`, signature, audience, client binding, any supplied resource, `exp` / `iat` / `nbf`, max lifetime, and `jti` replay. When the optional `resource` claim is omitted, the AS uses `resourceMetadata.resource`, so issued tokens remain pinned to the configured MCP resource. Refresh tokens are not issued for this grant — the ID-JAG itself is the renewable assertion.
 
 ### Public clients
 
@@ -410,7 +410,7 @@ enterpriseManagedAuthorization: {
 }
 ```
 
-This is useful for clients registered via a [Client ID Metadata Document (CIMD)](https://modelcontextprotocol.io/), which are always public and therefore cannot present a client secret. With this enabled, trust rests on the IdP-issued, signature-verified, short-lived, single-use ID-JAG assertion (audience-, resource-, and client-bound) rather than on a separately presented client secret. Leave it unset (default `false`) to keep the spec-default behavior of requiring client authentication.
+This is useful for clients registered via a [Client ID Metadata Document (CIMD)](https://modelcontextprotocol.io/), which are always public and therefore cannot present a client secret. With this enabled, trust rests on the IdP-issued, signature-verified, short-lived, single-use ID-JAG assertion (audience- and client-bound), together with the provider's configured resource pinning, rather than on a separately presented client secret. Leave it unset (default `false`) to keep the spec-default behavior of requiring client authentication.
 
 Experimental — the MCP extension is still a draft.
 

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -262,6 +262,23 @@ describe('validateIdJagClaims', () => {
     expect(r.ok).toBe(true);
   });
 
+  it('uses the configured resource when the optional resource claim is omitted', () => {
+    const { resource: _omit, ...claimsWithoutResource } = validClaims;
+    const r = validateIdJagClaims({ rawClaims: claimsWithoutResource, ...claimsArgs });
+    expect(r).toMatchObject({
+      ok: true,
+      value: {
+        resource: claimsArgs.configuredResource,
+        claims: { resource: claimsArgs.configuredResource },
+      },
+    });
+  });
+
+  it('rejects a present but empty resource claim', () => {
+    const r = validateIdJagClaims({ rawClaims: { ...validClaims, resource: '' }, ...claimsArgs });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'invalid_claim', claim: 'resource' } });
+  });
+
   it('rejects missing required claims with the claim name', () => {
     const { sub: _omit, ...rest } = validClaims;
     const r = validateIdJagClaims({ rawClaims: rest, ...claimsArgs });

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -3663,6 +3663,24 @@ describe('OAuthProvider', () => {
       });
     });
 
+    it('should use the configured resource when the ID-JAG omits its optional resource claim', async () => {
+      const tokenResponse = await exchangeAssertion(await createAssertion({ resource: undefined }));
+      expect(tokenResponse.status).toBe(200);
+      const tokens = await tokenResponse.json<{ access_token?: string; resource?: string }>();
+
+      expect(tokens.access_token).toBeDefined();
+      expect(tokens.resource).toBe(resource);
+
+      const apiResponse = await enterpriseProvider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: `Bearer ${tokens.access_token}`,
+        }),
+        mockEnv,
+        mockCtx
+      );
+      expect(apiResponse.status).toBe(200);
+    });
+
     it('should accept ES256 assertions when the trusted issuer allows ES256', async () => {
       const ecKey = await createEcJwtKey();
       privateKey = ecKey.privateKey;

--- a/src/ema/types.ts
+++ b/src/ema/types.ts
@@ -22,7 +22,11 @@ export interface EmaIdJagClaims {
   /** Authorization server issuer URL or URLs for which this assertion is intended. */
   aud: string | string[];
 
-  /** RFC 9728 resource identifier of the MCP server. */
+  /**
+   * Effective RFC 9728 resource identifier of the MCP server. When the ID-JAG
+   * omits its optional `resource` claim, the provider supplies its configured
+   * `resourceMetadata.resource` value.
+   */
   resource: string;
 
   /** OAuth client identifier this assertion was issued to. */
@@ -74,7 +78,10 @@ export interface EmaClaimsMapperInput<Env = Cloudflare.Env> {
   /** Authenticated OAuth client that presented the assertion. */
   clientInfo: ClientInfo;
 
-  /** Validated MCP resource identifier from the assertion. */
+  /**
+   * Effective MCP resource identifier. Taken from the assertion when present,
+   * otherwise from the provider's configured `resourceMetadata.resource`.
+   */
   resource: string;
 
   /** Requested scopes after downscoping to the assertion's scope claim, if present. */
@@ -263,8 +270,9 @@ export interface EmaOptions<Env = Cloudflare.Env> {
    * always public (`none`) and therefore cannot present a client secret. The
    * security trade-off is documented in the README: the trust then rests on
    * the IdP-issued, signature-verified, short-lived, single-use ID-JAG
-   * assertion (audience-, resource-, and client-bound) rather than on a
-   * separately presented client secret.
+   * assertion (audience- and client-bound), together with the provider's
+   * configured resource pinning, rather than on a separately presented client
+   * secret.
    */
   allowPublicClients?: boolean;
 }

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -170,13 +170,14 @@ interface ValidateClaimsInput {
 }
 
 /**
- * Validate every required ID-JAG claim and produce a typed `ValidatedIdJag`.
+ * Validate the ID-JAG claims and produce a typed `ValidatedIdJag`.
  *
  * Enforces (in order):
- *   - presence + type of `iss`, `sub`, `aud`, `resource`, `client_id`, `jti`, `exp`, `iat`
+ *   - presence + type of `iss`, `sub`, `aud`, `client_id`, `jti`, `exp`, `iat`
  *   - `aud` contains the AS's expected audience
  *   - `client_id` matches the authenticated client
- *   - `resource` is a valid RFC 8707 URI and matches the AS's configured resource
+ *   - optional `resource` is a valid RFC 8707 URI and matches the AS's configured resource
+ *   - the configured resource is used when `resource` is omitted
  *   - `exp` is in the future
  *   - `iat` is not more than `clockSkewSeconds` in the future
  *   - `nbf` (if present) is ≤ `now + clockSkewSeconds`
@@ -203,7 +204,11 @@ export function validateIdJagClaims(input: ValidateClaimsInput): Result<Validate
   const aud = readAudienceClaim(rawClaims);
   if (!aud.ok) return aud;
 
-  const resource = readRequiredString(rawClaims, 'resource');
+  // The MCP EMA profile follows the core ID-JAG specification in making
+  // `resource` optional. Keep tokens pinned to this provider's declared
+  // resource when the IdP omits the claim; a present claim is still validated.
+  const resource =
+    rawClaims.resource === undefined ? ok(configuredResource) : readRequiredString(rawClaims, 'resource');
   if (!resource.ok) return resource;
 
   const claimClientId = readRequiredString(rawClaims, 'client_id');


### PR DESCRIPTION
## What changed

EMA token exchanges now accept ID-JAG assertions that omit the optional `resource` claim. This matches the stable [MCP Enterprise-Managed Authorization extension](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx), which defines [`resource` as optional in the token exchange](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx#4-token-exchange) and only constrains the [ID-JAG `resource` claim when present](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx#43-identity-assertion-jwt-authorization-grant). It also allows integrations with identity providers such as Okta that do not include the claim.

When `resource` is absent, the provider uses its required `resourceMetadata.resource` configuration as the effective resource. That value is passed to `mapClaims`, stored on the grant, used as the access token audience, and returned in the token response, so the token remains pinned to the configured MCP resource.

If an assertion does include `resource`, the existing validation remains unchanged: it must be a valid RFC 8707 resource URI and match the configured resource. Present but malformed, empty, or mismatched values are still rejected.

Regression coverage includes both the claim validator and a complete signed ID-JAG exchange without `resource`.