### PR TITLE
feat: derive resource policy from protected resource metadata

### DIFF
--- a/.changeset/tough-birds-resource.md
+++ b/.changeset/tough-birds-resource.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Use `resourceMetadata.resource` as the strict RFC 8707 resource policy. Configured deployments now require that exact resource throughout authorization, token issuance, and access-token validation. Unconfigured deployments remain interoperable by inheriting requested resources and defaulting omitted authorization resources to the request origin.

--- a/README.md
+++ b/README.md
@@ -527,13 +527,20 @@ Call it repeatedly via a cron trigger — deleted records disappear from KV, so 
 
 ## Protected Resource Metadata (RFC 9728)
 
-The library automatically serves a `/.well-known/oauth-protected-resource` endpoint. By default, it uses the request origin as the resource identifier and the token endpoint's origin as the authorization server. You can customize this with the `resourceMetadata` option:
+The library automatically serves a `/.well-known/oauth-protected-resource` endpoint. By default, it derives the resource identifier from the metadata request and the authorization server from the token endpoint.
+
+Resource policy follows the configuration:
+
+- When `resourceMetadata.resource` is configured, authorization requests and token requests must contain that one exact resource. Issued and externally resolved access tokens must have that exact audience.
+- Without an explicitly configured resource, valid RFC 8707 resource indicators are accepted. Token and refresh requests may omit `resource` and inherit it from the authorization grant. If the authorization request also omits it, the provider uses the request origin as the RFC 8707 default and issues an origin-bound token.
+
+The origin default is suitable for a co-located authorization server and resource server. Split deployments and deployments that require path-level audience isolation should configure the canonical protected resource explicitly:
 
 ```ts
 new OAuthProvider({
   // ... other options ...
   resourceMetadata: {
-    resource: 'https://api.example.com',
+    resource: 'https://api.example.com/mcp',
     authorization_servers: ['https://auth.example.com'],
     scopes_supported: ['read', 'write'],
     bearer_methods_supported: ['header'],

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -5465,12 +5465,20 @@ describe('OAuthProvider', () => {
       const clientSecret = client.client_secret;
       const redirectUri = 'https://client.example.com/callback';
 
-      // Get an auth code
-      const authRequest = createMockRequest(
-        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
-          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-          `&scope=read%20write&state=xyz123`
-      );
+      // Get an auth code for the same resource set that will be requested at
+      // the token endpoint. RFC 8707 does not allow a token request to add a
+      // resource that was absent from the authorization grant.
+      const authorizationUrl = new URL('https://example.com/authorize');
+      authorizationUrl.searchParams.set('response_type', 'code');
+      authorizationUrl.searchParams.set('client_id', clientId);
+      authorizationUrl.searchParams.set('redirect_uri', redirectUri);
+      authorizationUrl.searchParams.set('scope', 'read write');
+      authorizationUrl.searchParams.set('state', 'xyz123');
+      if (resource !== undefined) {
+        const resources = Array.isArray(resource) ? resource : [resource];
+        resources.forEach((value) => authorizationUrl.searchParams.append('resource', value));
+      }
+      const authRequest = createMockRequest(authorizationUrl.toString());
 
       const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
       const location = authResponse.headers.get('Location')!;
@@ -5565,7 +5573,7 @@ describe('OAuthProvider', () => {
       expect(api3Error.error).toBe('invalid_token');
     });
 
-    it('should accept token without audience claim (backward compatibility)', async () => {
+    it('should accept the origin audience default when the client omits resource', async () => {
       const accessToken = await getAccessTokenWithResource(undefined);
 
       const apiRequest = createMockRequest('https://example.com/api/test', 'GET', {
@@ -6125,6 +6133,22 @@ describe('OAuthProvider', () => {
       expect(data.success).toBe(true);
     });
 
+    it('should preserve a query component that is part of the audience', async () => {
+      const accessToken = await getAccessTokenWithResource('https://example.com/api/test?tenant=one');
+      const request = (url: string) =>
+        createMockRequest(url, 'GET', {
+          Authorization: `Bearer ${accessToken}`,
+        });
+
+      expect(
+        (await oauthProvider.fetch(request('https://example.com/api/test?tenant=one'), mockEnv, mockCtx)).status
+      ).toBe(200);
+      expect((await oauthProvider.fetch(request('https://example.com/api/test'), mockEnv, mockCtx)).status).toBe(401);
+      expect(
+        (await oauthProvider.fetch(request('https://example.com/api/test?tenant=two'), mockEnv, mockCtx)).status
+      ).toBe(401);
+    });
+
     it('should accept trailing slash as sub-path of audience (prefix matching)', async () => {
       const accessToken = await getAccessTokenWithResource('https://example.com/api/test');
 
@@ -6271,6 +6295,283 @@ describe('OAuthProvider', () => {
       const tokens = await tokenResponse.json<any>();
       expect(tokens.access_token).toBeDefined();
       expect(tokens.resource).toBe('https://api1.example.com');
+    });
+  });
+
+  describe('Configured resource policy and RFC 8707 defaults', () => {
+    const configuredResource = 'https://example.com/api';
+    const redirectUri = 'https://client.example.com/callback';
+
+    function createProvider(resource?: string, overrides: Partial<OAuthProviderOptions<TestEnv>> = {}) {
+      return new OAuthProvider<TestEnv>({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        resourceMetadata: resource ? { resource } : { resource_name: 'Test MCP Server' },
+        ...overrides,
+      });
+    }
+
+    async function registerClient(provider: OAuthProvider<TestEnv>) {
+      const response = await provider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: [redirectUri],
+            client_name: 'Resource Policy Client',
+            token_endpoint_auth_method: 'client_secret_basic',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      return response.json<any>();
+    }
+
+    async function authorize(
+      provider: OAuthProvider<TestEnv>,
+      clientId: string,
+      resources?: string[]
+    ): Promise<Response> {
+      const url = new URL('https://example.com/authorize');
+      url.searchParams.set('response_type', 'code');
+      url.searchParams.set('client_id', clientId);
+      url.searchParams.set('redirect_uri', redirectUri);
+      url.searchParams.set('state', 'resource-policy-state');
+      resources?.forEach((resource) => url.searchParams.append('resource', resource));
+      return provider.fetch(createMockRequest(url.toString()), mockEnv, mockCtx);
+    }
+
+    async function exchangeCode(
+      provider: OAuthProvider<TestEnv>,
+      client: any,
+      code: string,
+      resource?: string
+    ): Promise<Response> {
+      const params = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      });
+      if (resource) params.set('resource', resource);
+      return provider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+    }
+
+    it('should bind an omitted resource to the authorization origin without explicit resource configuration', async () => {
+      const provider = createProvider();
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+
+      const response = await exchangeCode(provider, client, code);
+
+      expect(response.status).toBe(200);
+      const tokens = await response.json<any>();
+      expect(tokens.resource).toBe('https://example.com');
+      const apiResponse = await provider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: `Bearer ${tokens.access_token}`,
+        }),
+        mockEnv,
+        mockCtx
+      );
+      expect(apiResponse.status).toBe(200);
+    });
+
+    it('should inherit an authorization resource when the token request omits it', async () => {
+      const provider = createProvider();
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id, ['https://example.com/api']);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+
+      const response = await exchangeCode(provider, client, code);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({ resource: 'https://example.com/api' });
+    });
+
+    it('should not let a token request replace the authorization origin default', async () => {
+      const provider = createProvider();
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+
+      const upscope = await exchangeCode(provider, client, code, 'https://other.example/resource');
+      expect(upscope.status).toBe(400);
+      await expect(upscope.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      const retry = await exchangeCode(provider, client, code);
+      expect(retry.status).toBe(200);
+      await expect(retry.json()).resolves.toMatchObject({ resource: 'https://example.com' });
+    });
+
+    it('should require exactly one configured resource during authorization', async () => {
+      const provider = createProvider(configuredResource);
+      const client = await registerClient(provider);
+
+      await expect(authorize(provider, client.client_id)).rejects.toThrow(
+        `The resource parameter must exactly match ${configuredResource}`
+      );
+      await expect(
+        authorize(provider, client.client_id, [configuredResource, 'https://other.example/resource'])
+      ).rejects.toThrow(`The resource parameter must exactly match ${configuredResource}`);
+      expect((await authorize(provider, client.client_id, [configuredResource])).status).toBe(302);
+    });
+
+    it('should re-apply configured resource policy in completeAuthorization', async () => {
+      const provider = createProvider(configuredResource);
+      await provider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+      const client = await mockEnv.OAUTH_PROVIDER!.createClient({
+        redirectUris: [redirectUri],
+        tokenEndpointAuthMethod: 'none',
+      });
+
+      await expect(
+        mockEnv.OAUTH_PROVIDER!.completeAuthorization({
+          request: {
+            responseType: 'code',
+            clientId: client.clientId,
+            redirectUri,
+            scope: [],
+            state: '',
+          },
+          userId: 'resource-policy-user',
+          metadata: {},
+          scope: [],
+          props: {},
+        })
+      ).rejects.toThrow(`The resource parameter must exactly match ${configuredResource}`);
+    });
+
+    it('should require the exact configured resource at the token endpoint without consuming the code', async () => {
+      const provider = createProvider(configuredResource, { resourceMatchOriginOnly: true });
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id, [configuredResource]);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+
+      const missing = await exchangeCode(provider, client, code);
+      expect(missing.status).toBe(400);
+      await expect(missing.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      const broad = await exchangeCode(provider, client, code, 'https://example.com');
+      expect(broad.status).toBe(400);
+      await expect(broad.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      const exact = await exchangeCode(provider, client, code, configuredResource);
+      expect(exact.status).toBe(200);
+      await expect(exact.json()).resolves.toMatchObject({ resource: configuredResource });
+    });
+
+    it('should require the exact configured resource during refresh', async () => {
+      const provider = createProvider(configuredResource);
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id, [configuredResource]);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      const tokenResponse = await exchangeCode(provider, client, code, configuredResource);
+      const tokens = await tokenResponse.json<any>();
+      const refresh = async (resource?: string) => {
+        const params = new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: tokens.refresh_token,
+          client_id: client.client_id,
+          client_secret: client.client_secret,
+        });
+        if (resource) params.set('resource', resource);
+        return provider.fetch(
+          createMockRequest(
+            'https://example.com/oauth/token',
+            'POST',
+            { 'Content-Type': 'application/x-www-form-urlencoded' },
+            params.toString()
+          ),
+          mockEnv,
+          mockCtx
+        );
+      };
+
+      expect((await refresh()).status).toBe(400);
+      expect((await refresh('https://example.com')).status).toBe(400);
+      const exact = await refresh(configuredResource);
+      expect(exact.status).toBe(200);
+      await expect(exact.json()).resolves.toMatchObject({ resource: configuredResource });
+    });
+
+    it('should require the exact configured resource during token exchange', async () => {
+      const provider = createProvider(configuredResource, { allowTokenExchangeGrant: true });
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id, [configuredResource]);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      const tokenResponse = await exchangeCode(provider, client, code, configuredResource);
+      const tokens = await tokenResponse.json<any>();
+
+      await expect(mockEnv.OAUTH_PROVIDER!.exchangeToken({ subjectToken: tokens.access_token })).rejects.toMatchObject({
+        code: 'invalid_target',
+      });
+      const exchanged = await mockEnv.OAUTH_PROVIDER!.exchangeToken({
+        subjectToken: tokens.access_token,
+        aud: configuredResource,
+      });
+      expect(exchanged.resource).toBe(configuredResource);
+    });
+
+    it('should reject a legacy origin-wide internal audience when a path resource is configured', async () => {
+      const permissiveProvider = createProvider();
+      const client = await registerClient(permissiveProvider);
+      const authorization = await authorize(permissiveProvider, client.client_id);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      const tokenResponse = await exchangeCode(permissiveProvider, client, code);
+      const tokens = await tokenResponse.json<any>();
+      const strictProvider = createProvider(configuredResource);
+
+      const response = await strictProvider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: `Bearer ${tokens.access_token}`,
+        }),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toMatchObject({
+        error: 'invalid_token',
+        error_description: 'Access token is not bound to the configured resource',
+      });
+    });
+
+    it('should reject absent and broader external audiences when a resource is configured', async () => {
+      const request = () =>
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: 'Bearer external-token',
+        });
+      const withoutAudience = createProvider(configuredResource, {
+        resolveExternalToken: async () => ({ props: { external: true } }),
+      });
+      const broadAudience = createProvider(configuredResource, {
+        resolveExternalToken: async () => ({ props: { external: true }, audience: 'https://example.com' }),
+      });
+      const exactAudience = createProvider(configuredResource, {
+        resolveExternalToken: async () => ({ props: { external: true }, audience: configuredResource }),
+      });
+
+      expect((await withoutAudience.fetch(request(), mockEnv, mockCtx)).status).toBe(401);
+      expect((await broadAudience.fetch(request(), mockEnv, mockCtx)).status).toBe(401);
+      expect((await exactAudience.fetch(request(), mockEnv, mockCtx)).status).toBe(200);
     });
   });
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -489,6 +489,7 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
    * with an origin-only resource (e.g. `https://server.com`) to be used with
    * path-aware resource requests (e.g. `https://server.com/mcp`), enabling seamless
    * migration from pre-0.4.0 versions that stored origin-only resource URIs.
