### PR TITLE
feat: add authorization response issuer support

### DIFF
--- a/.changeset/fair-tigers-issuer.md
+++ b/.changeset/fair-tigers-issuer.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Enable RFC 9207 authorization response issuer identification by default. Authorization server metadata advertises support, parsed requests carry the expected issuer for application-owned terminal error responses, and successful code and implicit redirects include `iss`. Legacy handlers can opt out explicitly.

--- a/.changeset/fair-tigers-issuer.md
+++ b/.changeset/fair-tigers-issuer.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': minor
 ---
 
-Enable RFC 9207 authorization response issuer identification by default. Authorization server metadata advertises support, parsed requests carry the expected issuer for application-owned terminal error responses, and successful code and implicit redirects include `iss`. Legacy handlers can opt out explicitly.
+Enable RFC 9207 authorization response issuer identification. Authorization server metadata advertises support, parsed requests carry the expected issuer for application-owned terminal error responses, and successful code and implicit redirects include `iss`.

--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ Other thrown values are re-thrown so unexpected validator bugs remain visible as
 the provider exposes `WWW-Authenticate` and `Retry-After` through CORS so browser clients can read discovery,
 step-up, and backoff guidance.
 
+### Authorization response issuer
+
+RFC 9207 issuer identification is enabled by default. `parseAuthRequest` returns the expected `issuer`; authorization
+handlers must include it in terminal OAuth error redirects. Set `authorizationResponseIssuerEnabled: false` only for
+legacy handlers that cannot yet include `iss` in their error responses.
+
 ## Token Exchange Callback
 
 This library allows you to update the `props` value during token exchanges by configuring a callback function. This is useful for scenarios where the application needs to perform additional processing when tokens are issued or refreshed.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a TypeScript library that implements the provider side of the OAuth 2.1 
 
 - The library acts as a wrapper around your Worker code, which adds authorization for your API endpoints.
 - All token management is handled automatically.
+- Authorization responses include RFC 9207 issuer identification to prevent mix-up attacks.
 - Your API handler is written like a regular fetch handler, but receives the already-authenticated user details as a parameter. No need to perform any checks of your own.
 - The library is agnostic to how you manage and authenticate users.
 - The library is agnostic to how you build your UI. Your authorization flow can be implemented using whatever UI framework you use for everything else.
@@ -300,9 +301,9 @@ step-up, and backoff guidance.
 
 ### Authorization response issuer
 
