### PR TITLE
fix: tighten Client ID Metadata Document validation

### DIFF
--- a/.changeset/clean-shoes-cimd.md
+++ b/.changeset/clean-shoes-cimd.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': patch
 ---
 
-Tighten Client ID Metadata Document validation by requiring a non-empty `client_name` and rejecting `private_key_jwt` until token-endpoint assertion validation is implemented. This prevents accepting CIMD clients that cannot complete authorization securely.
+Tighten Client ID Metadata Document validation by requiring a non-empty `client_name` and accepting only the currently implemented public-client authentication method, `none`. Support OpenID RP Metadata Choices by selecting `none` from `token_endpoint_auth_methods_supported`, including ChatGPT-style documents that also advertise `private_key_jwt`.

--- a/.changeset/clean-shoes-cimd.md
+++ b/.changeset/clean-shoes-cimd.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Tighten Client ID Metadata Document validation by requiring a non-empty `client_name` and rejecting `private_key_jwt` until token-endpoint assertion validation is implemented. This prevents accepting CIMD clients that cannot complete authorization securely.

--- a/README.md
+++ b/README.md
@@ -598,6 +598,8 @@ When CIMD is not enabled (the default), URL-formatted `client_id` values fall th
 
 The OAuth metadata endpoint reports `client_id_metadata_document_supported: true` only when both the option is enabled and the compatibility flag is present.
 
+CIMD currently supports only `token_endpoint_auth_method: "none"`.
+
 ## Written using Claude
 
 This library (including the schema documentation) was largely written with the help of [Claude](https://claude.ai), the AI model by Anthropic. Claude's output was thoroughly reviewed by Cloudflare engineers with careful attention paid to security and compliance with standards. Many improvements were made on the initial output, mostly again by prompting Claude (and reviewing the results). Check out the commit history to see how Claude was prompted and what code it produced.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -9885,7 +9885,7 @@ describe('OAuthProvider', () => {
         expect(authResponse.status).toBe(302);
       });
 
