### PR TITLE
fix: isolate structured external token errors

### DIFF
--- a/.changeset/tidy-rivers-resolve.md
+++ b/.changeset/tidy-rivers-resolve.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': minor
 ---
 
-Convert `OAuthError` thrown by `resolveExternalToken` into structured protected-resource error responses. Standard bearer-token failures receive `WWW-Authenticate` challenges, `requiredScopes` supplies step-up scope guidance, callback headers are preserved, browser clients can read `WWW-Authenticate` and `Retry-After` through CORS, and unexpected errors continue to surface as 500s.
+Add an exported `ExternalTokenError` for intentional structured errors from `resolveExternalToken`. Existing callbacks keep their previous behavior: returning `{ props, audience? }` authenticates, returning `null` returns a generic `401 invalid_token`, and every other thrown value, including `OAuthError`, propagates as an unexpected failure. Standard bearer-token `ExternalTokenError` failures receive `WWW-Authenticate` challenges, `requiredScopes` supplies step-up guidance, callback headers are preserved, and browser clients can read `WWW-Authenticate` and `Retry-After` through CORS.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Use `resolveExternalToken` to authenticate bearer tokens issued by another autho
 only when the token was not found in the provider's internal storage.
 
 ```ts
-import { OAuthError, OAuthProvider } from '@cloudflare/workers-oauth-provider';
+import { ExternalTokenError, OAuthProvider } from '@cloudflare/workers-oauth-provider';
 
 new OAuthProvider({
   // ... other options ...
@@ -267,14 +267,14 @@ new OAuthProvider({
 
     if (result.kind === 'invalid') return null;
     if (result.kind === 'insufficient_scope') {
-      throw new OAuthError('insufficient_scope', {
+      throw new ExternalTokenError('insufficient_scope', {
         description: 'The external token needs the account:read scope',
         statusCode: 403,
         requiredScopes: ['account:read'],
       });
     }
     if (result.kind === 'rate_limited') {
-      throw new OAuthError('temporarily_unavailable', {
+      throw new ExternalTokenError('temporarily_unavailable', {
         description: 'The external authorization server rate limited validation',
         statusCode: 429,
         headers: { 'Retry-After': result.retryAfter },
@@ -290,12 +290,23 @@ The callback has three outcomes:
 
 - Return `{ props, audience? }` to authenticate the request.
 - Return `null` for a generic `401 invalid_token` response.
-- Throw this package's exported `OAuthError` for an intentional structured response. Standard `invalid_token` 401
-  and `insufficient_scope` 403 errors receive a resource-specific `WWW-Authenticate` challenge unless the error
+- Throw this package's exported `ExternalTokenError` for an intentional structured response. Standard `invalid_token`
+  401 and `insufficient_scope` 403 errors receive a resource-specific `WWW-Authenticate` challenge unless the error
   supplies one. Set `requiredScopes` on `insufficient_scope` to include the operation's minimum scopes in the
   challenge for step-up authorization.
 
-Other thrown values are re-thrown so unexpected validator bugs remain visible as 500s. For cross-origin requests,
+`audience` means the protected resource where the credential is accepted, not its issuer, user, upstream API, or
+permissions. A JWT may carry an audience claim. For an opaque API token or PAT, the resolver can supply the local
+resource URI as policy after successful validation. When `resourceMetadata.resource` is configured, `audience` is
+required and must match it exactly.
+
+`WWW-Authenticate` is a standard response header describing the Bearer authentication failure. For MCP it includes
+the protected resource metadata URL and may include `invalid_token`, `insufficient_scope`, and required scopes. It
+never contains the submitted token or `ctx.props`. `ExternalTokenError.description` is returned publicly as
+`error_description`, so it must not contain credentials, upstream response bodies, or private diagnostics.
+
+Other thrown values, including `OAuthError`, are re-thrown so existing callback behavior and unexpected validator
+bugs remain visible as 500s. For cross-origin requests,
 the provider exposes `WWW-Authenticate` and `Retry-After` through CORS so browser clients can read discovery,
 step-up, and backoff guidance.
 
@@ -309,7 +320,7 @@ redirects. Intermediate identity-provider redirects and local HTML error pages d
 
 Set `resourceMetadata.scopes_supported` to the minimal scopes needed for basic resource functionality. The provider
 publishes them in Protected Resource Metadata and uses them as baseline Bearer challenge guidance. Operation-specific
-`OAuthError.requiredScopes` takes precedence. `scopesSupported` remains authorization-server metadata only, and
+`ExternalTokenError.requiredScopes` takes precedence. `scopesSupported` remains authorization-server metadata only, and
 `offline_access` is omitted from every provider-generated resource-facing scope list.
 
 ```ts
