### PR TITLE
fix: validate protected resource metadata configuration

### DIFF
--- a/.changeset/green-lions-metadata.md
+++ b/.changeset/green-lions-metadata.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Validate protected resource metadata at construction time. Reject empty or invalid authorization server issuer lists, invalid resource and scope values, and bearer presentation methods the provider does not implement instead of publishing unusable or misleading RFC 9728 metadata.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { OAuthError, OAuthProvider, type OAuthHelpers, type Token } from '../src/oauth-provider';
+import {
+  OAuthError,
+  OAuthProvider,
+  type OAuthHelpers,
+  type OAuthProviderOptions,
+  type Token,
+} from '../src/oauth-provider';
 import type { ExecutionContext } from '@cloudflare/workers-types';
 // We're importing WorkerEntrypoint from our mock implementation
 // The actual import is mocked in setup.ts
@@ -609,7 +615,7 @@ describe('OAuthProvider', () => {
           resource: 'https://api.example.com',
           authorization_servers: ['https://auth.example.com'],
           scopes_supported: ['custom:read', 'custom:write'],
-          bearer_methods_supported: ['header', 'body'],
+          bearer_methods_supported: ['header'],
           resource_name: 'Example API',
         },
       });
@@ -623,8 +629,53 @@ describe('OAuthProvider', () => {
       expect(metadata.resource).toBe('https://api.example.com');
       expect(metadata.authorization_servers).toEqual(['https://auth.example.com']);
       expect(metadata.scopes_supported).toEqual(['custom:read', 'custom:write']);
-      expect(metadata.bearer_methods_supported).toEqual(['header', 'body']);
+      expect(metadata.bearer_methods_supported).toEqual(['header']);
       expect(metadata.resource_name).toBe('Example API');
+    });
+
+    it.each<[string, OAuthProviderOptions['resourceMetadata'], string]>([
+      [
+        'an empty authorization server list',
+        { authorization_servers: [] },
+        'resourceMetadata.authorization_servers must contain at least one issuer',
+      ],
+      [
+        'an insecure authorization server issuer',
+        { authorization_servers: ['http://auth.example.com'] },
+        'resourceMetadata.authorization_servers must contain valid HTTPS issuer URLs',
+      ],
+      [
+        'an issuer with a query',
+        { authorization_servers: ['https://auth.example.com?tenant=a'] },
+        'resourceMetadata.authorization_servers must contain valid HTTPS issuer URLs',
+      ],
+      [
+        'an invalid resource identifier',
+        { resource: 'mcp.example.com' },
+        'resourceMetadata.resource must be an absolute HTTP(S) URI without a fragment',
+      ],
+      [
+        'an invalid scope token',
+        { scopes_supported: ['scope with spaces'] },
+        'resourceMetadata.scopes_supported must contain valid OAuth scope tokens',
+      ],
+      [
+        'an unsupported bearer method',
+        { bearer_methods_supported: ['body'] },
+        "resourceMetadata.bearer_methods_supported only supports 'header'",
+      ],
+    ])('should reject protected resource metadata with %s', (_label, resourceMetadata, message) => {
+      expect(
+        () =>
+          new OAuthProvider({
+            apiRoute: ['/api/'],
+            apiHandler: TestApiHandler,
+            defaultHandler: testDefaultHandler,
+            authorizeEndpoint: '/authorize',
+            tokenEndpoint: '/oauth/token',
+            resourceMetadata,
+          })
+      ).toThrow(message);
     });
 
     it('should fall back to top-level scopesSupported when resourceMetadata.scopes_supported is not set', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1407,6 +1407,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       );
     }
 
+    this.validateResourceMetadataOptions(this.options.resourceMetadata);
     this.validateEmaOptions(this.options.enterpriseManagedAuthorization);
 
     if (this.options.enterpriseManagedAuthorization) {
@@ -1460,6 +1461,40 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     throw new TypeError(
       `${name} must be either an ExportedHandler object with a fetch method or a class extending WorkerEntrypoint`
     );
+  }
+
+  /** Validate configured RFC 9728 protected resource metadata. */
+  private validateResourceMetadataOptions(options: OAuthProviderOptions<Env>['resourceMetadata']): void {
+    if (!options) return;
+
+    if (options.resource && !validateResourceUri(options.resource)) {
+      throw new TypeError('resourceMetadata.resource must be an absolute HTTP(S) URI without a fragment');
+    }
+
+    if (options.authorization_servers !== undefined) {
+      if (options.authorization_servers.length === 0) {
+        throw new TypeError('resourceMetadata.authorization_servers must contain at least one issuer');
+      }
+      for (const issuer of options.authorization_servers) {
+        let parsed: URL;
+        try {
+          parsed = new URL(issuer);
+        } catch {
+          throw new TypeError('resourceMetadata.authorization_servers must contain valid HTTPS issuer URLs');
+        }
+        if (parsed.protocol !== 'https:' || parsed.search || parsed.hash) {
+          throw new TypeError('resourceMetadata.authorization_servers must contain valid HTTPS issuer URLs');
+        }
+      }
+    }
+
+    if (options.scopes_supported?.some((scope) => !isValidOAuthScopeToken(scope))) {
+      throw new TypeError('resourceMetadata.scopes_supported must contain valid OAuth scope tokens');
+    }
+
+    if (options.bearer_methods_supported?.some((method) => method !== 'header')) {
+      throw new TypeError("resourceMetadata.bearer_methods_supported only supports 'header'");
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Validate configured RFC 9728 Protected Resource Metadata at provider construction time.

The provider now rejects:

- an empty `authorization_servers` list (MCP requires at least one issuer)
- malformed, insecure, query-bearing, or fragment-bearing authorization server issuer URLs
- invalid protected resource identifiers
- invalid OAuth scope tokens
- bearer presentation methods other than `header`

The final item fixes false metadata advertising: the provider only accepts bearer tokens through the Authorization header, but previously allowed callers to advertise unsupported `body` methods.

Defaults remain valid and continue to emit a non-empty authorization server list with header bearer support.

## Tests

- each invalid configuration above
- valid custom metadata
- default and cross-origin authorization server derivation

Validated with Node 24:

- `npm run check` (532 tests)
- `npm run build`
- `npx prettier --check .`