-      it('should accept private_key_jwt auth method', async () => {
+      it('should reject private_key_jwt until token-endpoint assertion validation is implemented', async () => {
         const cimdUrl = 'https://client.example.com/oauth/metadata.json';
         const validMetadata = {
           client_id: cimdUrl,
@@ -9902,10 +9902,7 @@ describe('OAuthProvider', () => {
           'GET'
         );
 
-        const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
-
-        // Should succeed with redirect
-        expect(authResponse.status).toBe(302);
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
       });
     });
 
@@ -9921,6 +9918,28 @@ describe('OAuthProvider', () => {
 
         const authRequest = createMockRequest(
           `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          'GET'
+        );
+
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid client');
+      });
+
+      it.each([
+        ['missing', undefined],
+        ['empty', '   '],
+      ])('should treat %s client_name as invalid client', async (_label, clientName) => {
+        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+        const invalidMetadata = {
+          client_id: cimdUrl,
+          ...(clientName === undefined ? {} : { client_name: clientName }),
+          redirect_uris: ['https://client.example.com/callback'],
+          token_endpoint_auth_method: 'none',
+        };
+
+        globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
+
+        const authRequest = createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state`,
           'GET'
         );
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -9885,6 +9885,31 @@ describe('OAuthProvider', () => {
         expect(authResponse.status).toBe(302);
       });
 
+      it('should negotiate none from ChatGPT-style authentication method choices', async () => {
+        const cimdUrl = 'https://chatgpt.com/oauth/client.json';
+        const validMetadata = {
+          client_id: cimdUrl,
+          client_name: 'ChatGPT',
+          redirect_uris: ['https://chatgpt.com/connector_platform_oauth_redirect'],
+          token_endpoint_auth_methods_supported: ['none', 'private_key_jwt'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+        };
+
+        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+        const authRequest = createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}` +
+            `&redirect_uri=${encodeURIComponent(validMetadata.redirect_uris[0])}` +
+            `&response_type=code&state=test-state` +
+            `&code_challenge=test-challenge&code_challenge_method=plain`,
+          'GET'
+        );
+
+        const response = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+
+        expect(response.status).toBe(302);
+      });
+
       it('should reject private_key_jwt until token-endpoint assertion validation is implemented', async () => {
         const cimdUrl = 'https://client.example.com/oauth/metadata.json';
         const validMetadata = {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -4246,10 +4246,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       const clientId = OAuthProviderImpl.validateStringField(rawMetadata.client_id, 'client_id');
       const clientName = OAuthProviderImpl.validateStringField(rawMetadata.client_name, 'client_name');
       const redirectUris = OAuthProviderImpl.validateStringArray(rawMetadata.redirect_uris, 'redirect_uris');
-      const tokenEndpointAuthMethod = OAuthProviderImpl.validateStringField(
+      const declaredAuthMethod = OAuthProviderImpl.validateStringField(
         rawMetadata.token_endpoint_auth_method,
         'token_endpoint_auth_method'
       );
+      const authMethodChoices = OAuthProviderImpl.validateStringArray(
+        rawMetadata.token_endpoint_auth_methods_supported,
+        'token_endpoint_auth_methods_supported'
+      );
+      const tokenEndpointAuthMethod = declaredAuthMethod ?? (authMethodChoices?.includes('none') ? 'none' : undefined);
 
       // Validate that client_id matches the URL (required by spec)
       if (clientId !== metadataUrl) {
@@ -4264,10 +4269,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         throw new Error('redirect_uris is required and must not be empty');
       }
 
-      if (tokenEndpointAuthMethod && !OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(tokenEndpointAuthMethod)) {
+      if (
+        (declaredAuthMethod && !OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(declaredAuthMethod)) ||
+        (authMethodChoices &&
+          !authMethodChoices.some((method) => OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(method)))
+      ) {
         throw new Error(
-          `token_endpoint_auth_method "${tokenEndpointAuthMethod}" is not allowed for CIMD clients. ` +
-            `Allowed methods: ${OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.join(', ')}`
+          `CIMD client does not support an accepted token endpoint authentication method. ` +
+            `Supported methods: ${OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.join(', ')}`
         );
       }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -4079,7 +4079,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * Allowed authentication methods for CIMD clients (per IETF spec)
    * CIMD clients cannot use symmetric secrets since there's no pre-shared secret
    */
-  private static readonly CIMD_ALLOWED_AUTH_METHODS = ['none', 'private_key_jwt'];
+  // private_key_jwt can be added once token-endpoint assertion validation is implemented.
+  // Accepting it in metadata before then creates clients that can authorize but never exchange a code.
+  private static readonly CIMD_ALLOWED_AUTH_METHODS = ['none'];
 
   /**
    * Validates that a field is a string or undefined
@@ -4242,6 +4244,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       const rawMetadata = await this.readJsonWithSizeLimit(response, OAuthProviderImpl.CIMD_MAX_SIZE_BYTES);
 
       const clientId = OAuthProviderImpl.validateStringField(rawMetadata.client_id, 'client_id');
+      const clientName = OAuthProviderImpl.validateStringField(rawMetadata.client_name, 'client_name');
       const redirectUris = OAuthProviderImpl.validateStringArray(rawMetadata.redirect_uris, 'redirect_uris');
       const tokenEndpointAuthMethod = OAuthProviderImpl.validateStringField(
         rawMetadata.token_endpoint_auth_method,
@@ -4251,6 +4254,10 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // Validate that client_id matches the URL (required by spec)
       if (clientId !== metadataUrl) {
         throw new Error(`client_id "${clientId}" does not match metadata URL "${metadataUrl}"`);
+      }
+
+      if (!clientName?.trim()) {
+        throw new Error('client_name is required and must not be empty');
       }
 
       if (!redirectUris || redirectUris.length === 0) {
@@ -4267,7 +4274,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return {
         clientId,
         redirectUris,
-        clientName: OAuthProviderImpl.validateStringField(rawMetadata.client_name, 'client_name'),
+        clientName,
         clientUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.client_uri, 'client_uri'),
         logoUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.logo_uri, 'logo_uri'),
         policyUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.policy_uri, 'policy_uri'),


### PR DESCRIPTION
## Summary

Tighten CIMD validation while preserving current client compatibility:

- require a non-empty `client_name`
- support only the implemented method, `none`
- negotiate `none` from `token_endpoint_auth_methods_supported` choices
- reject singular `private_key_jwt`, which the token endpoint has never implemented

Verified clients:

- Claude.ai: `none`
- Claude Code: `none`
- ChatGPT: advertises `none` and `private_key_jwt`; this PR selects `none`
- Cloudflare AI Playground: Agents SDK client metadata uses `none` (DCR)

## Tests

- missing and blank `client_name`
- ChatGPT-style authentication method choices
- singular `private_key_jwt` rejection
- `none` success
- existing CIMD security and cache coverage

Validated with Node 24:

- `npm run check` (545 tests)
- `npm run build`
- `npx prettier --check .`
