### PR TITLE
fix: validate refresh resources before rotation

### DIFF
--- a/.changeset/fresh-wolves-resource.md
+++ b/.changeset/fresh-wolves-resource.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Validate refresh-token `resource` parameters before invoking callbacks, rotating refresh tokens, or writing grant state. Invalid or out-of-grant resource requests now return `invalid_target` without mutating the authorization grant.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -6336,6 +6336,57 @@ describe('OAuthProvider', () => {
       expect(refreshedTokens.access_token).toBeDefined();
     });
 
+    it('should reject an invalid refresh resource without rotating or mutating the grant', async () => {
+      const { clientId, clientSecret, code, redirectUri } = await registerClientAndGetCode(
+        originMatchingProvider,
+        'https://api1.example.com'
+      );
+      const exchangeParams = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        client_secret: clientSecret,
+        resource: 'https://api1.example.com',
+      });
+      const tokenResponse = await originMatchingProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          exchangeParams.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const tokens = await tokenResponse.json<any>();
+      const grantKey = (await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys[0].name;
+      const grantBefore = await mockEnv.OAUTH_KV.get(grantKey);
+      const refreshParams = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+        client_id: clientId,
+        client_secret: clientSecret,
+        resource: 'https://evil.example.com/mcp',
+      });
+
+      const response = await originMatchingProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          refreshParams.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: 'invalid_target' });
+      expect(await mockEnv.OAUTH_KV.get(grantKey)).toBe(grantBefore);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(1);
+    });
+
     it('should still reject different origins even with resourceMatchOriginOnly enabled', async () => {
       const { clientId, clientSecret, code, redirectUri } = await registerClientAndGetCode(
         originMatchingProvider,

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2496,6 +2496,26 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       }
     }
 
+    // Validate the requested resource before callbacks, token rotation, or storage writes.
+    const originOnly = !!this.options.resourceMatchOriginOnly;
+    if (body.resource && grantData.resource) {
+      const requestedResources = Array.isArray(body.resource) ? body.resource : [body.resource];
+      const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
+      for (const requested of requestedResources) {
+        if (!grantedResources.some((granted) => resourceMatches(requested, granted, originOnly))) {
+          return this.createErrorResponse('invalid_target', {
+            description: 'Requested resource was not included in the authorization request',
+          });
+        }
+      }
+    }
+    const audience = parseResourceParameter(body.resource || grantData.resource);
+    if ((body.resource || grantData.resource) && !audience) {
+      return this.createErrorResponse('invalid_target', {
+        description: 'The resource parameter must be a valid absolute URI without a fragment',
+      });
+    }
+
     // Generate new access token with embedded user and grant IDs
     const accessTokenSecret = generateRandomString(TOKEN_LENGTH);
     const newAccessToken = `${userId}:${grantId}:${accessTokenSecret}`;
@@ -2674,32 +2694,6 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     // Save the updated grant with TTL if applicable
     await this.saveGrantWithTTL(env, grantKey, grantData, now);
-
-    // Parse and validate resource parameter (RFC 8707)
-    // Validate downscoping: token request resources must be subset of grant resources
-    const originOnly = !!this.options.resourceMatchOriginOnly;
-    if (body.resource && grantData.resource) {
-      const requestedResources = Array.isArray(body.resource) ? body.resource : [body.resource];
-      const grantedResources = Array.isArray(grantData.resource) ? grantData.resource : [grantData.resource];
-
-      // Check that all requested resources are in the granted resources
-      for (const requested of requestedResources) {
-        if (!grantedResources.some((granted) => resourceMatches(requested, granted, originOnly))) {
-          return this.createErrorResponse('invalid_target', {
-            description: 'Requested resource was not included in the authorization request',
-          });
-        }
-      }
-    }
-
-    // Use resource from token request if provided, otherwise use resource from grant
-    const audience = parseResourceParameter(body.resource || grantData.resource);
-    if ((body.resource || grantData.resource) && !audience) {
-      // RFC 8707 Section 2.1: invalid or unacceptable resource
-      return this.createErrorResponse('invalid_target', {
-        description: 'The resource parameter must be a valid absolute URI without a fragment',
-      });
-    }
 
     // Store new access token with denormalized grant information
     const accessTokenData: Token = {


### PR DESCRIPTION
## Summary

Validate refresh-token `resource` parameters before invoking callbacks, rotating refresh tokens, or writing grant/token state.

Previously resource validation happened after rotation state was updated and saved. A refresh request for an invalid or out-of-grant resource could therefore mutate the grant before returning `invalid_target`.

This moves the existing RFC 8707 syntax and downscoping validation ahead of all callback and mutation work. Successful refresh behavior is unchanged.

## Tests

- issue an audience-bound grant
- attempt refresh for a different origin
- assert `invalid_target`
- assert the grant record is byte-for-byte unchanged
- assert no additional access token was written
- preserve path-aware migration behavior

Validated with Node 24:

- `npm run check` (527 tests)
- `npm run build`
- `npx prettier --check .`
