### PR TITLE
fix: close recent OAuth validation gaps

### DIFF
--- a/.changeset/fail-closed-id-jag-claims.md
+++ b/.changeset/fail-closed-id-jag-claims.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Fail closed when ID-JAG assertions contain unsupported `authorization_details` or `cnf` authorization constraints. These claims now produce a generic `invalid_grant` response before replay reservation, mapping, or token storage.

--- a/.changeset/single-id-jag-audience.md
+++ b/.changeset/single-id-jag-audience.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Require ID-JAG assertions to identify exactly one authorization server audience. Multi-element, duplicate, empty, malformed, and mismatched audience arrays are now rejected before authorization state is written.

--- a/.changeset/valid-client-metadata.md
+++ b/.changeset/valid-client-metadata.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Validate configured scopes and registered OAuth client capabilities. Dynamic registration now applies RFC 7591 defaults, rejects unsupported or inconsistent authentication, grant, and response types before storage, and applies the same capability checks to CIMD metadata.

--- a/.changeset/validate-authorization-response.md
+++ b/.changeset/validate-authorization-response.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Validate authorization response types in both `parseAuthRequest()` and `completeAuthorization()`. Missing, unsupported, and client-disallowed values are rejected after client and redirect URI validation but before grant creation or existing-grant revocation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,12 @@ When in doubt about OAuth behavior, the MCP specification takes precedence for M
 ```
 workers-oauth-provider/
 ├── src/
-│   ├── oauth-provider.ts      # Core provider implementation (~5,900 lines)
+│   ├── oauth-provider.ts      # Core provider implementation
+│   ├── oauth-capabilities.ts  # Pure server/client metadata capability policy
 │   └── ema/                   # Enterprise-Managed Authorization pipeline
 ├── __tests__/
-│   ├── oauth-provider.test.ts # Comprehensive test suite (~13,000 lines)
+│   ├── oauth-provider.test.ts # Comprehensive provider integration suite
+│   ├── oauth-capabilities.test.ts # Pure capability policy tests
 │   ├── setup.ts               # Vitest setup and mocking
 │   └── mocks/
 │       └── cloudflare-workers.ts
@@ -54,7 +56,7 @@ workers-oauth-provider/
 └── README.md                  # Usage documentation
 ```
 
-**Audit-oriented architecture:** Core OAuth behavior remains in `src/oauth-provider.ts`. The experimental Enterprise-Managed Authorization validation pipeline is isolated in `src/ema/` so its JWT and trust-boundary code can be reviewed independently.
+**Audit-oriented architecture:** Request orchestration and storage-backed OAuth behavior remain in `src/oauth-provider.ts`. Pure authorization-server/client capability policy lives in `src/oauth-capabilities.ts`. The experimental Enterprise-Managed Authorization validation pipeline is isolated in `src/ema/` so its JWT and trust-boundary code can be reviewed independently.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ clientRegistrationEndpoint: '/oauth/register';
 
 MCP 2026-07-28 deprecates DCR for new implementations in favor of CIMD. The endpoint remains useful for compatibility with clients that do not support CIMD.
 
+Registration accepts only authentication methods, grants, and response types implemented by the configured provider, and rejects inconsistent grant/response combinations before storage. Omitted metadata uses the RFC 7591 defaults: `client_secret_basic`, `grant_types: ["authorization_code"]`, and `response_types: ["code"]`.
+
 Related options:
 
 - `clientRegistrationTTL` controls the lifetime of dynamically registered clients. The default is 90 days.
