### PR TITLE
fix: support structured errors from resolveExternalToken

### DIFF
--- a/.changeset/tidy-rivers-resolve.md
+++ b/.changeset/tidy-rivers-resolve.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': patch
+'@cloudflare/workers-oauth-provider': minor
 ---
 
-Convert `OAuthError` thrown by `resolveExternalToken` into structured protected-resource error responses. Standard bearer-token failures receive `WWW-Authenticate` challenges, callback headers are preserved, and unexpected errors continue to surface as 500s.
+Convert `OAuthError` thrown by `resolveExternalToken` into structured protected-resource error responses. Standard bearer-token failures receive `WWW-Authenticate` challenges, `requiredScopes` supplies step-up scope guidance, callback headers are preserved, browser clients can read `WWW-Authenticate` and `Retry-After` through CORS, and unexpected errors continue to surface as 500s.

--- a/.changeset/tidy-rivers-resolve.md
+++ b/.changeset/tidy-rivers-resolve.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Convert `OAuthError` thrown by `resolveExternalToken` into structured protected-resource error responses. Standard bearer-token failures receive `WWW-Authenticate` challenges, callback headers are preserved, and unexpected errors continue to surface as 500s.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,49 @@ Note that `deleteClient()` cascades: it revokes all grants (and their associated
 
 See the `OAuthHelpers` interface definition for full API details.
 
+## External Token Resolution
+
+Use `resolveExternalToken` to authenticate bearer tokens issued by another authorization server. The callback runs
+only when the token was not found in the provider's internal storage.
+
+```ts
+import { OAuthError, OAuthProvider } from '@cloudflare/workers-oauth-provider';
+
+new OAuthProvider({
+  // ... other options ...
+  resolveExternalToken: async ({ token }) => {
+    const result = await validateExternalToken(token);
+
+    if (result.kind === 'invalid') return null;
+    if (result.kind === 'insufficient_scope') {
+      throw new OAuthError('insufficient_scope', {
+        description: 'The external token needs the account:read scope',
+        statusCode: 403,
+      });
+    }
+    if (result.kind === 'rate_limited') {
+      throw new OAuthError('temporarily_unavailable', {
+        description: 'The external authorization server rate limited validation',
+        statusCode: 429,
+        headers: { 'Retry-After': result.retryAfter },
+      });
+    }
+
+    return { props: result.props, audience: result.audience };
+  },
+});
+```
+
+The callback has three outcomes:
+
+- Return `{ props, audience? }` to authenticate the request.
+- Return `null` for a generic `401 invalid_token` response.
+- Throw this package's exported `OAuthError` for an intentional structured response. Standard `invalid_token` 401
+  and `insufficient_scope` 403 errors receive a resource-specific `WWW-Authenticate` challenge unless the error
+  supplies one.
+
+Other thrown values are re-thrown so unexpected validator bugs remain visible as 500s.
+
 ## Token Exchange Callback
 
 This library allows you to update the `props` value during token exchanges by configuring a callback function. This is useful for scenarios where the application needs to perform additional processing when tokens are issued or refreshed.
@@ -363,7 +406,7 @@ async function refreshUpstream(props) {
 - `options.statusCode` — HTTP status code (default `400`).
 - `options.headers` — additional response headers, such as `Retry-After` for transient failures. There is no implicit `Retry-After` default for callback-thrown errors.
 
-Only `OAuthError` from this package is converted into a structured `/token` response. Plain errors, plain objects with a `code` field, and app-local error classes continue to surface as 500s so unexpected failures stay visible. Import `OAuthError` from `@cloudflare/workers-oauth-provider` rather than copying or re-implementing it.
+Only `OAuthError` from this package is converted into a structured response. Plain errors, plain objects with a `code` field, and app-local error classes continue to surface as 500s so unexpected failures stay visible. Import `OAuthError` from `@cloudflare/workers-oauth-provider` rather than copying or re-implementing it.
 
 ## Enterprise-Managed Authorization (Experimental)
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ new OAuthProvider({
       throw new OAuthError('insufficient_scope', {
         description: 'The external token needs the account:read scope',
         statusCode: 403,
+        requiredScopes: ['account:read'],
       });
     }
     if (result.kind === 'rate_limited') {
@@ -290,9 +291,12 @@ The callback has three outcomes:
 - Return `null` for a generic `401 invalid_token` response.
 - Throw this package's exported `OAuthError` for an intentional structured response. Standard `invalid_token` 401
   and `insufficient_scope` 403 errors receive a resource-specific `WWW-Authenticate` challenge unless the error
-  supplies one.
+  supplies one. Set `requiredScopes` on `insufficient_scope` to include the operation's minimum scopes in the
+  challenge for step-up authorization.
 
-Other thrown values are re-thrown so unexpected validator bugs remain visible as 500s.
+Other thrown values are re-thrown so unexpected validator bugs remain visible as 500s. For cross-origin requests,
+the provider exposes `WWW-Authenticate` and `Retry-After` through CORS so browser clients can read discovery,
+step-up, and backoff guidance.
 
 ## Token Exchange Callback
 
@@ -405,6 +409,7 @@ async function refreshUpstream(props) {
 - `options.description` — human-readable text returned in `error_description`.
 - `options.statusCode` — HTTP status code (default `400`).
 - `options.headers` — additional response headers, such as `Retry-After` for transient failures. There is no implicit `Retry-After` default for callback-thrown errors.
+- `options.requiredScopes` — minimum scopes for a protected resource operation. On a structured `403 insufficient_scope` from `resolveExternalToken`, the provider validates, deduplicates, and serializes them into the synthesized `WWW-Authenticate` challenge.
 
 Only `OAuthError` from this package is converted into a structured response. Plain errors, plain objects with a `code` field, and app-local error classes continue to surface as 500s so unexpected failures stay visible. Import `OAuthError` from `@cloudflare/workers-oauth-provider` rather than copying or re-implementing it.
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -6731,9 +6731,37 @@ describe('OAuthProvider', () => {
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://client.example.com');
       expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
       expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
+      expect(response.headers.get('Access-Control-Expose-Headers')).toBe('WWW-Authenticate, Retry-After');
 
       const error = await response.json<any>();
       expect(error.error).toBe('invalid_token');
+    });
+
+    it('should preserve handler-supplied CORS exposed headers', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: '/api/',
+        apiHandler: {
+          fetch: () =>
+            Promise.resolve(
+              new Response('ok', {
+                headers: { 'Access-Control-Expose-Headers': 'X-Request-Id, www-authenticate' },
+              })
+            ),
+        },
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => ({ props: {} }),
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Origin: 'https://client.example.com',
+        Authorization: 'Bearer external-token',
+      });
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Access-Control-Expose-Headers')).toBe('X-Request-Id, www-authenticate, Retry-After');
     });
 
     it('should add CORS headers to token endpoint error responses', async () => {
@@ -8825,6 +8853,7 @@ describe('OAuthProvider', () => {
             description: 'Account Resources: Read is required',
             statusCode: 403,
             headers: { 'X-Trace-Id': 'trace-123' },
+            requiredScopes: ['account:read', 'profile:read', 'account:read'],
           });
         },
       });
@@ -8836,7 +8865,9 @@ describe('OAuthProvider', () => {
 
       expect(response.status).toBe(403);
       expect(response.headers.get('X-Trace-Id')).toBe('trace-123');
-      expect(response.headers.get('WWW-Authenticate')).toContain('error="insufficient_scope"');
+      expect(response.headers.get('WWW-Authenticate')).toBe(
+        'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/test", error="insufficient_scope", scope="account:read profile:read"'
+      );
       await expect(response.json()).resolves.toEqual({
         error: 'insufficient_scope',
         error_description: 'Account Resources: Read is required',
@@ -8892,6 +8923,30 @@ describe('OAuthProvider', () => {
       }
     );
 
+    it('should reject invalid requiredScopes before constructing a challenge', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => {
+          throw new OAuthError('insufficient_scope', {
+            description: 'invalid scope configuration',
+            statusCode: 403,
+            requiredScopes: ['scope with spaces'],
+          });
+        },
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: 'Bearer external-token',
+      });
+
+      await expect(provider.fetch(request, mockEnv, mockCtx)).rejects.toThrow(
+        'OAuthError requiredScopes must contain valid OAuth scope tokens'
+      );
+    });
+
     it('should preserve a caller-supplied WWW-Authenticate challenge', async () => {
       const challenge = 'Bearer realm="external", error="invalid_token"';
       const provider = new OAuthProvider({
@@ -8905,6 +8960,7 @@ describe('OAuthProvider', () => {
             description: 'external token rejected',
             statusCode: 401,
             headers: { 'www-authenticate': challenge },
+            requiredScopes: ['ignored because the caller supplied the complete challenge'],
           });
         },
       });

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -8782,6 +8782,159 @@ describe('OAuthProvider', () => {
       expect(externalTokenCalls[0].token).toBe('invalid-external-token');
     });
 
+    it('should convert OAuthError from external validation into a structured invalid_token response', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => {
+          throw new OAuthError('invalid_token', {
+            description: 'external token expired',
+            statusCode: 401,
+          });
+        },
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: 'Bearer expired-external-token',
+      });
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(response.headers.get('WWW-Authenticate')).toBe(
+        'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/test", error="invalid_token"'
+      );
+      await expect(response.json()).resolves.toEqual({
+        error: 'invalid_token',
+        error_description: 'external token expired',
+      });
+    });
+
+    it('should convert insufficient_scope from external validation into a structured 403 response', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => {
+          throw new OAuthError('insufficient_scope', {
+            description: 'Account Resources: Read is required',
+            statusCode: 403,
+            headers: { 'X-Trace-Id': 'trace-123' },
+          });
+        },
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: 'Bearer under-scoped-external-token',
+      });
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(403);
+      expect(response.headers.get('X-Trace-Id')).toBe('trace-123');
+      expect(response.headers.get('WWW-Authenticate')).toContain('error="insufficient_scope"');
+      await expect(response.json()).resolves.toEqual({
+        error: 'insufficient_scope',
+        error_description: 'Account Resources: Read is required',
+      });
+    });
+
+    it.each<{
+      code: string;
+      description: string;
+      status: number;
+      headers: Record<string, string>;
+    }>([
+      {
+        code: 'temporarily_unavailable',
+        description: 'external authorization server rate limited',
+        status: 429,
+        headers: { 'Retry-After': '17' },
+      },
+      {
+        code: 'server_error',
+        description: 'external authorization server unavailable',
+        status: 502,
+        headers: { 'X-Upstream-Status': '503' },
+      },
+    ])(
+      'should preserve a structured $status external validation failure',
+      async ({ code, description, status, headers }) => {
+        const provider = new OAuthProvider({
+          apiRoute: ['/api/'],
+          apiHandler: TestApiHandler,
+          defaultHandler: testDefaultHandler,
+          authorizeEndpoint: '/authorize',
+          tokenEndpoint: '/oauth/token',
+          resolveExternalToken: async () => {
+            throw new OAuthError(code, { description, statusCode: status, headers });
+          },
+        });
+        const request = createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: 'Bearer unavailable-external-token',
+        });
+
+        const response = await provider.fetch(request, mockEnv, mockCtx);
+
+        expect(response.status).toBe(status);
+        for (const [name, value] of Object.entries(headers)) {
+          expect(response.headers.get(name)).toBe(value);
+        }
+        expect(response.headers.get('WWW-Authenticate')).toBeNull();
+        await expect(response.json()).resolves.toEqual({
+          error: code,
+          error_description: description,
+        });
+      }
+    );
+
+    it('should preserve a caller-supplied WWW-Authenticate challenge', async () => {
+      const challenge = 'Bearer realm="external", error="invalid_token"';
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => {
+          throw new OAuthError('invalid_token', {
+            description: 'external token rejected',
+            statusCode: 401,
+            headers: { 'www-authenticate': challenge },
+          });
+        },
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: 'Bearer rejected-external-token',
+      });
+
+      const response = await provider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.headers.get('WWW-Authenticate')).toBe(challenge);
+    });
+
+    it('should rethrow non-OAuthError failures from external validation', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => {
+          throw new Error('external validator bug');
+        },
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: 'Bearer external-token',
+      });
+
+      await expect(provider.fetch(request, mockEnv, mockCtx)).rejects.toThrow('external validator bug');
+    });
+
     it('should prioritize internal tokens over external validation', async () => {
       // Mock external token validation to track if it's called
       const externalTokenCalls: any[] = [];

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -450,8 +450,9 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * For example, if a request includes an authenticated token from a different OAuth authentication server,
    * the callback can be used to authenticate it and set the context props through it.
    *
-   * The callback can optionally return props values that will passed-through to the apiHandlers.
-   * The callback can return `null` to signal resolution failure.
+   * Return props to authenticate the request, or `null` for a generic `invalid_token` response.
+   * Throw this package's exported {@link OAuthError} to return a structured OAuth error response.
+   * Other thrown errors remain unexpected failures and are re-thrown.
    */
   resolveExternalToken?: (input: ResolveExternalTokenInput) => Promise<ResolveExternalTokenResult | null>;
 
@@ -2125,18 +2126,37 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
-   * Build a structured OAuth `/token` error response from an OAuth error.
+   * Build a structured OAuth error response from an OAuth error.
    *
    * The supported form is throwing this package's exported `OAuthError`.
    * Anything else is re-thrown so unexpected failures still surface as 500s.
    *
+   * When handling a protected resource request, standard bearer-token errors
+   * receive an RFC 6750 / RFC 9728 challenge unless the caller supplied one.
    * Use `headers['Retry-After']` for rate-limit / transient-failure backoff
    * hints (see RFC 7231 §7.1.3 — either an integer seconds value or an
    * HTTP-date is allowed).
    */
-  private createOAuthErrorResponse(error: unknown): Response | undefined {
+  private createOAuthErrorResponse(error: unknown, resourceMetadataUrl?: string): Response | undefined {
     if (!(error instanceof OAuthError)) return undefined;
-    return this.createErrorResponse(error.code, error.options);
+
+    const headers = error.options.headers ?? {};
+    const hasChallenge = Object.keys(headers).some((name) => name.toLowerCase() === 'www-authenticate');
+    const isBearerError =
+      (error.code === 'invalid_token' && error.statusCode === 401) ||
+      (error.code === 'insufficient_scope' && error.statusCode === 403);
+
+    return this.createErrorResponse(error.code, {
+      ...error.options,
+      ...(resourceMetadataUrl && isBearerError && !hasChallenge
+        ? {
+            headers: {
+              ...headers,
+              'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, error.code),
+            },
+          }
+        : {}),
+    });
   }
 
   /**
@@ -3727,8 +3747,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // Set the decrypted props on the context object
       (ctx as MutableExecutionContext).props = decryptedProps;
     } else if (this.options.resolveExternalToken) {
-      // No token data was found, so we validate the provided token with the provided validator
-      const ext = await this.options.resolveExternalToken({ token: accessToken, request, env });
+      // No token data was found, so we validate the provided token with the provided validator.
+      // Convert only the package's exported OAuthError into a structured response;
+      // unexpected callback failures remain visible as 500s.
+      let ext: ResolveExternalTokenResult | null;
+      try {
+        ext = await this.options.resolveExternalToken({ token: accessToken, request, env });
+      } catch (error) {
+        const response = this.createOAuthErrorResponse(error, resourceMetadataUrl);
+        if (response) return response;
+        throw error;
+      }
 
       // Failed external validation
       if (!ext) {
@@ -4342,10 +4371,9 @@ export interface OAuthErrorOptions {
 /**
  * Structured OAuth 2.0 error.
  *
- * Throw from a `tokenExchangeCallback` (or any code it calls — the error
- * propagates naturally up through deep call stacks) to surface a standard
- * `/token` error response (`{ error, error_description }`) instead of a
- * generic `500 Internal Server Error`.
+ * Throw from a `tokenExchangeCallback`, `resolveExternalToken`, or any code
+ * they call to surface a standard OAuth error response
+ * (`{ error, error_description }`) instead of a generic `500 Internal Server Error`.
  *
  * Anything thrown that is **not** an `OAuthError` continues to surface as
  * a 500 so unexpected failures remain visible — the provider does not

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1976,6 +1976,20 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     newResponse.headers.set('Access-Control-Allow-Methods', '*');
     // Include Authorization explicitly since it's not included in * for security reasons
     newResponse.headers.set('Access-Control-Allow-Headers', 'Authorization, *');
+
+    // Browser-based OAuth/MCP clients need these non-safelisted response
+    // headers for authorization discovery, step-up challenges, and backoff.
+    // Preserve any headers the API handler already chose to expose.
+    const exposedHeaders = (newResponse.headers.get('Access-Control-Expose-Headers') ?? '')
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean);
+    for (const requiredHeader of ['WWW-Authenticate', 'Retry-After']) {
+      if (!exposedHeaders.some((name) => name.toLowerCase() === requiredHeader.toLowerCase())) {
+        exposedHeaders.push(requiredHeader);
+      }
+    }
+    newResponse.headers.set('Access-Control-Expose-Headers', exposedHeaders.join(', '));
     newResponse.headers.set('Access-Control-Max-Age', '86400'); // 24 hours
 
     return newResponse;
@@ -2146,16 +2160,21 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       (error.code === 'invalid_token' && error.statusCode === 401) ||
       (error.code === 'insufficient_scope' && error.statusCode === 403);
 
+    let challengeHeaders: Record<string, string> | undefined;
+    if (resourceMetadataUrl && isBearerError && !hasChallenge) {
+      const requiredScopes = [...new Set(error.options.requiredScopes ?? [])];
+      if (requiredScopes.some((scope) => !isValidOAuthScopeToken(scope))) {
+        throw new TypeError('OAuthError requiredScopes must contain valid OAuth scope tokens');
+      }
+      challengeHeaders = {
+        ...headers,
+        'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, error.code, undefined, requiredScopes),
+      };
+    }
+
     return this.createErrorResponse(error.code, {
       ...error.options,
-      ...(resourceMetadataUrl && isBearerError && !hasChallenge
-        ? {
-            headers: {
-              ...headers,
-              'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, error.code),
-            },
-          }
-        : {}),
+      ...(challengeHeaders ? { headers: challengeHeaders } : {}),
     });
   }
 
@@ -4285,8 +4304,16 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   /**
    * Builds a WWW-Authenticate header value with resource_metadata per RFC 9728 §5.1
    */
-  private buildWwwAuthenticateHeader(resourceMetadataUrl: string, error: string, errorDescription?: string): string {
+  private buildWwwAuthenticateHeader(
+    resourceMetadataUrl: string,
+    error: string,
+    errorDescription?: string,
+    requiredScopes: string[] = []
+  ): string {
     let header = `Bearer realm="OAuth", resource_metadata="${resourceMetadataUrl}", error="${error}"`;
+    if (requiredScopes.length > 0) {
+      header += `, scope="${requiredScopes.join(' ')}"`;
+    }
     if (errorDescription) {
       header += `, error_description="${errorDescription}"`;
     }
@@ -4366,6 +4393,17 @@ export interface OAuthErrorOptions {
    * number of seconds or an HTTP-date.
    */
   headers?: Record<string, string>;
+
+  /**
+   * Minimum scopes needed for the protected resource operation.
+   *
+   * When `resolveExternalToken` throws a standard bearer-token error with
+   * HTTP 401 or 403, these values are serialized into the synthesized
+   * `WWW-Authenticate` challenge's `scope` parameter. This is especially
+   * useful for step-up authorization after `insufficient_scope`. Each value
+   * must use the OAuth scope-token grammar from RFC 6749 §3.3.
+   */
+  requiredScopes?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Convert the package's exported `OAuthError` thrown by `resolveExternalToken` into a structured protected-resource response, matching the established `tokenExchangeCallback` behavior from #199.

```ts
resolveExternalToken: async ({ token }) => {
  const result = await validateExternalToken(token)

  if (!result.active) return null
  if (!result.hasRequiredScope) {
    throw new OAuthError('insufficient_scope', {
      description: 'The external token needs additional permissions',
      statusCode: 403,
      requiredScopes: ['account:read']
    })
  }

  return { props: result.props }
}
```

The callback now has three explicit outcomes:

- return `{ props, audience? }` to authenticate
- return `null` for the existing generic `401 invalid_token`
- throw the package's exported `OAuthError` for an intentional structured error

All other thrown values are re-thrown, so validator bugs remain visible as 500s rather than being mistaken for authentication failures.

## MCP 2026 protected-resource behavior

For standard bearer-token failures, the provider synthesizes a path-specific challenge when the caller did not supply one:

- `401 invalid_token`
- `403 insufficient_scope`

`OAuthErrorOptions.requiredScopes` validates, deduplicates, and serializes the current operation's minimum scopes into the challenge. This enables the MCP 2026-07-28 step-up flow without requiring applications to hand-build or escape `WWW-Authenticate`.

Caller-provided `WWW-Authenticate` headers take precedence. Other headers, including `Retry-After`, are preserved. Responses continue through `createErrorResponse`, so they receive `Cache-Control: no-store` and invoke `onError` consistently.

For cross-origin requests, the provider explicitly exposes `WWW-Authenticate` and `Retry-After`, while preserving handler-supplied `Access-Control-Expose-Headers`. Browser-based MCP clients can therefore read discovery, step-up, and backoff guidance.

This follows OAuth 2.1 resource error handling, RFC 6750, RFC 9728, and the MCP 2026-07-28 authorization specification.

## Why

Today `resolveExternalToken` supports only success or generic rejection. Expected failures such as insufficient scope, upstream rate limiting, or an unavailable external authorization server either collapse to `401 invalid_token` or escape as an unstructured Worker 500.

This change enables external-token integrations to preserve actionable `403`, `429`, and `502` responses without catching arbitrary errors or adding a second returned-error union.

## Tests

Added coverage for:

- structured `401 invalid_token` with RFC 9728 resource metadata challenge
- structured `403 insufficient_scope` with deduplicated required scopes
- invalid scope-token rejection
- preserved `429` + `Retry-After`
- preserved `502` and custom headers
- caller-supplied `WWW-Authenticate` precedence
- browser visibility of `WWW-Authenticate` and `Retry-After`
- preservation of handler-supplied CORS expose headers
- non-`OAuthError` failures still being re-thrown

Validated with Node 24:

- `npm run check` (534 tests)
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `npm pack --dry-run`