+   * Explicit `resourceMetadata.resource` configuration always uses exact matching.
    *
    * Defaults to false (strict exact matching per RFC 8707).
    */
@@ -504,7 +505,11 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   resourceMetadata?: {
     /**
      * The protected resource identifier URL (RFC 9728 `resource` field).
-     * If not set, defaults to the request URL's origin.
+     *
+     * Configuring this value pins authorization requests, token requests, and
+     * access-token audiences to this exact resource. If omitted, the provider
+     * accepts valid RFC 8707 resource indicators and uses the authorization
+     * request origin as the default when the client does not send one.
      */
     resource?: string;
     /**
@@ -2329,31 +2334,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       }
     }
 
-    // Parse and validate the resource parameter before exchanging the authorization code (RFC 8707)
-    // Validate downscoping: token request resources must be a subset of grant resources
-    const originOnly = !!this.options.resourceMatchOriginOnly;
-    if (body.resource && grantData.resource) {
-      const requestedResources = Array.isArray(body.resource) ? body.resource : [body.resource];
-      const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
-
-      // Check that all requested resources are in the granted resources
-      for (const requested of requestedResources) {
-        if (!grantedResources.some((granted) => resourceMatches(requested, granted, originOnly))) {
-          return this.createErrorResponse('invalid_target', {
-            description: 'Requested resource was not included in the authorization request',
-          });
-        }
-      }
-    }
-
-    // Use resource from token request if provided, otherwise use resource from grant
-    const audience = parseResourceParameter(body.resource || grantData.resource);
-    if ((body.resource || grantData.resource) && !audience) {
-      // RFC 8707 Section 2: invalid or unacceptable resource
-      return this.createErrorResponse('invalid_target', {
-        description: 'The resource parameter must be a valid absolute URI without a fragment',
-      });
-    }
+    // Resolve the token audience before consuming the authorization code.
+    const audience = this.resolveTokenResource(body.resource, grantData.resource);
 
     // Define the access token TTL, may be updated by callback if provided
     let accessTokenTTL = this.options.accessTokenTTL!;
@@ -2577,25 +2559,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       }
     }
 
-    // Validate the requested resource before callbacks, token rotation, or storage writes.
-    const originOnly = !!this.options.resourceMatchOriginOnly;
-    if (body.resource && grantData.resource) {
-      const requestedResources = Array.isArray(body.resource) ? body.resource : [body.resource];
-      const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
-      for (const requested of requestedResources) {
-        if (!grantedResources.some((granted) => resourceMatches(requested, granted, originOnly))) {
-          return this.createErrorResponse('invalid_target', {
-            description: 'Requested resource was not included in the authorization request',
-          });
-        }
-      }
-    }
-    const audience = parseResourceParameter(body.resource || grantData.resource);
-    if ((body.resource || grantData.resource) && !audience) {
-      return this.createErrorResponse('invalid_target', {
-        description: 'The resource parameter must be a valid absolute URI without a fragment',
-      });
-    }
+    // Resolve the token audience before callbacks, rotation, or storage writes.
+    const audience = this.resolveTokenResource(body.resource, grantData.resource);
 
     // Generate new access token with embedded user and grant IDs
     const accessTokenSecret = generateRandomString(TOKEN_LENGTH);
@@ -2862,34 +2827,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // An exchanged token inherits the subject token's scopes unless a narrower subset is requested.
     let tokenScopes: string[] = this.downscope(requestedScopes, tokenSummary.scope);
 
-    // Parse and validate resource parameter (RFC 8707) if provided
-    const originOnly = !!this.options.resourceMatchOriginOnly;
-    let newAudience: string | string[] | undefined = tokenSummary.audience;
-    if (requestedResource) {
-      // Validate downscoping: requested resources must be subset of grant resources if grant had resources
-      if (grantData.resource) {
-        const requestedResources = Array.isArray(requestedResource) ? requestedResource : [requestedResource];
-        const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
-
-        // Check that all requested resources are in the granted resources
-        for (const requested of requestedResources) {
-          if (!grantedResources.some((granted) => resourceMatches(requested, granted, originOnly))) {
-            throw new OAuthError('invalid_target', {
-              description: 'Requested resource was not included in the authorization request',
-            });
-          }
-        }
-      }
-
-      // Parse and validate the resource parameter
-      const parsedResource = parseResourceParameter(requestedResource);
-      if (!parsedResource) {
-        throw new OAuthError('invalid_target', {
-          description: 'The resource parameter must be a valid absolute URI without a fragment',
-        });
-      }
-      newAudience = parsedResource;
+    const configuredResource = this.options.resourceMetadata?.resource;
+    if (configuredResource && !isExactResource(tokenSummary.audience, configuredResource)) {
+      throw new OAuthError('invalid_target', {
+        description: 'Subject token is not bound to the configured resource',
+      });
     }
+    const newAudience = this.resolveTokenResource(requestedResource, grantData.resource);
 
     // Determine TTL for new token
     const now = Math.floor(Date.now() / 1000);
@@ -3754,6 +3698,17 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Internal token data was found in KV, so we check for expiration and set the context props
     if (tokenData) {
+      const configuredResource = this.options.resourceMetadata?.resource;
+      if (configuredResource && !isExactResource(tokenData.audience, configuredResource)) {
+        return this.createErrorResponse('invalid_token', {
+          description: 'Access token is not bound to the configured resource',
+          statusCode: 401,
+          headers: {
+            'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
+          },
+        });
+      }
+
       // Check if token is expired (should be auto-deleted by KV TTL, but double-check)
       const now = Math.floor(Date.now() / 1000);
       if (tokenData.expiresAt < now) {
@@ -3771,7 +3726,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // 'aud' claim when this claim is present, then the JWT MUST be rejected."
       if (tokenData.audience) {
         const requestUrl = new URL(request.url);
-        const resourceServer = `${requestUrl.protocol}//${requestUrl.host}${requestUrl.pathname}`;
+        const resourceServer = `${requestUrl.protocol}//${requestUrl.host}${requestUrl.pathname}${requestUrl.search}`;
         const audiences = Array.isArray(tokenData.audience) ? tokenData.audience : [tokenData.audience];
 
         // Check if any audience matches (RFC 3986: case-insensitive hostname comparison)
@@ -3823,10 +3778,21 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         });
       }
 
+      const configuredResource = this.options.resourceMetadata?.resource;
+      if (configuredResource && !isExactResource(ext.audience, configuredResource)) {
+        return this.createErrorResponse('invalid_token', {
+          description: 'External access token is not bound to the configured resource',
+          statusCode: 401,
+          headers: {
+            'WWW-Authenticate': this.buildWwwAuthenticateHeader(resourceMetadataUrl, 'invalid_token'),
+          },
+        });
+      }
+
       // Validate that tokens were issued specifically for them
       if (ext.audience) {
         const requestUrl = new URL(request.url);
-        const resourceServer = `${requestUrl.protocol}//${requestUrl.host}${requestUrl.pathname}`;
+        const resourceServer = `${requestUrl.protocol}//${requestUrl.host}${requestUrl.pathname}${requestUrl.search}`;
         const audiences = Array.isArray(ext.audience) ? ext.audience : [ext.audience];
 
         // Check if any audience matches (RFC 3986: case-insensitive hostname comparison)
@@ -3964,6 +3930,59 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Standard KV lookup
     const clientKey = `client:${clientId}`;
     return env.OAUTH_KV.get(clientKey, { type: 'json' });
+  }
+
+  /**
+   * Resolves an access-token audience from a token request and its authorization grant.
+   * Explicit resource configuration requires one exact value in both places. Without
+   * configuration, RFC 8707 downscoping is allowed and omission inherits the grant.
+   */
+  private resolveTokenResource(
+    requestedResource: string | string[] | undefined,
+    grantedResource: string | string[] | undefined
+  ): string | string[] | undefined {
+    const requestedAudience = parseResourceParameter(requestedResource);
+    if (requestedResource && !requestedAudience) {
+      throw new OAuthError('invalid_target', {
+        description: 'The resource parameter must be a valid absolute URI without a fragment',
+      });
+    }
+    const grantedAudience = parseResourceParameter(grantedResource);
+    if (grantedResource && !grantedAudience) {
+      throw new OAuthError('invalid_target', {
+        description: 'The authorization grant contains an invalid resource',
+      });
+    }
+
+    const configuredResource = this.options.resourceMetadata?.resource;
+    if (
+      configuredResource &&
+      (!isExactResource(grantedResource, configuredResource) || !isExactResource(requestedResource, configuredResource))
+    ) {
+      throw new OAuthError('invalid_target', {
+        description: `The resource parameter must exactly match ${configuredResource}`,
+      });
+    }
+    if (!configuredResource && requestedResource && !grantedResource) {
+      throw new OAuthError('invalid_target', {
+        description: 'Requested resource was not included in the authorization request',
+      });
+    }
+
+    const originOnly = configuredResource ? false : !!this.options.resourceMatchOriginOnly;
+    if (requestedResource && grantedResource) {
+      const requestedResources = Array.isArray(requestedResource) ? requestedResource : [requestedResource];
+      const grantedResources = Array.isArray(grantedResource) ? grantedResource : [grantedResource];
+      for (const requested of requestedResources) {
+        if (!grantedResources.some((granted) => resourceMatches(requested, granted, originOnly))) {
+          throw new OAuthError('invalid_target', {
+            description: 'Requested resource was not included in the authorization request',
+          });
+        }
+      }
+    }
+
+    return requestedAudience ?? grantedAudience;
   }
 
   /**
@@ -4647,6 +4666,13 @@ function audienceMatches(resourceServerUrl: string, audienceValue: string): bool
       return false;
     }
 
+    // A query-bearing resource identifier names a more specific resource.
+    // Requests may add a query when the audience omits one, but must preserve
+    // the configured query when it is part of the audience.
+    if (audience.search && resource.search !== audience.search) {
+      return false;
+    }
+
     // Origin-only audience matches any path (backward compatibility)
     if (audience.pathname === '/' || audience.pathname === '') {
       return true;
@@ -4682,6 +4708,13 @@ function parseResourceParameter(value: string | string[] | undefined): string | 
   }
 
   return value;
+}
+
+/** Whether a request or audience names one exact configured resource. */
+function isExactResource(value: string | string[] | undefined, configuredResource: string): boolean {
+  return (
+    value === configuredResource || (Array.isArray(value) && value.length === 1 && value[0] === configuredResource)
+  );
 }
 
 /**
@@ -5136,11 +5169,20 @@ class OAuthHelpersImpl implements OAuthHelpers {
     // Using helper function that normalizes and checks in a case-insensitive manner
     validateRedirectUriScheme(redirectUri);
 
-    // Parse and validate resource parameter (RFC 8707)
-    const resource = parseResourceParameter(resourceParam);
+    // Parse and validate the resource parameter (RFC 8707). An explicitly
+    // configured resource is deployment policy and therefore requires one
+    // exact value. Without that policy, RFC 8707 §2.1 allows the authorization
+    // server to use a predefined default; the request origin is the safest
+    // interoperable default available to a co-located AS/RS deployment.
+    let resource = parseResourceParameter(resourceParam);
     if (resourceParam && !resource) {
       throw new Error('The resource parameter must be a valid absolute URI without a fragment');
     }
+    const configuredResource = this.provider.options.resourceMetadata?.resource;
+    if (configuredResource && !isExactResource(resource, configuredResource)) {
+      throw new Error(`The resource parameter must exactly match ${configuredResource}`);
+    }
+    resource ??= url.origin;
 
     // Check if implicit flow is requested but not allowed
     if (responseType === 'token' && !this.provider.options.allowImplicitFlow) {
@@ -5216,6 +5258,18 @@ class OAuthHelpersImpl implements OAuthHelpers {
       );
     }
 
+    // completeAuthorization() is a public helper and callers can pass a
+    // reconstructed AuthRequest rather than one returned directly by
+    // parseAuthRequest(). Re-apply configured resource policy here before
+    // creating any grant. For an unconfigured provider, retain the parsed
+    // resource or use the recorded authorization-server origin as the RFC 8707
+    // default when available.
+    const configuredResource = this.provider.options.resourceMetadata?.resource;
+    if (configuredResource && !isExactResource(options.request.resource, configuredResource)) {
+      throw new Error(`The resource parameter must exactly match ${configuredResource}`);
+    }
+    const effectiveResource = options.request.resource ?? options.request.issuer;
+
     // If requested, collect existing grants for this user+client to revoke AFTER the new grant is created.
     // This avoids a data-loss window where the user has no grants if creation fails.
     let grantsToRevoke: string[] = [];
@@ -5259,8 +5313,8 @@ class OAuthHelpersImpl implements OAuthHelpers {
       const accessTokenWrappedKey = await wrapKeyWithToken(accessToken, encryptionKey);
 
       // Parse and validate resource parameter (RFC 8707) for implicit flow
-      const audience = parseResourceParameter(options.request.resource);
-      if (options.request.resource && !audience) {
+      const audience = parseResourceParameter(effectiveResource);
+      if (effectiveResource && !audience) {
         throw new Error('The resource parameter must be a valid absolute URI without a fragment');
       }
 
@@ -5273,7 +5327,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         metadata: options.metadata,
         encryptedProps: encryptedData,
         createdAt: now,
-        resource: options.request.resource,
+        resource: effectiveResource,
       };
 
       // Store the grant with a key that includes the user ID
@@ -5356,7 +5410,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
         // Store PKCE parameters if provided
         codeChallenge: options.request.codeChallenge,
         codeChallengeMethod: options.request.codeChallengeMethod,
-        resource: options.request.resource,
+        resource: effectiveResource,
       };
 
       // Store the grant with a key that includes the user ID


### PR DESCRIPTION
## Summary

Use `resourceMetadata.resource` as the resource-policy signal instead of adding a separate `requireResourceIndicator` option.

When `resourceMetadata.resource` is configured:

- authorization requests must contain that one exact resource
- authorization-code, refresh-token, and token-exchange requests must repeat that exact resource
- `completeAuthorization()` re-applies the policy before creating a grant
- internal and externally resolved tokens must have that exact audience
- `resourceMatchOriginOnly` cannot weaken the configured policy

When no resource is configured:

- valid RFC 8707 resource indicators are accepted
- token and refresh requests may omit `resource` and inherit it from the authorization grant
- an authorization request that omits `resource` uses its origin as the RFC 8707 default, so newly issued tokens remain origin-bound
- token requests cannot add a resource that was absent from the authorization grant

Audience validation now also preserves a query component when the resource identifier includes one.

## Standards basis

The [MCP 2026-07-28 authorization specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#resource-parameter-implementation) requires MCP clients to include `resource` in authorization and token requests and requires MCP servers to validate that tokens were issued for them.

[RFC 8707 Section 2.1](https://www.rfc-editor.org/rfc/rfc8707.html#section-2.1) also allows an authorization server to process an omitted authorization resource with a predefined default. The request origin provides an interoperable default for co-located authorization and resource servers. Split deployments and deployments needing path-level isolation can opt into exact behavior by configuring the canonical resource.

## Consumer review

Checked current consumers before choosing the configuration signal:

- `cloudflare/mcp` supplies `resourceMetadata.resource_name`, but not `resource`; its existing omission-compatible flow remains on the default path.
- `cloudflare/mcp-server-cloudflare` does not configure a resource and remains on the default path.
- `getsentry/sentry-mcp` owns path-specific protected-resource metadata, sends a resource at authorization, and omits it during code exchange and refresh. The provider continues to inherit that resource from the grant.

Using the whole `resourceMetadata` object as the signal would have broken `cloudflare/mcp`, so only the `resource` field enables exact policy.

## Migration note

This changes the meaning of an existing field. Deployments that already set `resourceMetadata.resource` must ensure clients send that exact value in both authorization and token requests. External token resolvers must return the same audience. This is a minor release.

## Tests

Added coverage for:

- origin-bound defaults when clients omit `resource`
- authorization resource inheritance at code exchange
- prevention of token-request resource upscoping
- exact configured-resource enforcement at authorization, code exchange, refresh, token exchange, and `completeAuthorization()`
- rejection of legacy broad internal audiences under a path-specific policy
- internal and external audience validation
- configured query-component preservation
- metadata-only configuration remaining permissive

Validated with Node 22:

- `npm run check` (557 tests)
- `npm run build`
- `npx prettier --check .`
