### PR TITLE
fix(cimd): report metadata fetch failures instead of treating them as unknown clients

### DIFF
--- a/.changeset/cimd-fetch-error-propagation.md
+++ b/.changeset/cimd-fetch-error-propagation.md
@@ -7,9 +7,10 @@ A failed Client ID Metadata Document fetch previously became a `null` client
 lookup, so a network problem (timeout, WAF block, upstream outage) was
 indistinguishable from an unregistered client — at the token endpoint, in the
 `onError` hook, and for `OAuthHelpers` callers. The fetch failure now throws a
-new exported `CimdFetchError` carrying the metadata URL and underlying reason.
-The token endpoint still returns the same generic `invalid_client` / "Client
-not found" response, but reports the failure through the `onError` hook's
+new exported `CimdFetchError` carrying the metadata URL, stable
+`metadata_resolution_failed` reason, and underlying diagnostic detail. The
+token endpoint still returns the same generic `invalid_client` / "Client not
+found" response, but reports the failure through the `onError` hook's
 `internal` field (category `client-id-metadata-document`) together with a new
 optional `request` field. Breaking for callers of `OAuthHelpers.lookupClient`
 (and methods built on it) that relied on `null` for CIMD fetch failures: catch

--- a/.changeset/cimd-fetch-error-propagation.md
+++ b/.changeset/cimd-fetch-error-propagation.md
@@ -1,0 +1,16 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Report CIMD metadata fetch failures instead of treating them as unknown clients.
+A failed Client ID Metadata Document fetch previously became a `null` client
+lookup, so a network problem (timeout, WAF block, upstream outage) was
+indistinguishable from an unregistered client — at the token endpoint, in the
+`onError` hook, and for `OAuthHelpers` callers. The fetch failure now throws a
+new exported `CimdFetchError` carrying the metadata URL and underlying reason.
+The token endpoint still returns the same generic `invalid_client` / "Client
+not found" response, but reports the failure through the `onError` hook's
+`internal` field (category `client-id-metadata-document`) together with a new
+optional `request` field. Breaking for callers of `OAuthHelpers.lookupClient`
+(and methods built on it) that relied on `null` for CIMD fetch failures: catch
+`CimdFetchError` to restore the old behavior.

--- a/README.md
+++ b/README.md
@@ -608,7 +608,22 @@ new OAuthProvider({
 
 The compatibility flag is required for SSRF (Server-Side Request Forgery) protection. Due to a legacy quirk, `fetch()` requests to URLs within your zone's domain are sent directly to the origin server, bypassing Cloudflare. The `global_fetch_strictly_public` flag disables this behavior. See [Cloudflare's documentation](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public) for more details.
 
-When CIMD is not enabled (the default), URL-formatted `client_id` values fall through to standard KV lookup. When enabled, if fetching the metadata document fails, the library logs a warning and returns an `invalid_client` error, allowing MCP clients to recover by falling back to Dynamic Client Registration.
+When CIMD is not enabled (the default), URL-formatted `client_id` values fall through to standard KV lookup. When enabled, if fetching or validating the metadata document fails, the token endpoint returns a generic `invalid_client` response. The `onError` callback receives `internal.category: "client-id-metadata-document"`, the stable reason `metadata_resolution_failed`, diagnostic details, and the originating request. Use request metadata for correlation, but do not log its credentials or body.
+
+`OAuthHelpers.lookupClient()`, `parseAuthRequest()`, `completeAuthorization()`, and `exchangeToken()` throw `CimdFetchError` when they cannot resolve a CIMD client. `lookupClient()` returns `null` only when the client does not exist:
+
+```ts
+import { CimdFetchError } from '@cloudflare/workers-oauth-provider';
+
+try {
+  const client = await env.OAUTH_PROVIDER.lookupClient(clientId);
+} catch (error) {
+  if (error instanceof CimdFetchError) {
+    console.error(error.reason, error.metadataUrl, error.detail);
+  }
+  throw error;
+}
+```
 
 The OAuth metadata endpoint reports `client_id_metadata_document_supported: true` only when both the option is enabled and the compatibility flag is present.
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import {
+  CimdFetchError,
   OAuthError,
   OAuthProvider,
   type OAuthHelpers,
@@ -10123,7 +10124,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
     });
 
@@ -10146,7 +10147,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat streaming response exceeding 5KB as invalid client', async () => {
@@ -10169,7 +10170,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
     });
 
