### PR TITLE
fix: add protected resource scope guidance

### DIFF
--- a/.changeset/tall-pandas-scopes.md
+++ b/.changeset/tall-pandas-scopes.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Include protected resource scopes in bearer challenges for MCP scope selection and omit `offline_access` from challenges and RFC 9728 `scopes_supported`, since refresh-token issuance is an authorization server capability rather than a protected resource requirement.

--- a/.changeset/tall-pandas-scopes.md
+++ b/.changeset/tall-pandas-scopes.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': minor
 ---
 
-Include protected resource scopes in bearer challenges for MCP scope selection and omit `offline_access` from challenges and RFC 9728 `scopes_supported`, since refresh-token issuance is an authorization server capability rather than a protected resource requirement.
+Separate authorization-server and protected-resource scope configuration. Explicit `resourceMetadata.scopes_supported` values become baseline Bearer challenge guidance, operation-specific `requiredScopes` takes precedence, and `offline_access` is omitted from provider-generated resource-facing scope lists. Deployments relying on the old `scopesSupported` fallback must configure protected-resource scopes explicitly.

--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ RFC 9207 issuer identification is always enabled. Successful authorization respo
 `parseAuthRequest` returns the expected `issuer`; authorization handlers must include it in terminal OAuth error
 redirects. Intermediate identity-provider redirects and local HTML error pages do not need it.
 
+### Protected resource scopes
+
+The provider includes configured protected resource scopes in bearer challenges so MCP clients can select initial
+scopes without guessing. `offline_access` is omitted from both challenges and Protected Resource Metadata because it
+controls authorization server refresh-token issuance rather than access to a protected resource.
+
 ## Token Exchange Callback
 
 This library allows you to update the `props` value during token exchanges by configuring a callback function. This is useful for scenarios where the application needs to perform additional processing when tokens are issued or refreshed.

--- a/README.md
+++ b/README.md
@@ -307,9 +307,18 @@ redirects. Intermediate identity-provider redirects and local HTML error pages d
 
 ### Protected resource scopes
 
-The provider includes configured protected resource scopes in bearer challenges so MCP clients can select initial
-scopes without guessing. `offline_access` is omitted from both challenges and Protected Resource Metadata because it
-controls authorization server refresh-token issuance rather than access to a protected resource.
+Set `resourceMetadata.scopes_supported` to the minimal scopes needed for basic resource functionality. The provider
+publishes them in Protected Resource Metadata and uses them as baseline Bearer challenge guidance. Operation-specific
+`OAuthError.requiredScopes` takes precedence. `scopesSupported` remains authorization-server metadata only, and
+`offline_access` is omitted from every provider-generated resource-facing scope list.
+
+```ts
+new OAuthProvider({
+  scopesSupported: ['files:read', 'files:write', 'offline_access'],
+  resourceMetadata: { scopes_supported: ['files:read'] },
+  // ... other options ...
+});
+```
 
 ## Token Exchange Callback
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -601,7 +601,7 @@ describe('OAuthProvider', () => {
       const metadata = await response.json<any>();
       expect(metadata.resource).toBe('https://example.com');
       expect(metadata.authorization_servers).toEqual(['https://example.com']);
-      expect(metadata.scopes_supported).toEqual(['read', 'write', 'profile']);
+      expect(metadata.scopes_supported).toBeUndefined();
       expect(metadata.bearer_methods_supported).toEqual(['header']);
       expect(metadata.resource_name).toBeUndefined();
     });