@@ -396,7 +398,7 @@ Path-aware audiences use path-boundary prefix matching. A token for `https://exa
 
 ## Scopes and step-up authorization
 
-`scopesSupported` is published in authorization server metadata and is also the default for protected resource metadata. `resourceMetadata.scopes_supported` can override the protected resource value.
+`scopesSupported` is published only in authorization server metadata. Configure `resourceMetadata.scopes_supported` explicitly with the minimal scopes required for basic protected-resource functionality and baseline Bearer challenges.
 
 The application decides which requested scopes to grant through `completeAuthorization({ scope })`. Token and refresh requests can only narrow those scopes.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const defaultHandler: ExportedHandler<Env> = {
     }
 
     // This parses the OAuth parameters and validates the client, redirect URI,
-    // resource indicators, and configured PKCE restrictions.
+    // response type, resource indicators, and configured PKCE restrictions.
     let oauthRequest: AuthRequest;
     try {
       oauthRequest = await env.OAUTH_PROVIDER.parseAuthRequest(request);
@@ -133,18 +133,6 @@ const defaultHandler: ExportedHandler<Env> = {
 
     if (!client) {
       return new Response('Unknown OAuth client', { status: 400 });
-    }
-
-    // MCP uses authorization code flow. Reject unsupported or client-disabled
-    // response types before completeAuthorization().
-    const responseTypeAllowed =
-      oauthRequest.responseType === 'code' && (!client.responseTypes || client.responseTypes.includes('code'));
-    if (!responseTypeAllowed) {
-      const redirect = new URL(oauthRequest.redirectUri);
-      redirect.searchParams.set('error', oauthRequest.responseType ? 'unsupported_response_type' : 'invalid_request');
-      if (oauthRequest.state) redirect.searchParams.set('state', oauthRequest.state);
-      if (oauthRequest.issuer) redirect.searchParams.set('iss', oauthRequest.issuer);
-      return Response.redirect(redirect.toString(), 302);
     }
 
     // Authenticate the user and obtain consent here. Do not automatically
@@ -279,14 +267,13 @@ The package serves RFC 8414 metadata rather than OpenID Connect discovery. MCP a
 
 ## Authorization endpoint
 
-Your `authorizeEndpoint` belongs to the application's `defaultHandler`. A typical flow has four steps:
+Your `authorizeEndpoint` belongs to the application's `defaultHandler`. A typical flow has three steps:
 
-1. Call `parseAuthRequest(request)` to parse the request and validate the client, redirect URI, resource, and PKCE restrictions.
-2. Reject response types that the deployment does not support. MCP uses `code`.
-3. Authenticate the user, show consent, and decide which scopes to grant.
-4. Call `completeAuthorization()` and redirect to its returned `redirectTo` URL.
+1. Call `parseAuthRequest(request)` to validate the client, redirect URI, response type, resource, and PKCE restrictions.
+2. Authenticate the user, show consent, and decide which scopes to grant.
+3. Call `completeAuthorization()` and redirect to its returned `redirectTo` URL.
 
-The explicit response type check is required because `completeAuthorization()` currently treats any response type other than `token` as authorization code flow.
+`completeAuthorization()` repeats response-type validation before writing a grant or revoking existing grants. The application remains responsible for rendering local authorization errors and for constructing any terminal OAuth error redirect only after client and redirect URI validation.
 
 `completeAuthorization()` stores a new grant and, by default, revokes existing grants for the same user and client after the new grant is safely stored. Set `revokeExistingGrants: false` only when the application intentionally allows concurrent grants for the same user and client.
 

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -312,6 +312,14 @@ describe('validateIdJagClaims', () => {
     expect(r).toMatchObject({ ok: false, error: { reason } });
   });
 
+  it.each([
+    ['authorization_details', []],
+    ['cnf', { jkt: 'thumbprint' }],
+  ])('fails closed when unsupported %s is present', (claim, value) => {
+    const r = validateIdJagClaims({ rawClaims: { ...validClaims, [claim]: value }, ...claimsArgs });
+    expect(r).toMatchObject({ ok: false, error: { reason: 'unsupported_claim', claim } });
+  });
+
   it('rejects client_id mismatch', () => {
     const r = validateIdJagClaims({ rawClaims: { ...validClaims, client_id: 'other' }, ...claimsArgs });
     expect(r).toMatchObject({ ok: false, error: { reason: 'client_id_mismatch' } });

--- a/__tests__/ema-validators.test.ts
+++ b/__tests__/ema-validators.test.ts
@@ -293,12 +293,23 @@ describe('validateIdJagClaims', () => {
     expect(r).toMatchObject({ ok: false, error: { reason: 'aud_mismatch' } });
   });
 
-  it('accepts aud as an array containing the expected audience', () => {
+  it('accepts aud as a single-element array containing the expected audience', () => {
     const r = validateIdJagClaims({
-      rawClaims: { ...validClaims, aud: ['https://x.example', 'https://as.example.com'] },
+      rawClaims: { ...validClaims, aud: ['https://as.example.com'] },
       ...claimsArgs,
     });
     expect(r.ok).toBe(true);
+  });
+
+  it.each([
+    [['https://as.example.com', 'https://other.example.com'], 'invalid_claim'],
+    [['https://as.example.com', 'https://as.example.com'], 'invalid_claim'],
+    [[], 'invalid_claim'],
+    [['https://as.example.com', 42], 'invalid_claim'],
+    [['https://other.example.com'], 'aud_mismatch'],
+  ])('rejects unsupported aud array %j', (aud, reason) => {
+    const r = validateIdJagClaims({ rawClaims: { ...validClaims, aud }, ...claimsArgs });
+    expect(r).toMatchObject({ ok: false, error: { reason } });
   });
 
   it('rejects client_id mismatch', () => {

--- a/__tests__/oauth-capabilities.test.ts
+++ b/__tests__/oauth-capabilities.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOAuthServerCapabilities,
+  validateAuthorizationServerScopes,
+  validateClientCapabilities,
+} from '../src/oauth-capabilities';
+
+const defaults = buildOAuthServerCapabilities({
+  allowImplicitFlow: false,
+  allowTokenExchangeGrant: false,
+  enterpriseManagedAuthorization: false,
+});
+
+describe('OAuth server capabilities', () => {
+  it('derives advertised capabilities from enabled provider features', () => {
+    const enabled = buildOAuthServerCapabilities({
+      allowImplicitFlow: true,
+      allowTokenExchangeGrant: true,
+      enterpriseManagedAuthorization: true,
+    });
+
+    expect(defaults).toEqual({
+      grantTypes: ['authorization_code', 'refresh_token'],
+      responseTypes: ['code'],
+      tokenEndpointAuthMethods: ['client_secret_basic', 'client_secret_post', 'none'],
+    });
+    expect(enabled.grantTypes).toEqual([
+      'authorization_code',
+      'refresh_token',
+      'implicit',
+      'urn:ietf:params:oauth:grant-type:token-exchange',
+      'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    ]);
+    expect(enabled.responseTypes).toEqual(['code', 'token']);
+  });
+
+  it.each([
+    [
+      'unsupported authentication method',
+      { tokenEndpointAuthMethod: 'private_key_jwt', grantTypes: ['authorization_code'], responseTypes: ['code'] },
+    ],
+    ['unsupported grant', { tokenEndpointAuthMethod: 'none', grantTypes: ['password'], responseTypes: [] }],
+    ['unsupported response', { tokenEndpointAuthMethod: 'none', grantTypes: [], responseTypes: ['id_token'] }],
+    [
+      'inconsistent code registration',
+      { tokenEndpointAuthMethod: 'none', grantTypes: ['authorization_code'], responseTypes: [] },
+    ],
+  ])('rejects %s', (_label, client) => {
+    expect(() => validateClientCapabilities(defaults, client)).toThrow();
+  });
+
+  it('accepts capabilities that the server advertises', () => {
+    expect(() =>
+      validateClientCapabilities(defaults, {
+        tokenEndpointAuthMethod: 'client_secret_basic',
+        grantTypes: ['authorization_code', 'refresh_token'],
+        responseTypes: ['code'],
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('authorization server scopes', () => {
+  it('accepts distinct OAuth scope tokens', () => {
+    expect(() => validateAuthorizationServerScopes(['read', 'account:write'])).not.toThrow();
+  });
+
+  it.each([[['']], [['scope with spaces']], [['read', 'read']]])('rejects invalid scope configuration %j', (scopes) => {
+    expect(() => validateAuthorizationServerScopes(scopes)).toThrow();
+  });
+});

--- a/__tests__/oauth-capabilities.test.ts
+++ b/__tests__/oauth-capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildOAuthServerCapabilities,
+  validateAuthorizationResponseType,
   validateAuthorizationServerScopes,
   validateClientCapabilities,
 } from '../src/oauth-capabilities';
@@ -48,6 +49,14 @@ describe('OAuth server capabilities', () => {
     ],
   ])('rejects %s', (_label, client) => {
     expect(() => validateClientCapabilities(defaults, client)).toThrow();
+  });
+
+  it.each([
+    ['', ['code'], 'invalid_request'],
+    ['token', ['code', 'token'], 'unsupported_response_type'],
+    ['code', ['token'], 'unauthorized_client'],
+  ])('rejects response type %j against client %j', (responseType, clientResponseTypes, error) => {
+    expect(() => validateAuthorizationResponseType(defaults, responseType, clientResponseTypes)).toThrow(error);
   });
 
   it('accepts capabilities that the server advertises', () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -4348,6 +4348,17 @@ describe('OAuthProvider', () => {
       expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
     });
 
+    it('should reject assertions with multiple audiences without writing authorization state', async () => {
+      const response = await exchangeAssertion(
+        await createAssertion({ aud: ['https://example.com', 'https://other.example.com'] })
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toEqual({ error: 'invalid_grant', error_description: 'Invalid assertion' });
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
+    });
+
     it('should reject assertions from unknown issuers', async () => {
       const response = await exchangeAssertion(await createAssertion({ iss: 'https://unknown-idp.example.com' }));
       expect(response.status).toBe(400);

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1582,6 +1582,78 @@ describe('OAuthProvider', () => {
       expect(grants.keys.length).toBe(1);
     });
 
+    it.each([
+      ['missing response_type', '', 'invalid_request'],
+      ['unsupported response_type', '&response_type=unsupported', 'unsupported_response_type'],
+    ])('should reject %s without creating authorization state', async (_label, responseType, code) => {
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read&state=state-123${responseType}`
+      );
+
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(code);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
+    });
+
+    it('should prioritize a missing response_type over later PKCE validation', async () => {
+      const providerWithoutPlainPkce = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        allowPlainPKCE: false,
+      });
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}&state=state-123`
+      );
+
+      await expect(providerWithoutPlainPkce.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('invalid_request');
+    });
+
+    it('should reject a response type excluded by registered client metadata', async () => {
+      const registrationResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: [redirectUri],
+            client_name: 'Implicit Only Client',
+            token_endpoint_auth_method: 'none',
+            grant_types: ['implicit'],
+            response_types: ['token'],
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const client = await registrationResponse.json<any>();
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${client.client_id}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}&state=state-123` +
+          `&code_challenge=test-challenge&code_challenge_method=plain`
+      );
+
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('unauthorized_client');
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
+    });
+
+    it('should keep unsupported response errors local when the redirect URI is invalid', async () => {
+      const invalidRedirectUri = 'https://attacker.example.com/callback';
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=unsupported&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(invalidRedirectUri)}&state=state-123`
+      );
+
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('Invalid redirect URI');
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
+    });
+
     it('should reject authorization request with invalid redirect URI', async () => {
       // Create an authorization request with an invalid redirect URI
       const invalidRedirectUri = 'https://attacker.example.com/callback';
@@ -1651,6 +1723,41 @@ describe('OAuthProvider', () => {
       expect(grants.keys.length).toBe(0);
     });
 
+    it('should reject unsupported response types in completeAuthorization before storage', async () => {
+      await oauthProvider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+      const helpers = mockEnv.OAUTH_PROVIDER!;
+      const authRequest = await helpers.parseAuthRequest(
+        createMockRequest(
+          `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+            `&redirect_uri=${encodeURIComponent(redirectUri)}&scope=read&state=state-123`
+        )
+      );
+
+      await helpers.completeAuthorization({
+        request: authRequest,
+        userId: 'test-user-123',
+        metadata: {},
+        scope: ['read'],
+        props: {},
+      });
+      const originalGrantKeys = (await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys.map((key) => key.name);
+
+      await expect(
+        helpers.completeAuthorization({
+          request: { ...authRequest, responseType: 'unsupported' },
+          userId: 'test-user-123',
+          metadata: {},
+          scope: ['read'],
+          props: {},
+        })
+      ).rejects.toThrow('unsupported_response_type');
+
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys.map((key) => key.name)).toEqual(
+        originalGrantKeys
+      );
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
+    });
+
     it('should reject completeAuthorization if redirect_uri is invalid', async () => {
       // This test ensures that completeAuthorization re-validates the redirect_uri.
       const authRequest = createMockRequest(
@@ -1692,6 +1799,8 @@ describe('OAuthProvider', () => {
         redirect_uris: ['https://spa-client.example.com/callback'],
         client_name: 'SPA Test Client',
         token_endpoint_auth_method: 'none', // Public client
+        grant_types: ['authorization_code', 'implicit'],
+        response_types: ['code', 'token'],
       };
 
       const request = createMockRequest(
@@ -1791,15 +1900,11 @@ describe('OAuthProvider', () => {
           `&scope=read%20write&state=xyz123`
       );
 
-      // Mock parseAuthRequest to test error handling
-      vi.spyOn(authRequest, 'formData').mockImplementation(() => {
-        throw new Error('The implicit grant flow is not enabled for this provider');
-      });
-
-      // Expect an error response
       await expect(providerWithoutImplicit.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-        'The implicit grant flow is not enabled for this provider'
+        'unsupported_response_type'
       );
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
     });
 
     it('should reject plain PKCE when allowPlainPKCE is false', async () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -4359,6 +4359,18 @@ describe('OAuthProvider', () => {
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
     });
 
+    it.each([
+      ['authorization_details', []],
+      ['cnf', { jkt: 'thumbprint' }],
+    ])('should fail closed on unsupported %s without writing authorization state', async (claim, value) => {
+      const response = await exchangeAssertion(await createAssertion({ [claim]: value }));
+
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toEqual({ error: 'invalid_grant', error_description: 'Invalid assertion' });
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
+    });
+
     it('should reject assertions from unknown issuers', async () => {
       const response = await exchangeAssertion(await createAssertion({ iss: 'https://unknown-idp.example.com' }));
       expect(response.status).toBe(400);

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -496,6 +496,24 @@ describe('OAuthProvider', () => {
         });
       }).not.toThrow();
     });
+
+    it.each([
+      [[''], 'scopesSupported must contain valid OAuth scope tokens'],
+      [['scope with spaces'], 'scopesSupported must contain valid OAuth scope tokens'],
+      [['read', 'read'], 'scopesSupported must not contain duplicate values'],
+    ])('should reject invalid authorization server scopes: %j', (scopesSupported, message) => {
+      expect(
+        () =>
+          new OAuthProvider({
+            apiRoute: '/api/',
+            apiHandler: { fetch: () => Promise.resolve(new Response()) },
+            defaultHandler: testDefaultHandler,
+            authorizeEndpoint: '/authorize',
+            tokenEndpoint: '/oauth/token',
+            scopesSupported,
+          })
+      ).toThrow(message);
+    });
   });
 
   describe('OAuth Metadata Discovery', () => {
@@ -514,6 +532,7 @@ describe('OAuthProvider', () => {
       expect(metadata.response_types_supported).toContain('code');
       expect(metadata.response_types_supported).toContain('token'); // Implicit flow enabled
       expect(metadata.grant_types_supported).toContain('authorization_code');
+      expect(metadata.grant_types_supported).toContain('implicit');
       expect(metadata.code_challenge_methods_supported).toContain('S256');
       expect(metadata.authorization_response_iss_parameter_supported).toBe(true);
       // Implicit flow is enabled in the default test provider, so fragment mode should be advertised
@@ -690,7 +709,7 @@ describe('OAuthProvider', () => {
         defaultHandler: testDefaultHandler,
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'offline_access', 'write', 'read'],
+        scopesSupported: ['read', 'offline_access', 'write'],
         resourceMetadata: {
           resource: 'https://api.example.com',
         },
@@ -712,7 +731,7 @@ describe('OAuthProvider', () => {
         mockCtx
       );
       const authorizationServerMetadata = await authorizationServerResponse.json<any>();
-      expect(authorizationServerMetadata.scopes_supported).toEqual(['read', 'offline_access', 'write', 'read']);
+      expect(authorizationServerMetadata.scopes_supported).toEqual(['read', 'offline_access', 'write']);
     });
 
     it('should include explicit resource scopes but not offline_access in bearer challenges', async () => {
@@ -893,6 +912,23 @@ describe('OAuthProvider', () => {
   });
 
   describe('Client Registration', () => {
+    function registerMetadata(metadata: Record<string, unknown> = {}): Promise<Response> {
+      return oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Metadata Client',
+            ...metadata,
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+    }
+
     it('should register a new client', async () => {
       const clientData = {
         redirect_uris: ['https://client.example.com/callback'],
@@ -956,6 +992,57 @@ describe('OAuthProvider', () => {
       const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
       expect(savedClient).not.toBeNull();
       expect(savedClient.clientSecret).toBeUndefined(); // No secret stored
+    });
+
+    it('should apply RFC 7591 defaults and return the values actually registered', async () => {
+      const response = await registerMetadata();
+
+      expect(response.status).toBe(201);
+      const registeredClient = await response.json<any>();
+      expect(registeredClient.token_endpoint_auth_method).toBe('client_secret_basic');
+      expect(registeredClient.grant_types).toEqual(['authorization_code']);
+      expect(registeredClient.response_types).toEqual(['code']);
+
+      const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
+      expect(savedClient.grantTypes).toEqual(['authorization_code']);
+      expect(savedClient.responseTypes).toEqual(['code']);
+    });
+
+    it('should accept enabled extension grant and response types', async () => {
+      const response = await registerMetadata({
+        token_endpoint_auth_method: 'none',
+        grant_types: [
+          'authorization_code',
+          'refresh_token',
+          'implicit',
+          'urn:ietf:params:oauth:grant-type:token-exchange',
+        ],
+        response_types: ['code', 'token'],
+      });
+
+      expect(response.status).toBe(201);
+      const client = await response.json<any>();
+      expect(client.grant_types).toEqual([
+        'authorization_code',
+        'refresh_token',
+        'implicit',
+        'urn:ietf:params:oauth:grant-type:token-exchange',
+      ]);
+      expect(client.response_types).toEqual(['code', 'token']);
+    });
+
+    it.each([
+      ['unsupported authentication method', { token_endpoint_auth_method: 'private_key_jwt' }],
+      ['unsupported grant type', { grant_types: ['password'], response_types: [] }],
+      ['unsupported response type', { grant_types: [], response_types: ['id_token'] }],
+      ['code without authorization_code', { grant_types: ['refresh_token'], response_types: ['code'] }],
+      ['authorization_code without code', { grant_types: ['authorization_code'], response_types: [] }],
+    ])('should reject %s before storing the client', async (_label, metadata) => {
+      const response = await registerMetadata(metadata);
+
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_client_metadata' });
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'client:' })).keys).toHaveLength(0);
     });
 
     it('should accept http(s) metadata URIs and persist them', async () => {
@@ -10642,6 +10729,30 @@ describe('OAuthProvider', () => {
         };
 
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
+
+        const authRequest = createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          'GET'
+        );
+
+        await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
+      });
+
+      it.each([
+        ['an unsupported grant type', { grant_types: ['password'], response_types: [] }],
+        ['an unsupported response type', { grant_types: [], response_types: ['id_token'] }],
+        ['an inconsistent grant and response type', { grant_types: ['authorization_code'], response_types: [] }],
+      ])('should reject CIMD metadata with %s', async (_label, metadata) => {
+        const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+        globalThis.fetch = vi.fn().mockResolvedValue(
+          createMockFetchResponse({
+            client_id: cimdUrl,
+            client_name: 'Invalid Capabilities Client',
+            redirect_uris: ['https://client.example.com/callback'],
+            token_endpoint_auth_method: 'none',
+            ...metadata,
+          })
+        );
 
         const authRequest = createMockRequest(
           `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -109,7 +109,7 @@ new OAuthProvider({
 });
 ```
 
-The provider validates ID-JAG type, signature, issuer, audience, client binding, resource, timestamps, maximum lifetime, and replay identifier. The audience must be the authorization server issuer as a string or a single-element array. Refresh tokens are not issued for this grant.
+The provider validates ID-JAG type, signature, issuer, audience, client binding, resource, timestamps, maximum lifetime, and replay identifier. The audience must be the authorization server issuer as a string or a single-element array. Assertions containing `authorization_details` or `cnf` fail closed until typed authorization-detail and DPoP processing are implemented. Refresh tokens are not issued for this grant.
 
 The grant requires client authentication by default. Set `allowPublicClients: true` only when public clients, including CIMD clients, must use it and the ID-JAG trust model is appropriate for the deployment.
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -109,7 +109,7 @@ new OAuthProvider({
 });
 ```
 
-The provider validates ID-JAG type, signature, issuer, audience, client binding, resource, timestamps, maximum lifetime, and replay identifier. Refresh tokens are not issued for this grant.
+The provider validates ID-JAG type, signature, issuer, audience, client binding, resource, timestamps, maximum lifetime, and replay identifier. The audience must be the authorization server issuer as a string or a single-element array. Refresh tokens are not issued for this grant.
 
 The grant requires client authentication by default. Set `allowPublicClients: true` only when public clients, including CIMD clients, must use it and the ID-JAG trust model is appropriate for the deployment.
 

--- a/src/ema/result.ts
+++ b/src/ema/result.ts
@@ -31,6 +31,7 @@ export type EmaValidationError =
   | { reason: 'jwks_fetch_failed'; status?: number }
   | { reason: 'invalid_claim'; claim: string }
   | { reason: 'aud_mismatch'; expected: string; got: string | string[] }
+  | { reason: 'unsupported_claim'; claim: 'authorization_details' | 'cnf' }
   | { reason: 'expired'; exp: number; now: number }
   | { reason: 'iat_in_future'; iat: number; now: number; skew: number }
   | { reason: 'nbf_in_future'; nbf: number; now: number; skew: number }
@@ -95,6 +96,7 @@ export function emaErrorToWire(e: EmaValidationError): EmaErrorWireResponse {
     case 'jwks_fetch_failed':
     case 'invalid_claim':
     case 'aud_mismatch':
+    case 'unsupported_claim':
     case 'expired':
     case 'iat_in_future':
     case 'nbf_in_future':

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -174,7 +174,7 @@ interface ValidateClaimsInput {
  *
  * Enforces (in order):
  *   - presence + type of `iss`, `sub`, `aud`, `client_id`, `jti`, `exp`, `iat`
- *   - `aud` contains the AS's expected audience
+ *   - `aud` is the AS's expected audience, as a string or single-element array
  *   - `client_id` matches the authenticated client
  *   - optional `resource` is a valid RFC 8707 URI and matches the AS's configured resource
  *   - the configured resource is used when `resource` is omitted
@@ -223,8 +223,8 @@ export function validateIdJagClaims(input: ValidateClaimsInput): Result<Validate
   const iat = readNumericDateClaim(rawClaims, 'iat');
   if (!iat.ok) return iat;
 
-  const audiences = Array.isArray(aud.value) ? aud.value : [aud.value];
-  if (!audiences.includes(expectedAudience)) {
+  const audience = Array.isArray(aud.value) ? aud.value[0] : aud.value;
+  if (audience !== expectedAudience) {
     return err({ reason: 'aud_mismatch', expected: expectedAudience, got: aud.value });
   }
 
@@ -436,7 +436,7 @@ function readAudienceClaim(claims: Record<string, unknown>): Result<string | str
   if (typeof aud === 'string' && aud.length > 0) {
     return ok(aud);
   }
-  if (Array.isArray(aud) && aud.length > 0 && aud.every((v) => typeof v === 'string' && v.length > 0)) {
+  if (Array.isArray(aud) && aud.length === 1 && typeof aud[0] === 'string' && aud[0].length > 0) {
     return ok(aud);
   }
   return err({ reason: 'invalid_claim', claim: 'aud' });

--- a/src/ema/validators.ts
+++ b/src/ema/validators.ts
@@ -175,6 +175,7 @@ interface ValidateClaimsInput {
  * Enforces (in order):
  *   - presence + type of `iss`, `sub`, `aud`, `client_id`, `jti`, `exp`, `iat`
  *   - `aud` is the AS's expected audience, as a string or single-element array
+ *   - unsupported authorization-bearing claims fail closed
  *   - `client_id` matches the authenticated client
  *   - optional `resource` is a valid RFC 8707 URI and matches the AS's configured resource
  *   - the configured resource is used when `resource` is omitted
@@ -203,6 +204,10 @@ export function validateIdJagClaims(input: ValidateClaimsInput): Result<Validate
 
   const aud = readAudienceClaim(rawClaims);
   if (!aud.ok) return aud;
+
+  for (const claim of ['authorization_details', 'cnf'] as const) {
+    if (rawClaims[claim] !== undefined) return err({ reason: 'unsupported_claim', claim });
+  }
 
   // The MCP EMA profile follows the core ID-JAG specification in making
   // `resource` optional. Keep tokens pinned to this provider's declared

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -1,0 +1,64 @@
+const OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+
+export interface OAuthServerCapabilities {
+  readonly grantTypes: readonly string[];
+  readonly responseTypes: readonly string[];
+  readonly tokenEndpointAuthMethods: readonly string[];
+}
+
+export interface ClientCapabilities {
+  readonly grantTypes: readonly string[];
+  readonly responseTypes: readonly string[];
+  readonly tokenEndpointAuthMethod: string;
+}
+
+export function buildOAuthServerCapabilities(options: {
+  allowImplicitFlow: boolean;
+  allowTokenExchangeGrant: boolean;
+  enterpriseManagedAuthorization: boolean;
+}): OAuthServerCapabilities {
+  return {
+    grantTypes: [
+      'authorization_code',
+      'refresh_token',
+      ...(options.allowImplicitFlow ? ['implicit'] : []),
+      ...(options.allowTokenExchangeGrant ? ['urn:ietf:params:oauth:grant-type:token-exchange'] : []),
+      ...(options.enterpriseManagedAuthorization ? ['urn:ietf:params:oauth:grant-type:jwt-bearer'] : []),
+    ],
+    responseTypes: options.allowImplicitFlow ? ['code', 'token'] : ['code'],
+    tokenEndpointAuthMethods: ['client_secret_basic', 'client_secret_post', 'none'],
+  };
+}
+
+export function validateClientCapabilities(server: OAuthServerCapabilities, client: ClientCapabilities): void {
+  if (!server.tokenEndpointAuthMethods.includes(client.tokenEndpointAuthMethod)) {
+    throw new Error(`Unsupported token_endpoint_auth_method: ${client.tokenEndpointAuthMethod}`);
+  }
+
+  const unsupportedGrant = client.grantTypes.find((grantType) => !server.grantTypes.includes(grantType));
+  if (unsupportedGrant) throw new Error(`Unsupported grant_type: ${unsupportedGrant}`);
+
+  const unsupportedResponse = client.responseTypes.find((responseType) => !server.responseTypes.includes(responseType));
+  if (unsupportedResponse) throw new Error(`Unsupported response_type: ${unsupportedResponse}`);
+
+  if (client.grantTypes.includes('authorization_code') !== client.responseTypes.includes('code')) {
+    throw new Error('grant_types authorization_code and response_types code must be registered together');
+  }
+  if (client.grantTypes.includes('implicit') !== client.responseTypes.includes('token')) {
+    throw new Error('grant_types implicit and response_types token must be registered together');
+  }
+}
+
+export function validateAuthorizationServerScopes(scopes: readonly string[] | undefined): void {
+  if (!scopes) return;
+  if (scopes.some((scope) => !isValidOAuthScopeToken(scope))) {
+    throw new TypeError('scopesSupported must contain valid OAuth scope tokens');
+  }
+  if (new Set(scopes).size !== scopes.length) {
+    throw new TypeError('scopesSupported must not contain duplicate values');
+  }
+}
+
+export function isValidOAuthScopeToken(scopeToken: string): boolean {
+  return OAUTH_SCOPE_TOKEN_PATTERN.test(scopeToken);
+}

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -49,6 +49,20 @@ export function validateClientCapabilities(server: OAuthServerCapabilities, clie
   }
 }
 
+export function validateAuthorizationResponseType(
+  server: OAuthServerCapabilities,
+  responseType: string,
+  clientResponseTypes: readonly string[] | undefined
+): void {
+  if (!responseType) throw new Error('invalid_request: response_type is required');
+  if (!server.responseTypes.includes(responseType)) {
+    throw new Error(`unsupported_response_type: the authorization server does not support ${responseType}`);
+  }
+  if (!(clientResponseTypes ?? ['code']).includes(responseType)) {
+    throw new Error(`unauthorized_client: the client is not registered for response_type ${responseType}`);
+  }
+}
+
 export function validateAuthorizationServerScopes(scopes: readonly string[] | undefined): void {
   if (!scopes) return;
   if (scopes.some((scope) => !isValidOAuthScopeToken(scope))) {

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1,6 +1,13 @@
 import { WorkerEntrypoint } from 'cloudflare:workers';
 
 import {
+  buildOAuthServerCapabilities,
+  isValidOAuthScopeToken,
+  validateAuthorizationServerScopes,
+  validateClientCapabilities,
+  type OAuthServerCapabilities,
+} from './oauth-capabilities';
+import {
   EMA_DEFAULT_CLOCK_SKEW_SECONDS,
   EMA_DEFAULT_MAX_ASSERTION_LIFETIME_SECONDS,
   EMA_ID_JAG_GRANT_PROFILE,
@@ -35,6 +42,7 @@ export type {
   EmaTrustedIssuerResolverInput,
 } from './ema/types';
 export type { EmaValidationError } from './ema/result';
+export { isValidOAuthScopeToken } from './oauth-capabilities';
 
 const PROTECTED_RESOURCE_WELL_KNOWN_PREFIX = '/.well-known/oauth-protected-resource';
 const NO_CACHE_HEADERS = { 'Cache-Control': 'no-store', Pragma: 'no-cache' } as const;
@@ -1363,6 +1371,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    */
   private typedApiHandlers: Array<[string, TypedHandler<Env>]>;
 
+  /** Capabilities shared by discovery and client metadata validation. */
+  readonly serverCapabilities: OAuthServerCapabilities;
+
   /** In-memory cached IdP JWKS fetcher; only constructed when EMA is configured. */
   private readonly jwksProvider: EmaJwksProvider | undefined;
 
@@ -1448,6 +1459,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       );
     }
 
+    this.serverCapabilities = buildOAuthServerCapabilities({
+      allowImplicitFlow: !!this.options.allowImplicitFlow,
+      allowTokenExchangeGrant: !!this.options.allowTokenExchangeGrant,
+      enterpriseManagedAuthorization: !!this.options.enterpriseManagedAuthorization,
+    });
+    validateAuthorizationServerScopes(this.options.scopesSupported);
     this.validateResourceMetadataOptions(this.options.resourceMetadata);
     this.validateEmaOptions(this.options.enterpriseManagedAuthorization);
 
@@ -2121,24 +2138,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       registrationEndpoint = this.getFullEndpointUrl(this.options.clientRegistrationEndpoint, requestUrl);
     }
 
-    // Determine supported response types
-    const responseTypesSupported = ['code'];
-
-    // Add token response type if implicit flow is allowed
-    if (this.options.allowImplicitFlow) {
-      responseTypesSupported.push('token');
-    }
-
-    // Determine supported grant types
-    const grantTypesSupported = [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN];
-    if (this.options.allowTokenExchangeGrant) {
-      grantTypesSupported.push(GrantType.TOKEN_EXCHANGE);
-    }
-    const authorizationGrantProfilesSupported: string[] = [];
-    if (this.options.enterpriseManagedAuthorization) {
-      grantTypesSupported.push(GrantType.JWT_BEARER);
-      authorizationGrantProfilesSupported.push(EMA_ID_JAG_GRANT_PROFILE);
-    }
+    const responseTypesSupported = this.serverCapabilities.responseTypes;
+    const grantTypesSupported = this.serverCapabilities.grantTypes;
+    const authorizationGrantProfilesSupported = this.options.enterpriseManagedAuthorization
+      ? [EMA_ID_JAG_GRANT_PROFILE]
+      : [];
 
     const metadata = {
       issuer: new URL(tokenEndpoint).origin,
@@ -2154,8 +2158,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       ...(authorizationGrantProfilesSupported.length > 0
         ? { authorization_grant_profiles_supported: authorizationGrantProfilesSupported }
         : {}),
-      // Support "none" auth method for public clients
-      token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
+      token_endpoint_auth_methods_supported: this.serverCapabilities.tokenEndpointAuthMethods,
       // not implemented: token_endpoint_auth_signing_alg_values_supported
       // not implemented: service_documentation
       // not implemented: ui_locales_supported
@@ -3586,9 +3589,28 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.createErrorResponse('invalid_request', { description: 'Invalid JSON payload', statusCode: 400 });
     }
 
-    // Get token endpoint auth method, default to client_secret_basic
-    const authMethod =
-      OAuthProviderImpl.validateStringField(clientMetadata.token_endpoint_auth_method) || 'client_secret_basic';
+    let authMethod: string;
+    let grantTypes: string[];
+    let responseTypes: string[];
+    try {
+      authMethod =
+        OAuthProviderImpl.validateStringField(clientMetadata.token_endpoint_auth_method) || 'client_secret_basic';
+      grantTypes = OAuthProviderImpl.validateStringArray(clientMetadata.grant_types, 'grant_types') || [
+        GrantType.AUTHORIZATION_CODE,
+      ];
+      responseTypes = OAuthProviderImpl.validateStringArray(clientMetadata.response_types, 'response_types') || [
+        'code',
+      ];
+      validateClientCapabilities(this.serverCapabilities, {
+        tokenEndpointAuthMethod: authMethod,
+        grantTypes,
+        responseTypes,
+      });
+    } catch (error) {
+      return this.createErrorResponse('invalid_client_metadata', {
+        description: error instanceof Error ? error.message : 'Invalid client metadata',
+      });
+    }
     const isPublicClient = authMethod === 'none';
 
     // Check if public client registrations are disallowed
@@ -3634,12 +3656,8 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         jwksUri: OAuthProviderImpl.validateOptionalUriField(clientMetadata.jwks_uri, 'jwks_uri'),
         i18n: OAuthProviderImpl.extractI18nFields(clientMetadata),
         contacts: OAuthProviderImpl.validateStringArray(clientMetadata.contacts),
-        grantTypes: OAuthProviderImpl.validateStringArray(clientMetadata.grant_types) || [
-          GrantType.AUTHORIZATION_CODE,
-          GrantType.REFRESH_TOKEN,
-          ...(this.options.allowTokenExchangeGrant ? [GrantType.TOKEN_EXCHANGE] : []),
-        ],
-        responseTypes: OAuthProviderImpl.validateStringArray(clientMetadata.response_types) || ['code'],
+        grantTypes,
+        responseTypes,
         registrationDate: Math.floor(Date.now() / 1000),
         tokenEndpointAuthMethod: authMethod,
       };
@@ -4403,6 +4421,19 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         );
       }
 
+      const grantTypes = OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
+        GrantType.AUTHORIZATION_CODE,
+      ];
+      const responseTypes = OAuthProviderImpl.validateStringArray(rawMetadata.response_types, 'response_types') || [
+        'code',
+      ];
+      const effectiveAuthMethod = tokenEndpointAuthMethod || 'none';
+      validateClientCapabilities(this.serverCapabilities, {
+        tokenEndpointAuthMethod: effectiveAuthMethod,
+        grantTypes,
+        responseTypes,
+      });
+
       return {
         clientId,
         redirectUris,
@@ -4414,11 +4445,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         jwksUri: OAuthProviderImpl.validateOptionalUriField(rawMetadata.jwks_uri, 'jwks_uri'),
         i18n: OAuthProviderImpl.extractI18nFields(rawMetadata),
         contacts: OAuthProviderImpl.validateStringArray(rawMetadata.contacts, 'contacts'),
-        grantTypes: OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
-          'authorization_code',
-        ],
-        responseTypes: OAuthProviderImpl.validateStringArray(rawMetadata.response_types, 'response_types') || ['code'],
-        tokenEndpointAuthMethod: tokenEndpointAuthMethod || 'none',
+        grantTypes,
+        responseTypes,
+        tokenEndpointAuthMethod: effectiveAuthMethod,
       };
     } finally {
       clearTimeout(timeoutId);
@@ -4803,11 +4832,6 @@ function getRevokeExistingGrantsBatchSize(batchSize: number | undefined): number
  */
 const TOKEN_LENGTH = 32;
 
-/**
- * RFC 6749 Section 3.3 scope-token grammar.
- */
-const OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
-
 // Helper Functions
 /**
  * Validates a resource URI per RFC 8707 Section 2
@@ -5153,10 +5177,6 @@ export function parseJwtJsonPart(encoded: string): Record<string, unknown> {
   } catch {
     throw new Error('Malformed JWT part');
   }
-}
-
-export function isValidOAuthScopeToken(scopeToken: string): boolean {
-  return OAUTH_SCOPE_TOKEN_PATTERN.test(scopeToken);
 }
 
 /**

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -3,6 +3,7 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 import {
   buildOAuthServerCapabilities,
   isValidOAuthScopeToken,
+  validateAuthorizationResponseType,
   validateAuthorizationServerScopes,
   validateClientCapabilities,
   type OAuthServerCapabilities,
@@ -580,6 +581,7 @@ export interface OAuthHelpers {
    * Parses an OAuth authorization request from the HTTP request
    * @param request - The HTTP request containing OAuth parameters
    * @returns The parsed authorization request parameters
+   * @throws Error when the response type is missing, unsupported, or not registered for the client
    * @throws {@link CimdFetchError} when the client ID is a CIMD URL whose document cannot be resolved
    */
   parseAuthRequest(request: Request): Promise<AuthRequest>;
@@ -596,6 +598,7 @@ export interface OAuthHelpers {
    * Completes an authorization request by creating a grant and authorization code
    * @param options - Options specifying the grant details
    * @returns A Promise resolving to an object containing the redirect URL
+   * @throws Error when the request's response type is not permitted
    * @throws {@link CimdFetchError} when the client ID is a CIMD URL whose document cannot be resolved
    */
   completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }>;
@@ -1682,17 +1685,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Call the default handler based on its type
     // Note: We don't add CORS headers to default handler responses
     if (this.typedDefaultHandler.type === HandlerType.EXPORTED_HANDLER) {
-      // It's an object with a fetch method
       return this.typedDefaultHandler.handler.fetch(
         request as Parameters<ExportedHandlerWithFetch<Env>['fetch']>[0],
         env,
         ctx
       );
-    } else {
-      // It's a WorkerEntrypoint class - instantiate it with ctx and env in that order
-      const handler = new this.typedDefaultHandler.handler(ctx, env);
-      return handler.fetch(request);
     }
+
+    const handler = new this.typedDefaultHandler.handler(ctx, env);
+    return handler.fetch(request);
   }
 
   /**
@@ -5399,6 +5400,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
    * Parses an OAuth authorization request from the HTTP request
    * @param request - The HTTP request containing OAuth parameters
    * @returns The parsed authorization request parameters
+   * @throws Error when the response type is missing, unsupported, or not registered for the client
    * @throws CimdFetchError when the client ID is a CIMD URL whose document cannot be resolved
    */
   async parseAuthRequest(request: Request): Promise<AuthRequest> {
@@ -5435,16 +5437,6 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     }
     resource ??= url.origin;
 
-    // Check if implicit flow is requested but not allowed
-    if (responseType === 'token' && !this.provider.options.allowImplicitFlow) {
-      throw new Error('The implicit grant flow is not enabled for this provider');
-    }
-
-    // Check if plain PKCE method is used but not allowed (OAuth 2.1 recommends S256 only)
-    if (codeChallengeMethod === 'plain' && this.provider.options.allowPlainPKCE === false) {
-      throw new Error('The plain PKCE method is not allowed. Use S256 instead.');
-    }
-
     // Validate the client ID and redirect URI
     if (clientId) {
       const clientInfo = await this.lookupClient(clientId);
@@ -5452,16 +5444,17 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
       if (!clientInfo) {
         throw new Error(`Invalid client. The clientId provided does not match to this client.`);
       }
+      if (!redirectUri || !isValidRedirectUri(redirectUri, clientInfo.redirectUris)) {
+        throw new Error(
+          `Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.`
+        );
+      }
+      validateAuthorizationResponseType(this.provider.serverCapabilities, responseType, clientInfo.responseTypes);
+      if (codeChallengeMethod === 'plain' && this.provider.options.allowPlainPKCE === false) {
+        throw new Error('The plain PKCE method is not allowed. Use S256 instead.');
+      }
       if (responseType === 'code' && clientInfo.tokenEndpointAuthMethod === 'none' && !codeChallenge) {
         throw new Error('Public clients must use PKCE with the authorization code flow.');
-      }
-      // If client exists, validate the redirect URI against registered URIs
-      if (clientInfo && redirectUri) {
-        if (!isValidRedirectUri(redirectUri, clientInfo.redirectUris)) {
-          throw new Error(
-            `Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.`
-          );
-        }
       }
     }
 
@@ -5499,6 +5492,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
    * - For implicit flow: generating an access token directly
    * @param options - Options specifying the grant details
    * @returns A Promise resolving to an object containing the redirect URL
+   * @throws Error when the request's response type is not permitted
    * @throws CimdFetchError when the client ID is a CIMD URL whose document cannot be resolved
    */
   async completeAuthorization(options: CompleteAuthorizationOptions): Promise<{ redirectTo: string }> {
@@ -5515,6 +5509,11 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
         'Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.'
       );
     }
+    validateAuthorizationResponseType(
+      this.provider.serverCapabilities,
+      options.request.responseType,
+      clientInfo.responseTypes
+    );
 
     // completeAuthorization() is a public helper and callers can pass a
     // reconstructed AuthRequest rather than one returned directly by


### PR DESCRIPTION
## Summary

Fix the four newest OAuth validation bugs, with one independently green commit and changeset per issue.

### #267 — validate OAuth metadata capabilities

- add a pure `OAuthServerCapabilities` model shared by RFC 8414 discovery, DCR, and CIMD
- validate configured authorization-server scope syntax and duplicates
- apply RFC 7591's `authorization_code` / `code` registration defaults
- reject unsupported authentication methods, grants, response types, and inconsistent grant/response combinations before storage
- keep capability policy outside the provider's request-orchestration core

### #266 — validate authorization response types

- reject missing, server-unsupported, and client-disabled response types in `parseAuthRequest()`
- repeat the same pure validation in `completeAuthorization()` before grant creation or existing-grant revocation
- preserve application ownership of authorization error rendering and terminal redirects
- validate client and redirect URI before response type

### #268 — require a single ID-JAG audience

- accept the expected authorization-server issuer as a string or one-element array
- reject empty, malformed, duplicate, multi-audience, and mismatched arrays
- preserve the generic `invalid_grant` wire response

### #269 — fail closed on unsupported ID-JAG constraints

- reject assertions containing `authorization_details` or `cnf`
- use one typed `unsupported_claim` internal error shape
- fail before replay reservation, claim mapping, grant creation, or token storage
- keep wire errors generic

Closes #266
Closes #267
Closes #268
Closes #269

## Commit structure

1. `fix: validate OAuth metadata capabilities`
2. `fix: validate authorization response types`
3. `fix: require a single ID-JAG audience`
4. `fix: fail closed on unsupported ID-JAG claims`

Each commit independently passes `npm run check`.

## Code quality

- rebased onto current `origin/main`, including the shortened README and advanced guide from #270
- extracted pure capability policy into `src/oauth-capabilities.ts`
- removed the proposed authorization-error class and global default-handler catch
- reduced `src/oauth-provider.ts` versus the earlier PR version while adding a focused 81-line pure test suite
- updated README, advanced configuration, and AGENTS architecture notes in the matching issue commits

## Validation

Validated on Node 24:

- `npm run check` — 618 tests
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `npm pack --dry-run`
- `git diff --check origin/main`