@@ -10245,7 +10246,7 @@ describe('OAuthProvider', () => {
           `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
           'GET'
         );
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
 
         // No KV caching anymore - Cloudflare HTTP cache handles caching
         const cacheKey = `cimd:${cimdUrl}`;
@@ -10266,7 +10267,7 @@ describe('OAuthProvider', () => {
           `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
           'GET'
         );
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
 
         // No KV caching anymore - Cloudflare HTTP cache handles caching
         const cacheKey = `cimd:${cimdUrl}`;
@@ -10291,7 +10292,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat client_secret_basic auth method as invalid client', async () => {
@@ -10309,7 +10310,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat client_secret_jwt auth method as invalid client', async () => {
@@ -10327,7 +10328,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should accept none auth method', async () => {
@@ -10435,7 +10436,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat missing redirect_uris as invalid client', async () => {
@@ -10452,7 +10453,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat empty redirect_uris as invalid client', async () => {
@@ -10470,7 +10471,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat invalid JSON response as invalid client', async () => {
@@ -10488,7 +10489,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
     });
 
@@ -10556,7 +10557,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should pass AbortSignal to fetch', async () => {
@@ -10595,7 +10596,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat 500 responses as invalid client', async () => {
@@ -10607,7 +10608,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it('should treat network errors as invalid client', async () => {
@@ -10619,7 +10620,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
     });
 
@@ -10842,14 +10843,14 @@ describe('OAuthProvider', () => {
       it('should log warning with client URL and error message on HTTP failure', async () => {
         globalThis.fetch = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
 
-        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(cimdUrl), expect.stringContaining('HTTP 404'));
       });
 
       it('should log warning on timeout', async () => {
         globalThis.fetch = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
 
-        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(cimdUrl), expect.anything());
       });
 
@@ -10863,7 +10864,7 @@ describe('OAuthProvider', () => {
             )
           );
 
-        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
         expect(warnSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('size limit'));
       });
 
@@ -10875,27 +10876,85 @@ describe('OAuthProvider', () => {
           })
         );
 
-        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
         expect(warnSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('does not match'));
+      });
+
+      it('should expose the metadata URL and underlying reason on the thrown error', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Blocked', { status: 403 }));
+
+        const error = await oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx).then(
+          () => {
+            throw new Error('expected rejection');
+          },
+          (e) => e
+        );
+        expect(error).toBeInstanceOf(CimdFetchError);
+        expect(error.metadataUrl).toBe(cimdUrl);
+        expect(error.reason).toContain('HTTP 403');
       });
     });
 
     describe('Token Endpoint CIMD Failure', () => {
-      it('should return invalid_client OAuth error when CIMD fetch fails at token endpoint', async () => {
-        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
+      const cimdUrl = 'https://client.example.com/oauth/metadata.json';
 
-        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
-        const tokenRequest = createMockRequest(
+      function makeTokenRequest() {
+        return createMockRequest(
           'https://example.com/oauth/token',
           'POST',
           { 'Content-Type': 'application/x-www-form-urlencoded' },
           `grant_type=authorization_code&code=test-code&client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}`
         );
+      }
 
-        const response = await oauthProvider.fetch(tokenRequest, mockEnv, mockCtx);
+      it('should return invalid_client OAuth error when CIMD fetch fails at token endpoint', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
+
+        const response = await oauthProvider.fetch(makeTokenRequest(), mockEnv, mockCtx);
         expect(response.status).toBe(401);
         const body = await response.json<any>();
         expect(body.error).toBe('invalid_client');
+      });
+
+      it('should report the fetch failure through onError while keeping the wire response generic', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Blocked', { status: 403 }));
+
+        const onError = vi.fn();
+        const provider = new OAuthProvider({
+          apiRoute: ['/api/'],
+          apiHandler: TestApiHandler,
+          defaultHandler: testDefaultHandler,
+          authorizeEndpoint: '/authorize',
+          tokenEndpoint: '/oauth/token',
+          clientRegistrationEndpoint: '/oauth/register',
+          scopesSupported: ['read', 'write'],
+          clientIdMetadataDocumentEnabled: true,
+          onError,
+        });
+
+        const tokenRequest = makeTokenRequest();
+        const response = await provider.fetch(tokenRequest, mockEnv, mockCtx);
+
+        // The wire response is indistinguishable from an unknown client.
+        expect(response.status).toBe(401);
+        expect(await response.json<any>()).toEqual({
+          error: 'invalid_client',
+          error_description: 'Client not found',
+        });
+
+        // The hook receives the real reason and the originating request, so
+        // deployers can log it and attach it to request-scoped telemetry.
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            code: 'invalid_client',
+            status: 401,
+            internal: {
+              category: 'client-id-metadata-document',
+              reason: expect.stringContaining('HTTP 403'),
+            },
+            request: tokenRequest,
+          })
+        );
       });
     });
   });

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -10395,7 +10395,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
     });
 