@@ -431,9 +442,8 @@ async function refreshUpstream(props) {
 - `options.description` — human-readable text returned in `error_description`.
 - `options.statusCode` — HTTP status code (default `400`).
 - `options.headers` — additional response headers, such as `Retry-After` for transient failures. There is no implicit `Retry-After` default for callback-thrown errors.
-- `options.requiredScopes` — minimum scopes for a protected resource operation. On a structured `403 insufficient_scope` from `resolveExternalToken`, the provider validates, deduplicates, and serializes them into the synthesized `WWW-Authenticate` challenge.
 
-Only `OAuthError` from this package is converted into a structured response. Plain errors, plain objects with a `code` field, and app-local error classes continue to surface as 500s so unexpected failures stay visible. Import `OAuthError` from `@cloudflare/workers-oauth-provider` rather than copying or re-implementing it.
+Only `OAuthError` from this package is converted into a structured token-endpoint response. Plain errors, plain objects with a `code` field, `ExternalTokenError`, and app-local error classes continue to surface as 500s so unexpected failures stay visible. Import `OAuthError` from `@cloudflare/workers-oauth-provider` rather than copying or re-implementing it.
 
 ## Enterprise-Managed Authorization (Experimental)
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, expectTypeOf, beforeEach, vi, afterEach } from 'vitest';
 import {
   CimdFetchError,
+  ExternalTokenError,
   OAuthError,
   OAuthProvider,
   type OAuthHelpers,
   type OAuthProviderOptions,
+  type OAuthTokenErrorCode,
   type Token,
 } from '../src/oauth-provider';
 import type { ExecutionContext } from '@cloudflare/workers-types';
@@ -9029,6 +9031,21 @@ describe('OAuthProvider', () => {
       });
     });
 