-RFC 9207 issuer identification is enabled by default. `parseAuthRequest` returns the expected `issuer`; authorization
-handlers must include it in terminal OAuth error redirects. Set `authorizationResponseIssuerEnabled: false` only for
-legacy handlers that cannot yet include `iss` in their error responses.
+RFC 9207 issuer identification is always enabled. Successful authorization responses include `iss` automatically.
+`parseAuthRequest` returns the expected `issuer`; authorization handlers must include it in terminal OAuth error
+redirects. Intermediate identity-provider redirects and local HTML error pages do not need it.
 
 ## Token Exchange Callback
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -512,6 +512,7 @@ describe('OAuthProvider', () => {
       expect(metadata.response_types_supported).toContain('token'); // Implicit flow enabled
       expect(metadata.grant_types_supported).toContain('authorization_code');
       expect(metadata.code_challenge_methods_supported).toContain('S256');
+      expect(metadata.authorization_response_iss_parameter_supported).toBe(true);
       // Implicit flow is enabled in the default test provider, so fragment mode should be advertised
       expect(metadata.response_modes_supported).toContain('query');
       expect(metadata.response_modes_supported).toContain('fragment');
@@ -525,11 +526,13 @@ describe('OAuthProvider', () => {
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         allowImplicitFlow: false,
+        authorizationResponseIssuerEnabled: false,
       });
       const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
       const response = await providerNoImplicit.fetch(request, mockEnv, mockCtx);
       const metadata = await response.json<any>();
       expect(metadata.response_modes_supported).toEqual(['query']);
+      expect(metadata.authorization_response_iss_parameter_supported).toBeUndefined();
     });
 
     it('should not include token response type when implicit flow is disabled', async () => {
@@ -1407,6 +1410,7 @@ describe('OAuthProvider', () => {
       const url = new URL(location!);
       const code = url.searchParams.get('code');
       expect(code).toBeDefined();
+      expect(url.searchParams.get('iss')).toBe('https://example.com');
 
       // Verify a grant was created in KV
       const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
@@ -1578,6 +1582,7 @@ describe('OAuthProvider', () => {
       expect(fragment.get('expires_in')).toBe('3600');
       expect(fragment.get('scope')).toBe('read write');
       expect(fragment.get('state')).toBe('xyz123');
+      expect(fragment.get('iss')).toBe('https://example.com');
 
       // Verify a grant was created in KV
       const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -526,13 +526,12 @@ describe('OAuthProvider', () => {
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         allowImplicitFlow: false,
-        authorizationResponseIssuerEnabled: false,
       });
       const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
       const response = await providerNoImplicit.fetch(request, mockEnv, mockCtx);
       const metadata = await response.json<any>();
       expect(metadata.response_modes_supported).toEqual(['query']);
-      expect(metadata.authorization_response_iss_parameter_supported).toBeUndefined();
+      expect(metadata.authorization_response_iss_parameter_supported).toBe(true);
     });
 
     it('should not include token response type when implicit flow is disabled', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -398,16 +398,6 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   allowPlainPKCE?: boolean;
 
   /**
-   * Include the RFC 9207 `iss` parameter in successful authorization responses
-   * and advertise `authorization_response_iss_parameter_supported`.
-   *
-   * Application-owned terminal authorization error responses must also include
-   * the `issuer` returned by `parseAuthRequest`. Defaults to true; set to false
-   * only for legacy handlers that cannot yet emit `iss` on error redirects.
-   */
-  authorizationResponseIssuerEnabled?: boolean;
-
-  /**
    * Controls whether OAuth 2.0 Token Exchange (RFC 8693) is allowed.
    * When false, the token exchange grant type will not be advertised in metadata
    * and token exchange requests will be rejected.
@@ -2109,9 +2099,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // not implemented: introspection_endpoint_auth_methods_supported
       // not implemented: introspection_endpoint_auth_signing_alg_values_supported
       code_challenge_methods_supported: this.options.allowPlainPKCE !== false ? ['plain', 'S256'] : ['S256'], // PKCE support
-      ...(this.options.authorizationResponseIssuerEnabled !== false
-        ? { authorization_response_iss_parameter_supported: true }
-        : {}),
+      authorization_response_iss_parameter_supported: true,
       // MCP Client ID Metadata Document support (CIMD)
       // Only enabled when global_fetch_strictly_public compat flag is set (for SSRF protection)
       client_id_metadata_document_supported:
@@ -5327,7 +5315,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       if (options.request.state) {
         fragment.set('state', options.request.state);
       }
-      if (this.provider.options.authorizationResponseIssuerEnabled !== false && options.request.issuer) {
+      if (options.request.issuer) {
         fragment.set('iss', options.request.issuer);
       }
 
@@ -5384,7 +5372,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       if (options.request.state) {
         redirectUrl.searchParams.set('state', options.request.state);
       }
-      if (this.provider.options.authorizationResponseIssuerEnabled !== false && options.request.issuer) {
+      if (options.request.issuer) {
         redirectUrl.searchParams.set('iss', options.request.issuer);
       }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -398,6 +398,16 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   allowPlainPKCE?: boolean;
 
   /**
+   * Include the RFC 9207 `iss` parameter in successful authorization responses
+   * and advertise `authorization_response_iss_parameter_supported`.
+   *
+   * Application-owned terminal authorization error responses must also include
+   * the `issuer` returned by `parseAuthRequest`. Defaults to true; set to false
+   * only for legacy handlers that cannot yet emit `iss` on error redirects.
+   */
+  authorizationResponseIssuerEnabled?: boolean;
+
+  /**
    * Controls whether OAuth 2.0 Token Exchange (RFC 8693) is allowed.
    * When false, the token exchange grant type will not be advertised in metadata
    * and token exchange requests will be rejected.
@@ -706,6 +716,12 @@ export interface AuthRequest {
    * Resource parameter indicating target resource(s) (RFC 8707)
    */
   resource?: string | string[];
+
+  /**
+   * Authorization server issuer recorded while parsing this request.
+   * Include it as `iss` in successful and error authorization responses.
+   */
+  issuer?: string;
 }
 
 /**
@@ -1982,7 +1998,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   /**
    * Gets the authorization server issuer using the same derivation as RFC 8414 metadata.
    */
-  private getAuthorizationServerIssuer(requestUrl: URL): string {
+  getAuthorizationServerIssuer(requestUrl: URL): string {
     const tokenEndpoint = this.getFullEndpointUrl(this.options.tokenEndpoint, requestUrl);
     return new URL(tokenEndpoint).origin;
   }
@@ -2093,6 +2109,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // not implemented: introspection_endpoint_auth_methods_supported
       // not implemented: introspection_endpoint_auth_signing_alg_values_supported
       code_challenge_methods_supported: this.options.allowPlainPKCE !== false ? ['plain', 'S256'] : ['S256'], // PKCE support
+      ...(this.options.authorizationResponseIssuerEnabled !== false
+        ? { authorization_response_iss_parameter_supported: true }
+        : {}),
       // MCP Client ID Metadata Document support (CIMD)
       // Only enabled when global_fetch_strictly_public compat flag is set (for SSRF protection)
       client_id_metadata_document_supported:
@@ -5119,6 +5138,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
     const state = url.searchParams.get('state') || '';
     const codeChallenge = url.searchParams.get('code_challenge') || undefined;
     const codeChallengeMethod = url.searchParams.get('code_challenge_method') || 'plain';
+    const issuer = this.provider.getAuthorizationServerIssuer(url);
     // RFC 8707 Section 2.1: Multiple resource parameters MAY be used
     const resourceParams = url.searchParams.getAll('resource');
     const resourceParam =
@@ -5173,6 +5193,7 @@ class OAuthHelpersImpl implements OAuthHelpers {
       codeChallenge,
       codeChallengeMethod,
       resource,
+      issuer,
     };
   }
 
@@ -5306,6 +5327,9 @@ class OAuthHelpersImpl implements OAuthHelpers {
       if (options.request.state) {
         fragment.set('state', options.request.state);
       }
+      if (this.provider.options.authorizationResponseIssuerEnabled !== false && options.request.issuer) {
+        fragment.set('iss', options.request.issuer);
+      }
 
       // Set the fragment (hash) part of the URL
       redirectUrl.hash = fragment.toString();
@@ -5359,6 +5383,9 @@ class OAuthHelpersImpl implements OAuthHelpers {
       redirectUrl.searchParams.set('code', authCode);
       if (options.request.state) {
         redirectUrl.searchParams.set('state', options.request.state);
+      }
+      if (this.provider.options.authorizationResponseIssuerEnabled !== false && options.request.issuer) {
+        redirectUrl.searchParams.set('iss', options.request.issuer);
       }
 
       // Revoke old grants AFTER the new grant is successfully stored


### PR DESCRIPTION
## Summary

Enable RFC 9207 authorization response issuer identification for MCP 2026 mix-up protection.

- authorization server metadata advertises `authorization_response_iss_parameter_supported: true`
- `parseAuthRequest` records and returns the authorization server `issuer`
- authorization-code success redirects include `iss` in the query
- implicit success redirects include `iss` in the fragment

The provider controls metadata and successful terminal redirects, so no configuration is needed. Applications own authorization error redirects; when redirecting an OAuth error back to the client, include `AuthRequest.issuer` as `iss`. Intermediate identity-provider redirects and local HTML error pages are not authorization responses to the MCP client and do not need it.

The README feature list and authorization-handler guidance document this behavior.

## Tests

- metadata advertisement
- authorization-code response issuer
- implicit response issuer

Validated with Node 24:

- `npm run check` (546 tests)
- `npm run build`
- `npx prettier --check .`