@@ -10414,7 +10414,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
       it.each([
@@ -10880,18 +10880,19 @@ describe('OAuthProvider', () => {
         expect(warnSpy).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('does not match'));
       });
 
-      it('should expose the metadata URL and underlying reason on the thrown error', async () => {
+      it('should expose stable and diagnostic fields on the thrown error', async () => {
         globalThis.fetch = vi.fn().mockResolvedValue(new Response('Blocked', { status: 403 }));
 
         const error = await oauthProvider.fetch(makeAuthRequest(), mockEnv, mockCtx).then(
           () => {
             throw new Error('expected rejection');
           },
-          (e) => e
+          (cause) => cause
         );
         expect(error).toBeInstanceOf(CimdFetchError);
         expect(error.metadataUrl).toBe(cimdUrl);
-        expect(error.reason).toContain('HTTP 403');
+        expect(error.reason).toBe('metadata_resolution_failed');
+        expect(error.detail).toContain('HTTP 403');
       });
     });
 
@@ -10912,8 +10913,34 @@ describe('OAuthProvider', () => {
 
         const response = await oauthProvider.fetch(makeTokenRequest(), mockEnv, mockCtx);
         expect(response.status).toBe(401);
+        expect(response.headers.get('WWW-Authenticate')).toBeNull();
         const body = await response.json<any>();
         expect(body.error).toBe('invalid_client');
+      });
+
+      it('should retain the Basic challenge when CIMD resolution fails', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(new Response('Blocked', { status: 403 }));
+
+        const response = await oauthProvider.fetch(
+          createMockRequest(
+            'https://example.com/oauth/token',
+            'POST',
+            {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              Authorization: `Basic ${btoa(`${encodeURIComponent(cimdUrl)}:`)}`,
+            },
+            'grant_type=authorization_code&code=test-code'
+          ),
+          mockEnv,
+          mockCtx
+        );
+
+        expect(response.status).toBe(401);
+        expect(response.headers.get('WWW-Authenticate')).toBe('Basic realm="OAuth"');
+        expect(await response.json<any>()).toEqual({
+          error: 'invalid_client',
+          error_description: 'Client not found',
+        });
       });
 
       it('should report the fetch failure through onError while keeping the wire response generic', async () => {
@@ -10950,7 +10977,11 @@ describe('OAuthProvider', () => {
             status: 401,
             internal: {
               category: 'client-id-metadata-document',
-              reason: expect.stringContaining('HTTP 403'),
+              reason: 'metadata_resolution_failed',
+              detail: {
+                metadataUrl: cimdUrl,
+                message: expect.stringContaining('HTTP 403'),
+              },
             },
             request: tokenRequest,
           })

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -554,13 +554,15 @@ export interface OAuthHelpers {
    * Parses an OAuth authorization request from the HTTP request
    * @param request - The HTTP request containing OAuth parameters
    * @returns The parsed authorization request parameters
+   * @throws {@link CimdFetchError} when the client ID is a CIMD URL whose document cannot be resolved
    */
   parseAuthRequest(request: Request): Promise<AuthRequest>;
 
   /**
    * Looks up a client by its client ID
    * @param clientId - The client ID to look up
-   * @returns A Promise resolving to the client info, or null if not found
+   * @returns A Promise resolving to the client info, or null if the client does not exist
+   * @throws {@link CimdFetchError} when the client ID is a CIMD URL whose document cannot be resolved
    */
   lookupClient(clientId: string): Promise<ClientInfo | null>;
 
@@ -568,6 +570,7 @@ export interface OAuthHelpers {
    * Completes an authorization request by creating a grant and authorization code
    * @param options - Options specifying the grant details
    * @returns A Promise resolving to an object containing the redirect URL
+   * @throws {@link CimdFetchError} when the client ID is a CIMD URL whose document cannot be resolved
    */
   completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }>;
 
@@ -629,6 +632,7 @@ export interface OAuthHelpers {
    * Implements OAuth 2.0 Token Exchange (RFC 8693)
    * @param options - Options for token exchange including subject token and optional modifications
    * @returns Promise resolving to token response with new access token
+   * @throws {@link CimdFetchError} when the grant's client ID is a CIMD URL whose document cannot be resolved
    */
   exchangeToken(options: ExchangeTokenOptions): Promise<TokenResponse>;
 
@@ -1779,12 +1783,22 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     return `${requestUrl.origin}${suffix}`;
   }
 
-  private createInvalidClientResponse(description: string, basicAuthenticationAttempted: boolean): Response {
-    return this.createErrorResponse('invalid_client', {
-      description,
-      statusCode: 401,
-      ...(basicAuthenticationAttempted ? { headers: { 'WWW-Authenticate': BASIC_AUTH_CHALLENGE } } : {}),
-    });
+  private createInvalidClientResponse(
+    description: string,
+    basicAuthenticationAttempted: boolean,
+    internal?: { category: string; reason: string; detail?: unknown },
+    request?: Request
+  ): Response {
+    return this.createErrorResponse(
+      'invalid_client',
+      {
+        description,
+        statusCode: 401,
+        ...(basicAuthenticationAttempted ? { headers: { 'WWW-Authenticate': BASIC_AUTH_CHALLENGE } } : {}),
+      },
+      internal,
+      request
+    );
   }
 
   /**
@@ -1894,13 +1908,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       if (error instanceof CimdFetchError) {
         // Same wire response as an unknown client — the CIMD spec prescribes no
         // error body for metadata fetch failures — but the deployer's onError
-        // hook receives the real reason, so an upstream outage blocking the
-        // metadata URL is observable instead of masquerading as an
-        // unregistered client.
-        return this.createErrorResponse(
-          'invalid_client',
-          { description: 'Client not found', statusCode: 401 },
-          { category: 'client-id-metadata-document', reason: error.reason },
+        // hook receives a stable reason and diagnostic details, so an upstream
+        // outage blocking the metadata URL is observable instead of masquerading
+        // as an unregistered client.
+        return this.createInvalidClientResponse(
+          'Client not found',
+          basicAuthenticationAttempted,
+          {
+            category: 'client-id-metadata-document',
+            reason: error.reason,
+            detail: { metadataUrl: error.metadataUrl, message: error.detail },
+          },
           request
         );
       }
@@ -4593,17 +4611,24 @@ export class OAuthError extends Error {
  * failures should catch it to preserve their error contract.
  */
 export class CimdFetchError extends Error {
+  /** Stable reason slug suitable for telemetry and control flow. */
+  public readonly reason = 'metadata_resolution_failed' as const;
   /** The CIMD URL whose fetch or validation failed. */
   public readonly metadataUrl: string;
   /** The underlying failure message (e.g. "Failed to fetch client metadata: HTTP 403"). */
-  public readonly reason: string;
+  public readonly detail: string;
 
+  /**
+   * Creates an error for a failed CIMD fetch or validation.
+   * @param metadataUrl - The CIMD URL that could not be resolved
+   * @param cause - The underlying fetch or validation failure
+   */
   constructor(metadataUrl: string, cause: unknown) {
-    const reason = cause instanceof Error ? cause.message : String(cause);
-    super(`CIMD fetch failed for ${metadataUrl}: ${reason}`);
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`CIMD fetch failed for ${metadataUrl}: ${detail}`);
     this.name = 'CimdFetchError';
     this.metadataUrl = metadataUrl;
-    this.reason = reason;
+    this.detail = detail;
   }
 }
 
@@ -5250,6 +5275,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
    * Parses an OAuth authorization request from the HTTP request
    * @param request - The HTTP request containing OAuth parameters
    * @returns The parsed authorization request parameters
+   * @throws CimdFetchError when the client ID is a CIMD URL whose document cannot be resolved
    */
   async parseAuthRequest(request: Request): Promise<AuthRequest> {
     const url = new URL(request.url);
@@ -5349,6 +5375,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
    * - For implicit flow: generating an access token directly
    * @param options - Options specifying the grant details
    * @returns A Promise resolving to an object containing the redirect URL
+   * @throws CimdFetchError when the client ID is a CIMD URL whose document cannot be resolved
    */
   async completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }> {
     const { clientId, redirectUri } = options.request;
@@ -5864,6 +5891,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
    * Implements OAuth 2.0 Token Exchange (RFC 8693)
    * @param options - Options for token exchange including subject token and optional modifications
    * @returns Promise resolving to token response with new access token
+   * @throws CimdFetchError when the grant's client ID is a CIMD URL whose document cannot be resolved
    */
   async exchangeToken(options: ExchangeTokenOptions): Promise<TokenResponse> {
     // Validate subject token first to get client info

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -467,6 +467,11 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * deliberately did NOT put on the wire — used for richer diagnostics where the public
    * response must stay generic (e.g. JWT validation failures on the EMA path). Backwards
    * compatible: existing callbacks ignoring this field continue to work unchanged.
+   *
+   * `request` (when present) is the HTTP request that produced the error response, so the
+   * callback can correlate the error with per-request state such as request-keyed telemetry.
+   * Currently populated for CIMD metadata fetch failures at the token endpoint. Backwards
+   * compatible in the same way as `internal`.
    */
   onError?: (error: {
     code: string;
@@ -474,6 +479,7 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
     status: number;
     headers: Record<string, string>;
     internal?: { category: string; reason: string; detail?: unknown };
+    request?: Request;
   }) => Response | void;
 
   /**
@@ -1881,7 +1887,25 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     // Verify client exists
-    const clientInfo = await this.getClient(env, clientId);
+    let clientInfo: ClientInfo | null;
+    try {
+      clientInfo = await this.getClient(env, clientId);
+    } catch (error) {
+      if (error instanceof CimdFetchError) {
+        // Same wire response as an unknown client — the CIMD spec prescribes no
+        // error body for metadata fetch failures — but the deployer's onError
+        // hook receives the real reason, so an upstream outage blocking the
+        // metadata URL is observable instead of masquerading as an
+        // unregistered client.
+        return this.createErrorResponse(
+          'invalid_client',
+          { description: 'Client not found', statusCode: 401 },
+          { category: 'client-id-metadata-document', reason: error.reason },
+          request
+        );
+      }
+      throw error;
+    }
     if (!clientInfo) {
       return this.createInvalidClientResponse('Client not found', basicAuthenticationAttempted);
     }
@@ -3908,7 +3932,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    *
    * @param env - Cloudflare Worker environment variables
    * @param clientId - The client ID to look up (can be a regular ID or an HTTPS URL for CIMD)
-   * @returns The client information, or null if not found
+   * @returns The client information, or null if the client does not exist. Null means
+   * definitive absence; failures to determine the answer throw instead (KV errors
+   * propagate, and a CIMD metadata fetch failure throws `CimdFetchError`), so an
+   * upstream outage is distinguishable from an unregistered client.
    */
   async getClient(env: any, clientId: string): Promise<ClientInfo | null> {
     // Check if this is a CIMD (Client ID Metadata Document) URL
@@ -3925,9 +3952,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         return await this.fetchClientMetadataDocument(clientId);
       } catch (error) {
         // CIMD fetch failed (size limit, timeout, HTTP error, invalid metadata, etc.)
-        // Return null so callers treat this as "client not found" instead of a 500
+        // Throw a tagged error rather than returning null: KV-backed lookups
+        // already let infrastructure failures propagate, and conflating a fetch
+        // failure with "client not found" hides upstream outages from deployers
+        // (e.g. a WAF blocking the metadata URL reads as an unregistered client).
         console.warn(`CIMD fetch failed for ${clientId}:`, error instanceof Error ? error.message : error);
-        return null;
+        throw new CimdFetchError(clientId, error);
       }
     }
 
@@ -4407,7 +4437,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private createErrorResponse(
     code: string,
     options: OAuthErrorOptions,
-    internal?: { category: string; reason: string; detail?: unknown }
+    internal?: { category: string; reason: string; detail?: unknown },
+    request?: Request
   ): Response {
     const { description } = options;
     const responseStatus = options.statusCode ?? 400;
@@ -4423,6 +4454,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       status: responseStatus,
       headers: responseHeaders,
       ...(internal ? { internal } : {}),
+      ...(request ? { request } : {}),
     });
     if (customErrorResponse) return customErrorResponse;
 
@@ -4541,6 +4573,37 @@ export class OAuthError extends Error {
     this.description = this.options.description;
     this.statusCode = this.options.statusCode;
     this.headers = this.options.headers;
+  }
+}
+
+/**
+ * Thrown when fetching a Client ID Metadata Document (CIMD) fails — the
+ * server-to-server fetch errored, timed out, or returned an invalid document.
+ * Distinct from a client that simply does not exist, which is reported as a
+ * null client lookup result.
+ *
+ * At the token endpoint the provider handles this itself: the wire response
+ * stays a generic `invalid_client` / "Client not found", and the failure is
+ * reported through the `onError` hook's `internal` field (category
+ * `client-id-metadata-document`) together with the originating `request`.
+ *
+ * `OAuthHelpers` methods that look up clients (`lookupClient`, and methods
+ * built on it such as `exchangeToken`) let this error propagate to the
+ * caller. Callers that previously relied on a `null` result for these
+ * failures should catch it to preserve their error contract.
+ */
+export class CimdFetchError extends Error {
+  /** The CIMD URL whose fetch or validation failed. */
+  public readonly metadataUrl: string;
+  /** The underlying failure message (e.g. "Failed to fetch client metadata: HTTP 403"). */
+  public readonly reason: string;
+
+  constructor(metadataUrl: string, cause: unknown) {
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    super(`CIMD fetch failed for ${metadataUrl}: ${reason}`);
+    this.name = 'CimdFetchError';
+    this.metadataUrl = metadataUrl;
+    this.reason = reason;
   }
 }
 
@@ -5268,7 +5331,13 @@ class OAuthHelpersImpl implements OAuthHelpers {
   /**
    * Looks up a client by its client ID
    * @param clientId - The client ID to look up
-   * @returns A Promise resolving to the client info, or null if not found
+   * @returns A Promise resolving to the client info, or null if the client does not
+   * exist. Null means definitive absence; failures to determine the answer throw
+   * instead (KV errors propagate, and a CIMD metadata fetch failure throws
+   * `CimdFetchError`), so an upstream outage cannot masquerade as an unregistered
+   * client.
+   * @throws CimdFetchError when the client ID is a CIMD URL and fetching or
+   * validating the metadata document fails.
    */
   async lookupClient(clientId: string): Promise<ClientInfo | null> {
     return await this.provider.getClient(this.env, clientId);


### PR DESCRIPTION
## What changed

CIMD metadata resolution failures are now distinguishable from a client that does not exist.

Previously, `getClient()` caught every failed Client ID Metadata Document fetch or validation and returned `null`. Timeouts, WAF blocks, HTTP failures, oversized responses, and invalid metadata therefore looked identical to an unregistered client.

The provider now throws an exported `CimdFetchError` with:

- `reason: "metadata_resolution_failed"` — stable for telemetry and control flow
- `metadataUrl` — the CIMD URL
- `detail` — the underlying diagnostic message

### Token endpoint

The wire response remains the same generic `401 invalid_client` / `Client not found` response. The provider:

- preserves the RFC 6749 Basic challenge when authentication was attempted through HTTP Basic
- reports `internal.category: "client-id-metadata-document"`
- reports the stable `internal.reason: "metadata_resolution_failed"`
- puts the metadata URL and dynamic message in `internal.detail`
- includes the originating request for request-scoped correlation

### OAuth helpers

`OAuthHelpers.lookupClient()`, `parseAuthRequest()`, `completeAuthorization()`, and `exchangeToken()` let `CimdFetchError` propagate. `lookupClient()` now returns `null` only when the client does not exist. The public interface and README document the exception contract and recovery pattern.

This is a minor change because callers that previously treated CIMD resolution failures as `null` must catch `CimdFetchError` to retain that behavior.

## Standards basis

The Client ID Metadata Document draft says authorization servers should abort authorization when metadata retrieval fails and must not cache error responses or invalid documents. It does not prescribe a specific token-endpoint error body, so the provider keeps the existing generic wire response while exposing diagnostics only to trusted application code.

## Tests

Coverage includes:

- network, HTTP, timeout, size-limit, and metadata-validation failures
- stable error and telemetry fields
- generic token-endpoint wire responses
- Basic challenge preservation
- no Basic challenge for form-post authentication
- current CIMD authentication-method and metadata validation behavior

Validated with Node 24:

- `npm run check` — 558 tests
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `git diff --check`
