### PR TITLE
feat: add MCP redirect URI security policy

### DIFF
--- a/.changeset/safe-cats-redirect.md
+++ b/.changeset/safe-cats-redirect.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Add `enforceMcpRedirectUriSecurity` to restrict registered, programmatic, and CIMD redirect URIs to HTTPS or HTTP loopback addresses. This provides the redirect transport policy required by the MCP authorization security specification while preserving private-use URI schemes for non-MCP deployments by default.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,20 @@ Note that `deleteClient()` cascades: it revokes all grants (and their associated
 
 See the `OAuthHelpers` interface definition for full API details.
 
+### MCP redirect URI security
+
+MCP deployments can restrict redirect URIs to HTTPS or HTTP loopback addresses across DCR, programmatic clients,
+and Client ID Metadata Documents:
+
+```ts
+new OAuthProvider({
+  // ... other options ...
+  enforceMcpRedirectUriSecurity: true,
+});
+```
+
+This option defaults to `false` so non-MCP native OAuth applications can continue using private-use URI schemes.
+
 ## Token Exchange Callback
 
 This library allows you to update the `props` value during token exchanges by configuring a callback function. This is useful for scenarios where the application needs to perform additional processing when tokens are issued or refreshed.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1862,6 +1862,65 @@ describe('OAuthProvider', () => {
       });
     });
 
+    describe('MCP redirect URI security', () => {
+      const strictProvider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        clientRegistrationEndpoint: '/oauth/register',
+        enforceMcpRedirectUriSecurity: true,
+      });
+
+      it.each(['http://remote.example.com/callback', 'myapp://callback'])('should reject %s', async (redirectUri) => {
+        const response = await strictProvider.fetch(
+          createMockRequest(
+            'https://example.com/oauth/register',
+            'POST',
+            { 'Content-Type': 'application/json' },
+            JSON.stringify({
+              redirect_uris: [redirectUri],
+              client_name: 'MCP Client',
+              token_endpoint_auth_method: 'none',
+            })
+          ),
+          mockEnv,
+          mockCtx
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+          error: 'invalid_client_metadata',
+          error_description: 'MCP redirect URIs must use HTTPS or an HTTP loopback address',
+        });
+      });
+
+      it.each([
+        'https://client.example.com/callback',
+        'http://localhost:3000/callback',
+        'http://127.0.0.1:8787/callback',
+        'http://[::1]:8787/callback',
+      ])('should accept %s', async (redirectUri) => {
+        const response = await strictProvider.fetch(
+          createMockRequest(
+            'https://example.com/oauth/register',
+            'POST',
+            { 'Content-Type': 'application/json' },
+            JSON.stringify({
+              redirect_uris: [redirectUri],
+              client_name: 'MCP Client',
+              token_endpoint_auth_method: 'none',
+            })
+          ),
+          mockEnv,
+          mockCtx
+        );
+
+        expect(response.status).toBe(201);
+      });
+    });
+
     describe('should allow legitimate URIs', () => {
       const legitimateUris = [
         'https://client.example.com/callback',

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -398,6 +398,15 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   allowPlainPKCE?: boolean;
 
   /**
+   * Restrict redirect URIs to HTTPS or HTTP loopback addresses, as required
+   * by the MCP authorization security specification.
+   *
+   * Defaults to false so non-MCP native applications can continue using
+   * private-use URI schemes.
+   */
+  enforceMcpRedirectUriSecurity?: boolean;
+
+  /**
    * Controls whether OAuth 2.0 Token Exchange (RFC 8693) is allowed.
    * When false, the token exchange grant type will not be advertised in metadata
    * and token exchange requests will be rejected.
@@ -3509,7 +3518,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
       // Validate each redirect URI scheme
       for (const uri of redirectUris) {
-        validateRedirectUriScheme(uri);
+        validateRedirectUriScheme(uri, !!this.options.enforceMcpRedirectUriSecurity);
       }
 
       clientInfo = {
@@ -4175,6 +4184,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       if (!redirectUris || redirectUris.length === 0) {
         throw new Error('redirect_uris is required and must not be empty');
       }
+      for (const uri of redirectUris) {
+        validateRedirectUriScheme(uri, !!this.options.enforceMcpRedirectUriSecurity);
+      }
 
       if (tokenEndpointAuthMethod && !OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(tokenEndpointAuthMethod)) {
         throw new Error(
@@ -4645,7 +4657,7 @@ async function generateTokenId(token: string): Promise<string> {
  * @param redirectUri - The redirect URI to validate
  * @throws Error if the URI uses a blacklisted scheme or contains control characters
  */
-function validateRedirectUriScheme(redirectUri: string): void {
+function validateRedirectUriScheme(redirectUri: string, enforceMcpSecurity = false): void {
   // List of dangerous pseudo-schemes that should not be allowed
   const dangerousSchemes = ['javascript:', 'data:', 'vbscript:', 'file:', 'mailto:', 'blob:'];
 
@@ -4676,6 +4688,18 @@ function validateRedirectUriScheme(redirectUri: string): void {
   for (const dangerousScheme of dangerousSchemes) {
     if (scheme === dangerousScheme) {
       throw new Error('Invalid redirect URI');
+    }
+  }
+
+  if (enforceMcpSecurity) {
+    let parsed: URL;
+    try {
+      parsed = new URL(normalized);
+    } catch {
+      throw new Error('Invalid redirect URI');
+    }
+    if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLoopbackUri(normalized))) {
+      throw new Error('MCP redirect URIs must use HTTPS or an HTTP loopback address');
     }
   }
 }
@@ -5014,7 +5038,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
 
     // Validate redirect URI to prevent javascript: URIs / XSS attacks
     // Using helper function that normalizes and checks in a case-insensitive manner
-    validateRedirectUriScheme(redirectUri);
+    validateRedirectUriScheme(redirectUri, !!this.provider.options.enforceMcpRedirectUriSecurity);
 
     // Parse and validate resource parameter (RFC 8707)
     const resource = parseResourceParameter(resourceParam);
@@ -5293,7 +5317,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
 
     // Validate each redirect URI scheme
     for (const uri of newClient.redirectUris) {
-      validateRedirectUriScheme(uri);
+      validateRedirectUriScheme(uri, !!this.provider.options.enforceMcpRedirectUriSecurity);
     }
 
     // Only generate and store client secret for confidential clients


### PR DESCRIPTION
## Summary

Add opt-in `enforceMcpRedirectUriSecurity` for the MCP 2026 redirect transport policy.

When enabled, redirect URIs must be either:

- HTTPS, or
- HTTP loopback (`localhost`, `127.0.0.0/8`, or `::1`)

The policy is applied consistently to Dynamic Client Registration, programmatic clients, authorization requests, and Client ID Metadata Documents.

The option defaults to `false` so non-MCP native OAuth applications can continue using private-use URI schemes such as `myapp://`.

## Tests

- reject remote HTTP and private-use schemes in MCP mode
- accept HTTPS and IPv4/IPv6/localhost loopback HTTP
- preserve existing exact matching and flexible loopback-port behavior
- preserve non-MCP custom scheme compatibility

Validated with Node 24:

- `npm run check` (532 tests)
- `npm run build`
- `npx prettier --check .`