@@ -617,7 +617,7 @@ describe('OAuthProvider', () => {
         resourceMetadata: {
           resource: 'https://api.example.com',
           authorization_servers: ['https://auth.example.com'],
-          scopes_supported: ['custom:read', 'custom:write'],
+          scopes_supported: ['custom:read', 'offline_access', 'custom:write', 'custom:read'],
           bearer_methods_supported: ['header'],
           resource_name: 'Example API',
         },
@@ -681,7 +681,7 @@ describe('OAuthProvider', () => {
       ).toThrow(message);
     });
 
-    it('should fall back to top-level scopesSupported when resourceMetadata.scopes_supported is not set', async () => {
+    it('should not infer protected resource requirements from authorization server scopes', async () => {
       const providerWithPartialMetadata = new OAuthProvider({
         apiRoute: ['/api/'],
         apiHandler: TestApiHandler,
@@ -694,23 +694,36 @@ describe('OAuthProvider', () => {
         },
       });
 
-      const request = createMockRequest('https://example.com/.well-known/oauth-protected-resource');
-      const response = await providerWithPartialMetadata.fetch(request, mockEnv, mockCtx);
+      const resourceResponse = await providerWithPartialMetadata.fetch(
+        createMockRequest('https://example.com/.well-known/oauth-protected-resource'),
+        mockEnv,
+        mockCtx
+      );
+      const resourceMetadata = await resourceResponse.json<any>();
+      expect(resourceMetadata.resource).toBe('https://api.example.com');
+      expect(resourceMetadata.authorization_servers).toEqual(['https://example.com']);
+      expect(resourceMetadata.scopes_supported).toBeUndefined();
 
-      const metadata = await response.json<any>();
-      expect(metadata.resource).toBe('https://api.example.com');
-      expect(metadata.authorization_servers).toEqual(['https://example.com']);
-      expect(metadata.scopes_supported).toEqual(['read', 'write']);
+      const authorizationServerResponse = await providerWithPartialMetadata.fetch(
+        createMockRequest('https://example.com/.well-known/oauth-authorization-server'),
+        mockEnv,
+        mockCtx
+      );
+      const authorizationServerMetadata = await authorizationServerResponse.json<any>();
+      expect(authorizationServerMetadata.scopes_supported).toEqual(['read', 'offline_access', 'write', 'read']);
     });
 
-    it('should include resource scopes but not offline_access in bearer challenges', async () => {
+    it('should include explicit resource scopes but not offline_access in bearer challenges', async () => {
       const provider = new OAuthProvider({
         apiRoute: ['/api/'],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'offline_access', 'write'],
+        scopesSupported: ['admin'],
+        resourceMetadata: {
+          scopes_supported: ['read', 'offline_access', 'write', 'read'],
+        },
       });
 
       const response = await provider.fetch(
@@ -724,6 +737,46 @@ describe('OAuthProvider', () => {
       expect(response.status).toBe(401);
       expect(response.headers.get('WWW-Authenticate')).toContain('scope="read write"');
       expect(response.headers.get('WWW-Authenticate')).not.toContain('offline_access');
+      expect(response.headers.get('WWW-Authenticate')).not.toContain('admin');
+    });
+
+    it('should keep missing-credential challenges error-free while providing explicit resource scopes', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resourceMetadata: {
+          scopes_supported: ['read', 'offline_access', 'read'],
+        },
+      });
+
+      const response = await provider.fetch(createMockRequest('https://example.com/api/test'), mockEnv, mockCtx);
+      const challenge = response.headers.get('WWW-Authenticate');
+
+      expect(response.status).toBe(401);
+      expect(challenge).toContain('scope="read"');
+      expect(challenge).not.toContain('offline_access');
+      expect(challenge).not.toContain('error=');
+      expect(await response.text()).toBe('');
+    });
+
+    it('should omit challenge scopes when only authorization server scopes are configured', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        scopesSupported: ['read', 'write', 'admin'],
+      });
+
+      const response = await provider.fetch(createMockRequest('https://example.com/api/test'), mockEnv, mockCtx);
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('WWW-Authenticate')).not.toContain('scope=');
+      expect(response.headers.get('WWW-Authenticate')).not.toContain('error=');
     });
 
     it('should add CORS headers to protected resource metadata endpoint', async () => {
@@ -9407,12 +9460,15 @@ describe('OAuthProvider', () => {
         defaultHandler: testDefaultHandler,
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
+        resourceMetadata: {
+          scopes_supported: ['baseline:read', 'offline_access'],
+        },
         resolveExternalToken: async () => {
           throw new OAuthError('insufficient_scope', {
             description: 'Account Resources: Read is required',
             statusCode: 403,
             headers: { 'X-Trace-Id': 'trace-123' },
-            requiredScopes: ['account:read', 'profile:read', 'account:read'],
+            requiredScopes: ['account:read', 'offline_access', 'profile:read', 'account:read'],
           });
         },
       });
@@ -9427,6 +9483,8 @@ describe('OAuthProvider', () => {
       expect(response.headers.get('WWW-Authenticate')).toBe(
         'Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/test", error="insufficient_scope", scope="account:read profile:read"'
       );
+      expect(response.headers.get('WWW-Authenticate')).not.toContain('baseline:read');
+      expect(response.headers.get('WWW-Authenticate')).not.toContain('offline_access');
       await expect(response.json()).resolves.toEqual({
         error: 'insufficient_scope',
         error_description: 'Account Resources: Read is required',

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -688,7 +688,7 @@ describe('OAuthProvider', () => {
         defaultHandler: testDefaultHandler,
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
+        scopesSupported: ['read', 'offline_access', 'write', 'read'],
         resourceMetadata: {
           resource: 'https://api.example.com',
         },
@@ -701,6 +701,29 @@ describe('OAuthProvider', () => {
       expect(metadata.resource).toBe('https://api.example.com');
       expect(metadata.authorization_servers).toEqual(['https://example.com']);
       expect(metadata.scopes_supported).toEqual(['read', 'write']);
+    });
+
+    it('should include resource scopes but not offline_access in bearer challenges', async () => {
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        scopesSupported: ['read', 'offline_access', 'write'],
+      });
+
+      const response = await provider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', {
+          Authorization: 'Bearer invalid-token',
+        }),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('WWW-Authenticate')).toContain('scope="read write"');
+      expect(response.headers.get('WWW-Authenticate')).not.toContain('offline_access');
     });
 
     it('should add CORS headers to protected resource metadata endpoint', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -2162,6 +2162,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     });
   }
 
+  /** Scopes that are requirements of the protected resource itself. */
+  private getProtectedResourceScopes(): string[] {
+    const configured = this.options.resourceMetadata?.scopes_supported ?? this.options.scopesSupported ?? [];
+    return [...new Set(configured)].filter((scope) => scope !== 'offline_access');
+  }
+
   /**
    * Handles the OAuth Protected Resource Metadata endpoint
    * Implements RFC 9728 for OAuth Protected Resource Metadata
@@ -2175,10 +2181,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     const tokenEndpointUrl = this.getFullEndpointUrl(this.options.tokenEndpoint, requestUrl);
     const authServerOrigin = new URL(tokenEndpointUrl).origin;
 
+    const resourceScopes = this.getProtectedResourceScopes();
     const metadata: Record<string, unknown> = {
       resource: rm?.resource ?? this.deriveResourceIdentifier(requestUrl),
       authorization_servers: rm?.authorization_servers ?? [authServerOrigin],
-      scopes_supported: rm?.scopes_supported ?? this.options.scopesSupported,
+      ...(resourceScopes.length > 0 ? { scopes_supported: resourceScopes } : {}),
       bearer_methods_supported: rm?.bearer_methods_supported ?? ['header'],
     };
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -378,8 +378,9 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   clientRegistrationTTL?: number;
 
   /**
-   * List of scopes supported by this OAuth provider.
-   * If not provided, the 'scopes_supported' field will be omitted from the OAuth metadata.
+   * Scopes supported by the authorization server.
+   * These are advertised only in authorization server metadata; configure
+   * `resourceMetadata.scopes_supported` separately for protected resource requirements.
    */
   scopesSupported?: string[];
 
@@ -526,8 +527,10 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
      */
     authorization_servers?: string[];
     /**
-     * Scopes supported by this protected resource.
-     * If not set, falls back to the top-level scopesSupported option.
+     * Minimal scopes required for basic protected resource functionality.
+     * These scopes are advertised in Protected Resource Metadata and used as
+     * baseline bearer challenge guidance. `offline_access` is omitted because
+     * refresh-token issuance is an authorization server capability.
      */
     scopes_supported?: string[];
     /**
@@ -2162,10 +2165,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     });
   }
 
-  /** Scopes that are requirements of the protected resource itself. */
+  /** Scopes that are baseline requirements of the protected resource itself. */
   private getProtectedResourceScopes(): string[] {
-    const configured = this.options.resourceMetadata?.scopes_supported ?? this.options.scopesSupported ?? [];
-    return [...new Set(configured)].filter((scope) => scope !== 'offline_access');
+    return this.normalizeProtectedResourceScopes(this.options.resourceMetadata?.scopes_supported ?? []);
+  }
+
+  /** Deduplicate resource-facing scopes and remove authorization-server-only capabilities. */
+  private normalizeProtectedResourceScopes(scopes: string[]): string[] {
+    return [...new Set(scopes)].filter((scope) => scope !== 'offline_access');
   }
 
   /**
@@ -4442,8 +4449,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     if (error) {
       header += `, error="${error}"`;
     }
-    if (requiredScopes.length > 0) {
-      header += `, scope="${requiredScopes.join(' ')}"`;
+    const challengeScopes =
+      requiredScopes.length > 0
+        ? this.normalizeProtectedResourceScopes(requiredScopes)
+        : this.getProtectedResourceScopes();
+    if (challengeScopes.length > 0) {
+      header += `, scope="${challengeScopes.join(' ')}"`;
     }
     if (errorDescription) {
       header += `, error_description="${errorDescription}"`;


### PR DESCRIPTION
## Summary

Separate authorization-server scope capabilities from protected-resource requirements and align resource scope guidance with MCP 2026.

- `scopesSupported` is advertised only in authorization server metadata
- explicit `resourceMetadata.scopes_supported` is published in Protected Resource Metadata and used as baseline Bearer challenge guidance
- operation-specific `OAuthError.requiredScopes` takes precedence over the baseline
- provider-generated resource scope lists are deduplicated and omit `offline_access`
- missing-credential challenges remain error-free
- caller-supplied `WWW-Authenticate` headers remain untouched

The provider no longer infers protected-resource requirements from all authorization-server scopes. Deployments relying on that fallback must configure `resourceMetadata.scopes_supported` explicitly with the minimal scopes needed for basic resource functionality.

## Standards basis

MCP 2026 says challenge scopes are authoritative for the current operation and Protected Resource Metadata `scopes_supported` should represent the minimal set needed for basic functionality. It also says protected resources should not advertise `offline_access`, which controls authorization-server refresh-token issuance.

## Tests

Coverage includes:

- explicit resource scopes in metadata and baseline challenges
- no AS-scope inference into resource metadata or challenges
- operation `requiredScopes` precedence
- deduplication and `offline_access` removal
- error-free missing-credential challenges
- authorization-server metadata retaining its full configured scope list

Validated with Node 24:

- `npm run check` — 572 tests
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `git diff --check`
