### PR TITLE
feat: require S256 PKCE by default

### DIFF
--- a/.changeset/modern-pkce-default.md
+++ b/.changeset/modern-pkce-default.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Require S256 PKCE by default. Authorization servers now advertise only `S256` and reject PKCE challenges that use `plain` or omit `code_challenge_method` unless `allowPlainPKCE: true` is configured for legacy compatibility. Confidential clients may continue to omit PKCE entirely.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ export default new OAuthProvider<Env>({
   tokenEndpoint: '/oauth/token',
 
   scopesSupported: ['mcp:read'],
-  allowPlainPKCE: false,
 
   resourceMetadata: {
     resource: 'https://mcp.example.com/mcp',
@@ -316,15 +315,15 @@ Clients created by `OAuthHelpers.createClient()` are not affected by the DCR TTL
 
 ## PKCE and token lifecycle
 
-Public clients must use PKCE with authorization code flow. The provider always supports S256.
+Public clients must use PKCE with authorization code flow. PKCE challenges use only S256 by default. Confidential clients may still omit PKCE.
 
-For new MCP deployments, disable the legacy plain method:
+Legacy deployments with clients that cannot use S256 can opt back into plain PKCE:
 
 ```ts
-allowPlainPKCE: false;
+allowPlainPKCE: true;
 ```
 
-`allowPlainPKCE` defaults to `true` for backwards compatibility. `allowImplicitFlow` defaults to `false`; leave it disabled for MCP and other new OAuth deployments.
+`allowImplicitFlow` defaults to `false`; leave it disabled for MCP and other new OAuth deployments.
 
 The provider owns `tokenEndpoint`. It exchanges authorization codes for tokens, refreshes access tokens, and handles RFC 7009 revocation. Refresh tokens rotate on use. The immediately previous token remains valid until its replacement is first used, allowing a client to retry after losing a refresh response.
 
@@ -409,7 +408,7 @@ Deleting a client through `OAuthHelpers.deleteClient()` also revokes its grants 
 | `scopesSupported`                  | Publish authorization server scopes                      | Omitted                                     |
 | `resourceMetadata`                 | Configure RFC 9728 metadata                              | Derived from the request and token endpoint |
 | `clientIdMetadataDocumentEnabled`  | Enable CIMD lookup and advertisement                     | `false`                                     |
-| `allowPlainPKCE`                   | Permit the legacy plain PKCE method                      | `true`                                      |
+| `allowPlainPKCE`                   | Permit the legacy plain PKCE method                      | `false`                                     |
 | `allowImplicitFlow`                | Enable implicit token responses                          | `false`                                     |
 | `disallowPublicClientRegistration` | Reject public clients at DCR                             | `false`                                     |
 | `clientRegistrationCallback`       | Apply application policy before storing a DCR client     | None                                        |

--- a/__tests__/oauth-capabilities.test.ts
+++ b/__tests__/oauth-capabilities.test.ts
@@ -102,12 +102,76 @@ describe('PKCE capabilities', () => {
 
   it('requires PKCE for public authorization-code clients', () => {
     expect(() =>
+      validateAuthorizationPkce(defaults, { responseType: 'code' }, { tokenEndpointAuthMethod: 'none' })
+    ).toThrow('Public clients must use PKCE');
+  });
+
+  it('allows confidential clients to omit PKCE', () => {
+    expect(() =>
+      validateAuthorizationPkce(defaults, { responseType: 'code' }, { tokenEndpointAuthMethod: 'client_secret_basic' })
+    ).not.toThrow();
+  });
+
+  it('allows non-code response types to omit PKCE', () => {
+    expect(() =>
+      validateAuthorizationPkce(defaults, { responseType: 'token' }, { tokenEndpointAuthMethod: 'none' })
+    ).not.toThrow();
+  });
+
+  it('rejects plain PKCE by default when a challenge is supplied', () => {
+    expect(() =>
+      validateAuthorizationPkce(
+        defaults,
+        { responseType: 'code', codeChallenge: 'legacy-verifier', codeChallengeMethod: 'plain' },
+        { tokenEndpointAuthMethod: 'client_secret_basic' }
+      )
+    ).toThrow('plain PKCE method is not allowed');
+  });
+
+  it('applies the RFC 7636 plain default when a challenge omits its method', () => {
+    expect(() =>
+      validateAuthorizationPkce(
+        defaults,
+        { responseType: 'code', codeChallenge: 'legacy-verifier' },
+        { tokenEndpointAuthMethod: 'client_secret_basic' }
+      )
+    ).toThrow('plain PKCE method is not allowed');
+  });
+
+  it.each([
+    ['S256-only', defaults],
+    ['plain-compatible', withPlainPkce],
+  ])('accepts S256 under the %s policy', (_label, server) => {
+    expect(() =>
+      validateAuthorizationPkce(
+        server,
+        { responseType: 'code', codeChallenge: 's256-challenge', codeChallengeMethod: 'S256' },
+        { tokenEndpointAuthMethod: 'client_secret_basic' }
+      )
+    ).not.toThrow();
+  });
+
+  it.each([
+    ['an explicit plain method', { codeChallenge: 'legacy-verifier', codeChallengeMethod: 'plain' }],
+    ['an omitted method', { codeChallenge: 'legacy-verifier' }],
+  ])('accepts legacy plain PKCE with %s only when advertised', (_label, request) => {
+    expect(() =>
+      validateAuthorizationPkce(
+        withPlainPkce,
+        { responseType: 'code', ...request },
+        { tokenEndpointAuthMethod: 'client_secret_basic' }
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects a method without a challenge', () => {
+    expect(() =>
       validateAuthorizationPkce(
         defaults,
         { responseType: 'code', codeChallengeMethod: 'S256' },
-        { tokenEndpointAuthMethod: 'none' }
+        { tokenEndpointAuthMethod: 'client_secret_basic' }
       )
-    ).toThrow('Public clients must use PKCE');
+    ).toThrow('code_challenge is required');
   });
 });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -580,37 +580,28 @@ describe('OAuthProvider', () => {
       expect(metadata.response_types_supported).not.toContain('token');
     });
 
-    it('should only include S256 PKCE method when allowPlainPKCE is false', async () => {
-      // Create a provider with plain PKCE disabled
-      const providerWithoutPlainPKCE = new OAuthProvider({
+    it('should advertise only S256 PKCE by default', async () => {
+      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(200);
+      expect((await response.json<any>()).code_challenge_methods_supported).toEqual(['S256']);
+    });
+
+    it('should advertise legacy plain PKCE only when explicitly enabled', async () => {
+      const providerWithPlainPkce = new OAuthProvider({
         apiRoute: ['/api/'],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
-        allowPlainPKCE: false, // Enforce S256 only
+        allowPlainPKCE: true,
       });
-
       const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
-      const response = await providerWithoutPlainPKCE.fetch(request, mockEnv, mockCtx);
+      const response = await providerWithPlainPkce.fetch(request, mockEnv, mockCtx);
 
       expect(response.status).toBe(200);
-
-      const metadata = await response.json<any>();
-      expect(metadata.code_challenge_methods_supported).toEqual(['S256']);
-      expect(metadata.code_challenge_methods_supported).not.toContain('plain');
-    });
-
-    it('should include both plain and S256 PKCE methods by default', async () => {
-      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
-      const response = await oauthProvider.fetch(request, mockEnv, mockCtx);
-
-      expect(response.status).toBe(200);
-
-      const metadata = await response.json<any>();
-      expect(metadata.code_challenge_methods_supported).toContain('plain');
-      expect(metadata.code_challenge_methods_supported).toContain('S256');
+      expect((await response.json<any>()).code_challenge_methods_supported).toEqual(['plain', 'S256']);
     });
   });
 
@@ -1600,20 +1591,12 @@ describe('OAuthProvider', () => {
     });
 
     it('should prioritize a missing response_type over later PKCE validation', async () => {
-      const providerWithoutPlainPkce = new OAuthProvider({
-        apiRoute: ['/api/'],
-        apiHandler: TestApiHandler,
-        defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        allowPlainPKCE: false,
-      });
       const authRequest = createMockRequest(
         `https://example.com/authorize?client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}&state=state-123`
       );
 
-      await expect(providerWithoutPlainPkce.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('invalid_request');
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('invalid_request');
     });
 
     it('should reject a response type excluded by registered client metadata', async () => {
@@ -1956,59 +1939,74 @@ describe('OAuthProvider', () => {
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
     });
 
-    it('should reject plain PKCE when allowPlainPKCE is false', async () => {
-      // Create a provider with plain PKCE disabled
-      const providerWithoutPlainPKCE = new OAuthProvider({
-        apiRoute: ['/api/'],
-        apiHandler: TestApiHandler,
-        defaultHandler: testDefaultHandler,
-        authorizeEndpoint: '/authorize',
-        tokenEndpoint: '/oauth/token',
-        scopesSupported: ['read', 'write'],
-        allowPlainPKCE: false, // Enforce S256 only
-      });
-
-      // Create an authorization request with plain PKCE
+    it.each([
+      ['an explicit plain method', '&code_challenge_method=plain'],
+      ['an omitted method', ''],
+    ])('should reject plain PKCE with %s by default', async (_label, method) => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&scope=read%20write&state=xyz123` +
-          `&code_challenge=test_challenge&code_challenge_method=plain`
+          `&code_challenge=test_challenge${method}`
       );
 
-      // Expect an error response
-      await expect(providerWithoutPlainPKCE.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
         'The plain PKCE method is not allowed. Use S256 instead.'
       );
     });
 
-    it('should accept S256 PKCE when allowPlainPKCE is false', async () => {
-      // Create a provider with plain PKCE disabled
-      const providerWithoutPlainPKCE = new OAuthProvider({
+    it.each([
+      ['an explicit plain method', '&code_challenge_method=plain'],
+      ['an omitted method', ''],
+    ])('should accept legacy plain PKCE with %s only when explicitly enabled', async (_label, method) => {
+      const providerWithPlainPkce = new OAuthProvider({
         apiRoute: ['/api/'],
         apiHandler: TestApiHandler,
         defaultHandler: testDefaultHandler,
         authorizeEndpoint: '/authorize',
         tokenEndpoint: '/oauth/token',
         scopesSupported: ['read', 'write'],
-        allowPlainPKCE: false, // Enforce S256 only
+        allowImplicitFlow: true,
+        allowPlainPKCE: true,
       });
-
-      // Create a valid S256 code challenge (SHA-256 of 'test_verifier' base64url encoded)
-      const codeChallenge = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
-
-      // Create an authorization request with S256 PKCE
       const authRequest = createMockRequest(
         `https://example.com/authorize?response_type=code&client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&scope=read%20write&state=xyz123` +
-          `&code_challenge=${codeChallenge}&code_challenge_method=S256`
+          `&code_challenge=legacy-plain-code-verifier-that-is-at-least-43-characters${method}`
       );
 
-      // This should NOT throw - S256 is allowed
-      const response = await providerWithoutPlainPKCE.fetch(authRequest, mockEnv, mockCtx);
-      // The request should be processed by the default handler
-      expect(response.status).toBe(302);
+      const authResponse = await providerWithPlainPkce.fetch(authRequest, mockEnv, mockCtx);
+      expect(authResponse.status).toBe(302);
+      const code = new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+      const tokenResponse = await providerWithPlainPkce.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: redirectUri,
+            client_id: clientId,
+            code_verifier: 'legacy-plain-code-verifier-that-is-at-least-43-characters',
+          }).toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(tokenResponse.status).toBe(200);
+    });
+
+    it('should accept S256 PKCE by default', async () => {
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123` +
+          `&code_challenge=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk&code_challenge_method=S256`
+      );
+
+      expect((await oauthProvider.fetch(authRequest, mockEnv, mockCtx)).status).toBe(302);
     });
 
     it('should use the access token to access API directly', async () => {
@@ -10546,7 +10544,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10584,7 +10582,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10607,7 +10605,7 @@ describe('OAuthProvider', () => {
           .mockImplementation(() => Promise.resolve(createMockFetchResponse(maliciousMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10630,7 +10628,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://malicious.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://malicious.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10653,7 +10651,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://malicious.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://malicious.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10674,7 +10672,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
         await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
@@ -10711,7 +10709,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
         await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
@@ -10730,7 +10728,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
@@ -10751,7 +10749,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
@@ -10775,7 +10773,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10793,7 +10791,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10811,7 +10809,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10830,7 +10828,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10856,7 +10854,7 @@ describe('OAuthProvider', () => {
           `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}` +
             `&redirect_uri=${encodeURIComponent(validMetadata.redirect_uris[0])}` +
             `&response_type=code&state=test-state` +
-            `&code_challenge=test-challenge&code_challenge_method=plain`,
+            `&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10878,7 +10876,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10897,7 +10895,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10936,7 +10934,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10954,7 +10952,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockResolvedValue(createMockFetchResponse(invalidMetadata));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10978,7 +10976,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -10996,7 +10994,7 @@ describe('OAuthProvider', () => {
         );
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11010,7 +11008,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(httpUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(httpUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11023,7 +11021,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithoutPath)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithoutPath)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11036,7 +11034,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithRootPath)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(urlWithRootPath)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11049,7 +11047,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn();
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(regularClientId)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(regularClientId)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11064,7 +11062,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://abort.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://abort.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11083,7 +11081,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11103,7 +11101,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11115,7 +11113,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockResolvedValue(new Response('Internal Server Error', { status: 500 }));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11127,7 +11125,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://unreachable.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://unreachable.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11162,7 +11160,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11182,7 +11180,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11202,7 +11200,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11267,7 +11265,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11311,7 +11309,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11330,7 +11328,7 @@ describe('OAuthProvider', () => {
         globalThis.fetch = fetchSpy;
 
         const authRequest = createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
 
@@ -11346,7 +11344,7 @@ describe('OAuthProvider', () => {
 
       function makeAuthRequest(url: string = cimdUrl) {
         return createMockRequest(
-          `https://example.com/authorize?client_id=${encodeURIComponent(url)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=plain`,
+          `https://example.com/authorize?client_id=${encodeURIComponent(url)}&redirect_uri=${encodeURIComponent('https://client.example.com/callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
           'GET'
         );
       }

--- a/conformance/authorization-server.test.ts
+++ b/conformance/authorization-server.test.ts
@@ -128,6 +128,28 @@ describe.each(MCP_AUTH_REVISIONS)('MCP %s authorization server conformance', (re
     });
   });
 
+  it('rejects a PKCE challenge that omits its method because RFC 7636 defaults it to plain', async () => {
+    const client = await oauth.createClient('none');
+    const resource = clientResourceForRevision(revision);
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: client.clientId,
+      redirect_uri: client.redirectUri,
+      scope: READ_SCOPE,
+      state: 'implicit-plain-pkce',
+      code_challenge: 'plain-code-verifier',
+    });
+    if (resource) params.set('resource', resource);
+
+    const response = await oauth.request(`/authorize?${params}`);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: 'invalid_request',
+      error_description: expect.stringContaining('plain PKCE method is not allowed'),
+    });
+  });
+
   it('rejects an unsupported PKCE method instead of treating it as plain', async () => {
     const client = await oauth.createClient('none');
     const resource = clientResourceForRevision(revision);

--- a/conformance/worker/index.ts
+++ b/conformance/worker/index.ts
@@ -74,7 +74,6 @@ function createProviderOptions(configuration: WorkerConfiguration): OAuthProvide
     tokenEndpoint: '/oauth/token',
     clientRegistrationEndpoint: configuration.dynamicClientRegistration ? '/oauth/register' : undefined,
     scopesSupported: [READ_SCOPE, WRITE_SCOPE, OFFLINE_ACCESS_SCOPE],
-    allowPlainPKCE: false,
     clientIdMetadataDocumentEnabled: true,
     resourceMetadata: {
       ...(configuration.resource ? { resource: configuration.resource } : {}),

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -100,8 +100,14 @@ export function validateAuthorizationPkce(
   },
   client: Pick<ClientCapabilities, 'tokenEndpointAuthMethod'>
 ): void {
-  validatePkceCodeChallengeMethod(server, request.codeChallengeMethod);
-  if (request.responseType === 'code' && client.tokenEndpointAuthMethod === 'none' && !request.codeChallenge) {
+  if (request.codeChallenge) {
+    validatePkceCodeChallengeMethod(server, request.codeChallengeMethod);
+    return;
+  }
+  if (request.codeChallengeMethod) {
+    throw new Error('PKCE code_challenge is required when code_challenge_method is provided.');
+  }
+  if (request.responseType === 'code' && client.tokenEndpointAuthMethod === 'none') {
     throw new Error('Public clients must use PKCE with the authorization code flow.');
   }
 }

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -418,10 +418,9 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   allowImplicitFlow?: boolean;
 
   /**
-   * Controls whether the plain PKCE method is allowed.
-   * OAuth 2.1 recommends using S256 exclusively as plain offers no cryptographic protection.
-   * When set to false, only the S256 code_challenge_method will be accepted.
-   * Defaults to true for backward compatibility.
+   * Controls whether the legacy plain PKCE method is allowed.
+   * Defaults to false so PKCE challenges use S256 exclusively.
+   * Set to true only for compatibility with clients that cannot use S256.
    */
   allowPlainPKCE?: boolean;
 
@@ -1468,7 +1467,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
     this.serverCapabilities = buildOAuthServerCapabilities({
       allowImplicitFlow: !!this.options.allowImplicitFlow,
-      allowPlainPKCE: this.options.allowPlainPKCE !== false,
+      allowPlainPKCE: this.options.allowPlainPKCE === true,
       allowTokenExchangeGrant: !!this.options.allowTokenExchangeGrant,
       enterpriseManagedAuthorization: !!this.options.enterpriseManagedAuthorization,
     });
@@ -5429,7 +5428,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     const scope = (url.searchParams.get('scope') || '').split(' ').filter(Boolean);
     const state = url.searchParams.get('state') || '';
     const codeChallenge = url.searchParams.get('code_challenge') || undefined;
-    const codeChallengeMethod = url.searchParams.get('code_challenge_method') || 'plain';
+    const codeChallengeMethod = url.searchParams.get('code_challenge_method') || undefined;
     const issuer = this.provider.getAuthorizationServerIssuer(url);
     // RFC 8707 Section 2.1: Multiple resource parameters MAY be used
     const resourceParams = url.searchParams.getAll('resource');


### PR DESCRIPTION
## Summary

Change `allowPlainPKCE` to default to `false`, so authorization server metadata advertises only `S256` and PKCE challenges using the legacy `plain` transformation are rejected unless a deployment opts in.

`allowPlainPKCE: true` remains available for legacy clients. It accepts both an explicit `code_challenge_method=plain` and RFC 7636's implicit `plain` default when a challenge omits the method.

## Behavior

- Public authorization-code clients still have to use PKCE.
- S256 works under both the default and legacy-compatible policies.
- Confidential clients may still omit PKCE entirely.
- Non-code response types may omit PKCE.
- A method without a challenge is rejected as malformed.
- `parseAuthRequest()` now preserves an absent method as `undefined`; the RFC 7636 `plain` default is applied only when a challenge is present.

This is a minor change because deployments with clients that use plain PKCE must now set:

```ts
allowPlainPKCE: true
```

## Client compatibility

Live testing against the S256-only provider passed with:

- Claude Code 2.1.220
- Pi MCP adapter 2.11.0
- Codex 0.145.0-alpha.18 through PKCE authorization; its later RFC 9207 callback failure is tracked upstream in openai/codex#31573

All three clients sent `code_challenge_method=S256`.

## Tests

- policy tests cover default S256-only and explicit legacy-compatible modes
- endpoint tests cover S256, explicit plain, omitted method, public-client enforcement, confidential no-PKCE, and full plain token exchange
- Workerd conformance relies on the new default and covers explicit and implicit plain rejection across all four MCP authorization revisions

Validated with Node 24.14.1:

- `npm run check` (765 tests)
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `npx wrangler deploy --dry-run --config conformance/worker/wrangler.jsonc`
