### PR TITLE
fix: return bare missing-credential bearer challenge

### DIFF
--- a/.changeset/quiet-bears-challenge.md
+++ b/.changeset/quiet-bears-challenge.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Return a bare RFC 6750 bearer challenge when protected resource requests omit credentials or use an unsupported authorization scheme. These responses no longer mislabel absent credentials as `invalid_token` or include OAuth error details.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -5330,18 +5330,22 @@ describe('OAuthProvider', () => {
       await getAccessToken();
     });
 
-    it('should reject API requests without a token', async () => {
-      const apiRequest = createMockRequest('https://example.com/api/test');
+    it.each([
+      ['no authorization header', undefined],
+      ['an unsupported authorization scheme', 'Basic dXNlcjpwYXNz'],
+    ])('should challenge API requests with %s without OAuth error details', async (_label, authorization) => {
+      const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
+        ...(authorization ? { Authorization: authorization } : {}),
+      });
 
       const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
 
       expect(apiResponse.status).toBe(401);
-
-      const error = await apiResponse.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(apiResponse.headers.get('Cache-Control')).toBe('no-store');
+      expect(await apiResponse.text()).toBe('');
     });
 
-    it('should include resource_metadata in WWW-Authenticate header on 401 (RFC 9728)', async () => {
+    it('should include resource_metadata without an error code when credentials are absent', async () => {
       const apiRequest = createMockRequest('https://example.com/api/test');
 
       const apiResponse = await oauthProvider.fetch(apiRequest, mockEnv, mockCtx);
@@ -5352,7 +5356,7 @@ describe('OAuthProvider', () => {
       // so the client can discover metadata for the specific resource
       const wwwAuth = apiResponse.headers.get('WWW-Authenticate');
       expect(wwwAuth).toBe(
-        'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/test", error="invalid_token", error_description="Missing or invalid access token"'
+        'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/test"'
       );
     });
 
@@ -6797,9 +6801,8 @@ describe('OAuthProvider', () => {
       expect(response.headers.get('Access-Control-Allow-Methods')).toBe('*');
       expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, *');
       expect(response.headers.get('Access-Control-Expose-Headers')).toBe('WWW-Authenticate, Retry-After');
-
-      const error = await response.json<any>();
-      expect(error.error).toBe('invalid_token');
+      expect(await response.text()).toBe('');
+      expect(response.headers.get('WWW-Authenticate')).not.toContain('error=');
     });
 
     it('should preserve handler-supplied CORS exposed headers', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -3714,15 +3714,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const authHeader = request.headers.get('Authorization');
 
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return this.createErrorResponse('invalid_token', {
-        description: 'Missing or invalid access token',
-        statusCode: 401,
+      // OAuth 2.1 §5.3.2: when authentication information is absent or uses an
+      // unsupported scheme, challenge without an error code or description.
+      return new Response(null, {
+        status: 401,
         headers: {
-          'WWW-Authenticate': this.buildWwwAuthenticateHeader(
-            resourceMetadataUrl,
-            'invalid_token',
-            'Missing or invalid access token'
-          ),
+          ...NO_CACHE_HEADERS,
+          'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl),
         },
       });
     }
@@ -4341,11 +4339,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private buildWwwAuthenticateHeader(
     resourceMetadataUrl: string,
-    error: string,
+    error?: string,
     errorDescription?: string,
     requiredScopes: string[] = []
   ): string {
-    let header = `Bearer realm="OAuth", resource_metadata="${resourceMetadataUrl}", error="${error}"`;
+    let header = `Bearer realm="OAuth", resource_metadata="${resourceMetadataUrl}"`;
+    if (error) {
+      header += `, error="${error}"`;
+    }
     if (requiredScopes.length > 0) {
       header += `, scope="${requiredScopes.join(' ')}"`;
     }


### PR DESCRIPTION
## Summary

Return a bare bearer challenge when a protected resource request has no credentials or uses an unsupported authorization scheme.

Previously these requests were labeled `invalid_token` and returned OAuth error details even though no token had been presented. OAuth 2.1 §5.3.2 says such responses should not include an error code or other error information.

The response is now:

```http
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/test"
Cache-Control: no-store
```

The body is empty. Requests that actually present an invalid/expired token still receive `error="invalid_token"`.

## Tests

- no Authorization header
- unsupported Basic scheme
- path-specific RFC 9728 metadata URL
- no-store and CORS regression coverage

Validated with Node 24:

- `npm run check` (527 tests)
- `npm run build`
- `npx prettier --check .`