+    it('does not convert ExternalTokenError at the token endpoint', async () => {
+      const error = new ExternalTokenError('temporarily_unavailable', {
+        description: 'external validator only',
+        statusCode: 503,
+      });
+      const provider = buildProvider(async (options: any) => {
+        if (options.grantType === 'refresh_token') throw error;
+        return undefined;
+      });
+      await registerClient(provider);
+      const { refreshToken } = await getRefreshToken(provider);
+
+      await expect(refreshWithToken(provider, refreshToken)).rejects.toBe(error);
+    });
+
     it('lets app-local OAuthError classes surface as 500 (use the exported class)', async () => {
       class LocalOAuthError extends Error {
         name = 'OAuthError';
@@ -9457,7 +9474,7 @@ describe('OAuthProvider', () => {
       expect(externalTokenCalls[0].token).toBe('invalid-external-token');
     });
 
-    it('should convert OAuthError from external validation into a structured invalid_token response', async () => {
+    it('should convert ExternalTokenError from external validation into a structured invalid_token response', async () => {
       const provider = new OAuthProvider({
         apiRoute: ['/api/'],
         apiHandler: TestApiHandler,
@@ -9465,7 +9482,7 @@ describe('OAuthProvider', () => {
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         resolveExternalToken: async () => {
-          throw new OAuthError('invalid_token', {
+          throw new ExternalTokenError('invalid_token', {
             description: 'external token expired',
             statusCode: 401,
           });
@@ -9499,7 +9516,7 @@ describe('OAuthProvider', () => {
           scopes_supported: ['baseline:read', 'offline_access'],
         },
         resolveExternalToken: async () => {
-          throw new OAuthError('insufficient_scope', {
+          throw new ExternalTokenError('insufficient_scope', {
             description: 'Account Resources: Read is required',
             statusCode: 403,
             headers: { 'X-Trace-Id': 'trace-123' },
@@ -9527,7 +9544,7 @@ describe('OAuthProvider', () => {
     });
 
     it.each<{
-      code: string;
+      code: OAuthTokenErrorCode;
       description: string;
       status: number;
       headers: Record<string, string>;
@@ -9554,7 +9571,7 @@ describe('OAuthProvider', () => {
           authorizeEndpoint: '/authorize',
           tokenEndpoint: '/oauth/token',
           resolveExternalToken: async () => {
-            throw new OAuthError(code, { description, statusCode: status, headers });
+            throw new ExternalTokenError(code, { description, statusCode: status, headers });
           },
         });
         const request = createMockRequest('https://example.com/api/test', 'GET', {
@@ -9583,7 +9600,7 @@ describe('OAuthProvider', () => {
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         resolveExternalToken: async () => {
-          throw new OAuthError('insufficient_scope', {
+          throw new ExternalTokenError('insufficient_scope', {
             description: 'invalid scope configuration',
             statusCode: 403,
             requiredScopes: ['scope with spaces'],
@@ -9595,7 +9612,7 @@ describe('OAuthProvider', () => {
       });
 
       await expect(provider.fetch(request, mockEnv, mockCtx)).rejects.toThrow(
-        'OAuthError requiredScopes must contain valid OAuth scope tokens'
+        'ExternalTokenError requiredScopes must contain valid OAuth scope tokens'
       );
     });
 
@@ -9608,7 +9625,7 @@ describe('OAuthProvider', () => {
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         resolveExternalToken: async () => {
-          throw new OAuthError('invalid_token', {
+          throw new ExternalTokenError('invalid_token', {
             description: 'external token rejected',
             statusCode: 401,
             headers: { 'www-authenticate': challenge },
@@ -9625,7 +9642,29 @@ describe('OAuthProvider', () => {
       expect(response.headers.get('WWW-Authenticate')).toBe(challenge);
     });
 
-    it('should rethrow non-OAuthError failures from external validation', async () => {
+    it('should preserve the old behavior for OAuthError from external validation', async () => {
+      const error = new OAuthError('invalid_token', {
+        description: 'shared OAuth helper failure',
+        statusCode: 401,
+      });
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => {
+          throw error;
+        },
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: 'Bearer external-token',
+      });
+
+      await expect(provider.fetch(request, mockEnv, mockCtx)).rejects.toBe(error);
+    });
+
+    it('should rethrow ordinary failures from external validation', async () => {
       const provider = new OAuthProvider({
         apiRoute: ['/api/'],
         apiHandler: TestApiHandler,
@@ -9641,6 +9680,28 @@ describe('OAuthProvider', () => {
       });
 
       await expect(provider.fetch(request, mockEnv, mockCtx)).rejects.toThrow('external validator bug');
+    });
+
+    it('should not convert an app-local ExternalTokenError class', async () => {
+      class LocalExternalTokenError extends Error {
+        name = 'ExternalTokenError';
+      }
+      const error = new LocalExternalTokenError('local upstream failure');
+      const provider = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        resolveExternalToken: async () => {
+          throw error;
+        },
+      });
+      const request = createMockRequest('https://example.com/api/test', 'GET', {
+        Authorization: 'Bearer external-token',
+      });
+
+      await expect(provider.fetch(request, mockEnv, mockCtx)).rejects.toBe(error);
     });
 
     it('should prioritize internal tokens over external validation', async () => {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -287,15 +287,19 @@ export interface ResolveExternalTokenInput<Env = Cloudflare.Env> {
  */
 export interface ResolveExternalTokenResult {
   /**
-   * Application-specific properties that will be passed to the API handlers
-   * These properties are set in the execution context (ctx.props) when the external token is validated
+   * Application-specific properties that will be passed to the API handlers.
+   * These properties are set in the execution context (`ctx.props`) after the
+   * external bearer credential is validated.
    */
   props: any;
 
   /**
-   * Audience claim from the external token (RFC 7519 Section 4.1.3)
-   * If provided, will be validated against the resource server identity
+   * Protected resource audience established by the external validator.
    *
+   * A JWT may carry this value as an `aud` claim. For an opaque API token or
+   * PAT, the callback can supply the local resource URI as policy after
+   * successful validation. When `resourceMetadata.resource` is configured,
+   * this value is required and must match it exactly.
    */
   audience?: string | string[];
 }
@@ -456,14 +460,16 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   ) => Promise<TokenExchangeCallbackResult | void> | TokenExchangeCallbackResult | void;
 
   /**
-   * Optional callback function that is called when a provided token was not found in the internal KV.
-   * This allows authentication through external OAuth servers.
-   * For example, if a request includes an authenticated token from a different OAuth authentication server,
-   * the callback can be used to authenticate it and set the context props through it.
+   * Optional callback called when a provided bearer credential was not found
+   * in the internal KV. It can validate an external OAuth access token, opaque
+   * API token, personal access token (PAT), or another bearer credential and
+   * set the application props passed to the protected handler.
    *
    * Return props to authenticate the request, or `null` for a generic `invalid_token` response.
-   * Throw this package's exported {@link OAuthError} to return a structured OAuth error response.
-   * Other thrown errors remain unexpected failures and are re-thrown.
+   * Throw this package's exported {@link ExternalTokenError} to return an intentional
+   * structured error response for an upstream validation failure.
+   * All other thrown errors, including {@link OAuthError}, remain unexpected
+   * failures and are re-thrown for backwards compatibility.
    */
   resolveExternalToken?: (input: ResolveExternalTokenInput<Env>) => Promise<ResolveExternalTokenResult | null>;
 
@@ -2256,31 +2262,38 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   }
 
   /**
-   * Build a structured OAuth error response from an OAuth error.
+   * Build a structured OAuth token-endpoint response from an OAuth error.
    *
-   * The supported form is throwing this package's exported `OAuthError`.
-   * Anything else is re-thrown so unexpected failures still surface as 500s.
-   *
-   * When handling a protected resource request, standard bearer-token errors
-   * receive an RFC 6750 / RFC 9728 challenge unless the caller supplied one.
-   * Use `headers['Retry-After']` for rate-limit / transient-failure backoff
-   * hints (see RFC 7231 §7.1.3 — either an integer seconds value or an
-   * HTTP-date is allowed).
+   * The supported form is throwing this package's exported `OAuthError` from
+   * token issuance or `tokenExchangeCallback`. Anything else is re-thrown so
+   * unexpected failures still surface as 500s.
    */
-  private createOAuthErrorResponse(error: unknown, resourceMetadataUrl?: string): Response | undefined {
+  private createOAuthErrorResponse(error: unknown): Response | undefined {
     if (!(error instanceof OAuthError)) return undefined;
+    return this.createErrorResponse(error.code, error.options);
+  }
 
-    const headers = error.options.headers ?? {};
+  /**
+   * Build a structured protected-resource response from an external-token error.
+   *
+   * Only this package's exported `ExternalTokenError` is converted. Standard
+   * bearer failures receive an RFC 6750 / RFC 9728 challenge unless the caller
+   * supplied one. Other errors retain the pre-existing behavior and are re-thrown.
+   */
+  private createExternalTokenErrorResponse(error: unknown, resourceMetadataUrl: string): Response | undefined {
+    if (!(error instanceof ExternalTokenError)) return undefined;
+
+    const headers = error.headers ?? {};
     const hasChallenge = Object.keys(headers).some((name) => name.toLowerCase() === 'www-authenticate');
     const isBearerError =
       (error.code === 'invalid_token' && error.statusCode === 401) ||
       (error.code === 'insufficient_scope' && error.statusCode === 403);
 
     let challengeHeaders: Record<string, string> | undefined;
-    if (resourceMetadataUrl && isBearerError && !hasChallenge) {
-      const requiredScopes = [...new Set(error.options.requiredScopes ?? [])];
+    if (isBearerError && !hasChallenge) {
+      const requiredScopes = [...new Set(error.requiredScopes ?? [])];
       if (requiredScopes.some((scope) => !isValidOAuthScopeToken(scope))) {
-        throw new TypeError('OAuthError requiredScopes must contain valid OAuth scope tokens');
+        throw new TypeError('ExternalTokenError requiredScopes must contain valid OAuth scope tokens');
       }
       challengeHeaders = {
         ...headers,
@@ -2289,8 +2302,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     return this.createErrorResponse(error.code, {
-      ...error.options,
-      ...(challengeHeaders ? { headers: challengeHeaders } : {}),
+      description: error.description,
+      statusCode: error.statusCode,
+      headers: challengeHeaders ?? headers,
     });
   }
 
@@ -3834,13 +3848,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       (ctx as MutableExecutionContext).props = decryptedProps;
     } else if (this.options.resolveExternalToken) {
       // No token data was found, so we validate the provided token with the provided validator.
-      // Convert only the package's exported OAuthError into a structured response;
-      // unexpected callback failures remain visible as 500s.
+      // Convert only the package's exported ExternalTokenError into a structured response;
+      // every other thrown value retains the pre-existing failure behavior.
       let ext: ResolveExternalTokenResult | null;
       try {
         ext = await this.options.resolveExternalToken({ token: accessToken, request, env });
       } catch (error) {
-        const response = this.createOAuthErrorResponse(error, resourceMetadataUrl);
+        const response = this.createExternalTokenErrorResponse(error, resourceMetadataUrl);
         if (response) return response;
         throw error;
       }
@@ -4560,25 +4574,14 @@ export interface OAuthErrorOptions {
    * number of seconds or an HTTP-date.
    */
   headers?: Record<string, string>;
-
-  /**
-   * Minimum scopes needed for the protected resource operation.
-   *
-   * When `resolveExternalToken` throws a standard bearer-token error with
-   * HTTP 401 or 403, these values are serialized into the synthesized
-   * `WWW-Authenticate` challenge's `scope` parameter. This is especially
-   * useful for step-up authorization after `insufficient_scope`. Each value
-   * must use the OAuth scope-token grammar from RFC 6749 §3.3.
-   */
-  requiredScopes?: string[];
 }
 
 /**
- * Structured OAuth 2.0 error.
+ * Structured OAuth 2.0 token-endpoint error.
  *
- * Throw from a `tokenExchangeCallback`, `resolveExternalToken`, or any code
- * they call to surface a standard OAuth error response
- * (`{ error, error_description }`) instead of a generic `500 Internal Server Error`.
+ * Throw from a `tokenExchangeCallback` or any code it calls to surface a
+ * standard OAuth token response (`{ error, error_description }`) instead of a
+ * generic `500 Internal Server Error`.
  *
  * Anything thrown that is **not** an `OAuthError` continues to surface as
  * a 500 so unexpected failures remain visible — the provider does not
@@ -4632,6 +4635,66 @@ export class OAuthError extends Error {
     this.description = this.options.description;
     this.statusCode = this.options.statusCode;
     this.headers = this.options.headers;
+  }
+}
+
+/** Options accepted by the {@link ExternalTokenError} constructor. */
+export interface ExternalTokenErrorOptions {
+  /**
+   * Public description returned in the OAuth `error_description` field.
+   * Do not include credentials, upstream response bodies, or private diagnostics.
+   */
+  description: string;
+
+  /** HTTP status returned to the protected-resource client. */
+  statusCode: number;
+
+  /** Additional public response headers, such as `Retry-After`. */
+  headers?: Record<string, string>;
+
+  /**
+   * Minimum scopes needed for the protected-resource operation.
+   *
+   * For `403 insufficient_scope`, these values are validated, deduplicated,
+   * and added to the synthesized `WWW-Authenticate` challenge. Each value must
+   * use the OAuth scope-token grammar from RFC 6749 §3.3.
+   */
+  requiredScopes?: string[];
+}
+
+/**
+ * Intentional public error from an external bearer-token validator.
+ *
+ * Throw only from `resolveExternalToken` when an expected validation outcome
+ * should become a structured protected-resource response. Ordinary errors and
+ * {@link OAuthError} retain their pre-existing behavior and propagate as
+ * unexpected failures.
+ */
+export class ExternalTokenError extends Error {
+  /** OAuth error code returned in the response body and, when applicable, challenge. */
+  public readonly code: OAuthTokenErrorCode;
+  /** Public description returned as `error_description`. */
+  public readonly description: string;
+  /** HTTP status returned to the protected-resource client. */
+  public readonly statusCode: number;
+  /** Additional public response headers. */
+  public readonly headers?: Record<string, string>;
+  /** Minimum scopes for an `insufficient_scope` challenge. */
+  public readonly requiredScopes?: string[];
+
+  /**
+   * Creates an intentional external-token validation error.
+   * @param code - Standard OAuth error code to return
+   * @param options - Public response details
+   */
+  constructor(code: OAuthTokenErrorCode, options: ExternalTokenErrorOptions) {
+    super(options.description);
+    this.name = 'ExternalTokenError';
+    this.code = code;
+    this.description = options.description;
+    this.statusCode = options.statusCode;
+    this.headers = options.headers;
+    this.requiredScopes = options.requiredScopes;
   }
 }
 


### PR DESCRIPTION
## Summary

Preserve the original `resolveExternalToken` callback contract while keeping the structured protected-resource errors introduced by #251 opt-in.

- add an exported `ExternalTokenError` and `ExternalTokenErrorOptions`
- convert only this package's `ExternalTokenError` into an intentional structured protected-resource response
- keep existing callback behavior unchanged:
  - `{ props, audience? }` authenticates
  - `null` returns generic `401 invalid_token`
  - ordinary errors, `OAuthError`, plain objects, and app-local lookalike classes propagate as unexpected failures
- keep `OAuthError` scoped to token-endpoint and `tokenExchangeCallback` responses
- retain RFC 6750/RFC 9728 `WWW-Authenticate` synthesis, operation scopes, caller header precedence, and CORS visibility
- clarify that external credentials can be OAuth tokens, opaque API tokens, or PATs, and that `audience` names the local protected resource
- update the existing unreleased changeset rather than adding a second release note

This follows the newly merged `CimdFetchError` precedent: exceptional public behavior requires a distinct exported runtime class instead of changing the meaning of an existing error class.

Related documentation rewrite: #270.

## Compatibility

This behavior has not shipped in npm `0.8.3`. Existing published consumers continue to use commit `6ece742`. Before the next release, this PR restores the pre-#251 behavior for every existing thrown value and reserves structured external-token responses for the new class.

`ExternalTokenError.description` is explicitly public. Its JSDoc warns against including credentials, upstream response bodies, or private diagnostics.

## Validation

Rebased directly on `origin/main` at `0fa9bd5` before commit.

- `npm run check` (576 tests)
- `npm run build`
- `npx prettier --check .`
- `npm pack --dry-run`
- `npx changeset status`
