### PR TITLE
feat: tag authorization request errors

### DIFF
--- a/.changeset/tag-authorization-errors.md
+++ b/.changeset/tag-authorization-errors.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Export `AuthorizationError` and throw it from `parseAuthRequest()` for expected authorization-request validation failures. Errors carry a validated redirect URI, original state, and issuer only after exact client redirect validation succeeds, allowing applications to distinguish safe OAuth error redirects from failures that must be rendered locally.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ See [Client registration](#client-registration) for the matching provider option
 The provider accepts either plain `ExportedHandler` objects or classes extending `WorkerEntrypoint`. This example uses both.
 
 ```ts
-import { OAuthProvider, type AuthRequest, type OAuthHelpers } from '@cloudflare/workers-oauth-provider';
+import {
+  AuthorizationError,
+  OAuthProvider,
+  type AuthRequest,
+  type OAuthHelpers,
+} from '@cloudflare/workers-oauth-provider';
 import { WorkerEntrypoint } from 'cloudflare:workers';
 
 interface AuthProps {
@@ -72,9 +77,18 @@ const defaultHandler: ExportedHandler<Env> = {
     let oauthRequest: AuthRequest;
     try {
       oauthRequest = await env.OAUTH_PROVIDER.parseAuthRequest(request);
-    } catch {
-      // Do not redirect until the client and redirect URI have been validated.
-      return new Response('Invalid authorization request', { status: 400 });
+    } catch (error) {
+      if (!(error instanceof AuthorizationError)) throw error;
+      if (!error.redirectUri) {
+        // Unknown clients and invalid redirects must be rendered locally.
+        return new Response(error.description, { status: 400 });
+      }
+      const redirect = new URL(error.redirectUri);
+      redirect.searchParams.set('error', error.code);
+      redirect.searchParams.set('error_description', error.description);
+      if (error.state) redirect.searchParams.set('state', error.state);
+      if (error.issuer) redirect.searchParams.set('iss', error.issuer);
+      return Response.redirect(redirect, 302);
     }
 
     const client = await env.OAUTH_PROVIDER.lookupClient(oauthRequest.clientId);
@@ -228,7 +242,9 @@ A typical flow has three steps:
 2. Authenticate the user, show consent, and decide which scopes to grant.
 3. Call `completeAuthorization()` and redirect to its returned `redirectTo` URL.
 
-`completeAuthorization()` repeats response-type validation before writing a grant or revoking existing grants. The application remains responsible for rendering local authorization errors and for constructing any terminal OAuth error redirect only after client and redirect URI validation.
+`parseAuthRequest()` throws an exported `AuthorizationError` for expected request validation failures. Its optional `redirectUri` is present only after the client and exact registered redirect URI have been validated. Without it, render the error locally and never redirect. With it, the application can safely construct an OAuth error redirect using the error's `code`, `description`, original `state`, and RFC 9207 `issuer`, as shown in the quick start.
+
+`completeAuthorization()` repeats response-type validation before writing a grant or revoking existing grants. Validation errors from reconstructed requests are also typed as `AuthorizationError`, but applications should not construct redirects from untrusted reconstructed values; the redirect context is attached only by `parseAuthRequest()`.
 
 `completeAuthorization()` stores a new grant and, by default, revokes existing grants for the same user and client after the new grant is safely stored. Set `revokeExistingGrants: false` only when the application intentionally allows concurrent grants for the same user and client.
 

--- a/__tests__/oauth-capabilities.test.ts
+++ b/__tests__/oauth-capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  AuthorizationError,
   buildOAuthServerCapabilities,
   normalizePkceCodeChallengeMethod,
   validateAuthorizationPkce,
@@ -69,8 +70,14 @@ describe('OAuth server capabilities', () => {
     ['', ['code'], 'invalid_request'],
     ['token', ['code', 'token'], 'unsupported_response_type'],
     ['code', ['token'], 'unauthorized_client'],
-  ])('rejects response type %j against client %j', (responseType, clientResponseTypes, error) => {
-    expect(() => validateAuthorizationResponseType(defaults, responseType, clientResponseTypes)).toThrow(error);
+  ])('rejects response type %j against client %j', (responseType, clientResponseTypes, code) => {
+    try {
+      validateAuthorizationResponseType(defaults, responseType, clientResponseTypes);
+      throw new Error('Expected AuthorizationError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AuthorizationError);
+      expect(error).toMatchObject({ code });
+    }
   });
 
   it('accepts capabilities that the server advertises', () => {

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, expectTypeOf, beforeEach, vi, afterEach } from 'vitest';
 import {
+  AuthorizationError,
   CimdFetchError,
   ExternalTokenError,
   OAuthError,
@@ -1577,16 +1578,45 @@ describe('OAuthProvider', () => {
     it.each([
       ['missing response_type', '', 'invalid_request'],
       ['unsupported response_type', '&response_type=unsupported', 'unsupported_response_type'],
-    ])('should reject %s without creating authorization state', async (_label, responseType, code) => {
+    ])('tags redirectable %s with validated response context', async (_label, responseType, code) => {
       const authRequest = createMockRequest(
         `https://example.com/authorize?client_id=${clientId}` +
           `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&scope=read&state=state-123${responseType}`
       );
 
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(code);
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toMatchObject({
+        name: 'AuthorizationError',
+        code,
+        redirectUri,
+        state: 'state-123',
+        issuer: 'https://example.com',
+      });
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
+    });
+
+    it('keeps unknown clients and invalid redirects local', async () => {
+      const unknownClient = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=unknown` +
+          `&redirect_uri=${encodeURIComponent('https://attacker.example/callback')}&state=secret`
+      );
+      const badRedirect = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent('https://attacker.example/callback')}&state=secret`
+      );
+
+      for (const request of [unknownClient, badRedirect]) {
+        try {
+          await oauthProvider.fetch(request, mockEnv, mockCtx);
+          throw new Error('Expected AuthorizationError');
+        } catch (error) {
+          expect(error).toBeInstanceOf(AuthorizationError);
+          expect(error).toMatchObject({ name: 'AuthorizationError', code: 'invalid_request' });
+          expect((error as AuthorizationError).redirectUri).toBeUndefined();
+          expect((error as AuthorizationError).state).toBeUndefined();
+        }
+      }
     });
 
     it('should prioritize a missing response_type over later PKCE validation', async () => {
@@ -1595,7 +1625,9 @@ describe('OAuthProvider', () => {
           `&redirect_uri=${encodeURIComponent(redirectUri)}&state=state-123`
       );
 
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('invalid_request');
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toMatchObject({
+        code: 'invalid_request',
+      });
     });
 
     it('should reject a response type excluded by registered client metadata', async () => {
@@ -1622,7 +1654,9 @@ describe('OAuthProvider', () => {
           `&code_challenge=test-challenge&code_challenge_method=plain`
       );
 
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow('unauthorized_client');
+      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toMatchObject({
+        code: 'unauthorized_client',
+      });
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
     });
 
@@ -1734,7 +1768,7 @@ describe('OAuthProvider', () => {
           scope: ['read'],
           props: {},
         })
-      ).rejects.toThrow('unsupported_response_type');
+      ).rejects.toMatchObject({ code: 'unsupported_response_type' });
 
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys.map((key) => key.name)).toEqual(
         originalGrantKeys
@@ -1931,9 +1965,9 @@ describe('OAuthProvider', () => {
           `&scope=read%20write&state=xyz123`
       );
 
-      await expect(providerWithoutImplicit.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(
-        'unsupported_response_type'
-      );
+      await expect(providerWithoutImplicit.fetch(authRequest, mockEnv, mockCtx)).rejects.toMatchObject({
+        code: 'unsupported_response_type',
+      });
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
       expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
     });

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -1,5 +1,62 @@
 const OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
 
+export type AuthorizationErrorCode =
+  | 'invalid_request'
+  | 'unauthorized_client'
+  | 'access_denied'
+  | 'unsupported_response_type'
+  | 'invalid_scope'
+  | 'server_error'
+  | 'temporarily_unavailable';
+
+export interface AuthorizationErrorOptions {
+  /** Wire-safe OAuth authorization error description. */
+  description: string;
+  /** Exact registered redirect URI. Present only after client and redirect validation. */
+  redirectUri?: string;
+  /** Original client state, when supplied. */
+  state?: string;
+  /** Authorization server issuer for RFC 9207 error responses. */
+  issuer?: string;
+}
+
+/**
+ * Expected authorization-request validation failure. Absence of `redirectUri`
+ * means a caller MUST render locally and MUST NOT redirect.
+ */
+export class AuthorizationError extends Error {
+  public readonly code: AuthorizationErrorCode;
+  public readonly description: string;
+  public readonly redirectUri?: string;
+  public readonly state?: string;
+  public readonly issuer?: string;
+
+  constructor(code: AuthorizationErrorCode, options: AuthorizationErrorOptions) {
+    super(options.description);
+    this.name = 'AuthorizationError';
+    this.code = code;
+    this.description = options.description;
+    this.redirectUri = options.redirectUri;
+    this.state = options.state;
+    this.issuer = options.issuer;
+  }
+}
+
+/** @internal Attach context after exact client redirect validation succeeds. */
+export function withAuthorizationRedirect(
+  error: AuthorizationError,
+  redirectUri: string,
+  state: string | undefined,
+  issuer: string
+): AuthorizationError {
+  return new AuthorizationError(error.code, {
+    description: error.description,
+    redirectUri,
+    state,
+    issuer,
+  });
+}
+
 /** PKCE transformation methods implemented by the authorization server. */
 export type PkceCodeChallengeMethod = 'plain' | 'S256';
 
@@ -60,12 +117,18 @@ export function validateAuthorizationResponseType(
   responseType: string,
   clientResponseTypes: readonly string[] | undefined
 ): void {
-  if (!responseType) throw new Error('invalid_request: response_type is required');
+  if (!responseType) {
+    throw new AuthorizationError('invalid_request', { description: 'response_type is required' });
+  }
   if (!server.responseTypes.includes(responseType)) {
-    throw new Error(`unsupported_response_type: the authorization server does not support ${responseType}`);
+    throw new AuthorizationError('unsupported_response_type', {
+      description: `The authorization server does not support response_type ${responseType}`,
+    });
   }
   if (!(clientResponseTypes ?? ['code']).includes(responseType)) {
-    throw new Error(`unauthorized_client: the client is not registered for response_type ${responseType}`);
+    throw new AuthorizationError('unauthorized_client', {
+      description: `The client is not registered for response_type ${responseType}`,
+    });
   }
 }
 
@@ -73,7 +136,9 @@ export function validateAuthorizationResponseType(
 export function normalizePkceCodeChallengeMethod(method: string | undefined): PkceCodeChallengeMethod {
   const effectiveMethod = method ?? 'plain';
   if (effectiveMethod !== 'plain' && effectiveMethod !== 'S256') {
-    throw new Error(`Unsupported PKCE code_challenge_method: ${effectiveMethod}`);
+    throw new AuthorizationError('invalid_request', {
+      description: `Unsupported PKCE code_challenge_method: ${effectiveMethod}`,
+    });
   }
   return effectiveMethod;
 }
@@ -85,7 +150,9 @@ export function validatePkceCodeChallengeMethod(
 ): PkceCodeChallengeMethod {
   const effectiveMethod = normalizePkceCodeChallengeMethod(method);
   if (!server.codeChallengeMethods.includes(effectiveMethod)) {
-    throw new Error('The plain PKCE method is not allowed. Use S256 instead.');
+    throw new AuthorizationError('invalid_request', {
+      description: 'The plain PKCE method is not allowed. Use S256 instead.',
+    });
   }
   return effectiveMethod;
 }
@@ -105,10 +172,14 @@ export function validateAuthorizationPkce(
     return;
   }
   if (request.codeChallengeMethod) {
-    throw new Error('PKCE code_challenge is required when code_challenge_method is provided.');
+    throw new AuthorizationError('invalid_request', {
+      description: 'PKCE code_challenge is required when code_challenge_method is provided.',
+    });
   }
   if (request.responseType === 'code' && client.tokenEndpointAuthMethod === 'none') {
-    throw new Error('Public clients must use PKCE with the authorization code flow.');
+    throw new AuthorizationError('invalid_request', {
+      description: 'Public clients must use PKCE with the authorization code flow.',
+    });
   }
 }
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1,6 +1,7 @@
 import { WorkerEntrypoint } from 'cloudflare:workers';
 
 import {
+  AuthorizationError,
   buildOAuthServerCapabilities,
   isValidOAuthScopeToken,
   normalizePkceCodeChallengeMethod,
@@ -9,6 +10,7 @@ import {
   validatePkceCodeChallengeMethod,
   validateAuthorizationServerScopes,
   validateClientCapabilities,
+  withAuthorizationRedirect,
   type OAuthServerCapabilities,
   type PkceCodeChallengeMethod,
 } from './oauth-capabilities';
@@ -35,6 +37,9 @@ import {
   validateIdJagClaims,
   validateIdJagHeader,
 } from './ema/validators';
+
+export { AuthorizationError } from './oauth-capabilities';
+export type { AuthorizationErrorCode, AuthorizationErrorOptions } from './oauth-capabilities';
 
 export type {
   EmaClaimsMapper,
@@ -5424,7 +5429,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
    * Parses an OAuth authorization request from the HTTP request
    * @param request - The HTTP request containing OAuth parameters
    * @returns The parsed authorization request parameters
-   * @throws Error when the response type is missing, unsupported, or not registered for the client
+   * @throws AuthorizationError for expected authorization-request validation failures
    * @throws CimdFetchError when the client ID is a CIMD URL whose document cannot be resolved
    */
   async parseAuthRequest(request: Request): Promise<AuthRequest> {
@@ -5442,47 +5447,58 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     const resourceParam =
       resourceParams.length > 0 ? (resourceParams.length === 1 ? resourceParams[0] : resourceParams) : undefined;
 
-    // Validate redirect URI to prevent javascript: URIs / XSS attacks
-    // Using helper function that normalizes and checks in a case-insensitive manner
-    validateRedirectUriScheme(redirectUri);
+    if (!clientId) {
+      throw new AuthorizationError('invalid_request', { description: 'client_id is required' });
+    }
 
-    // Parse and validate the resource parameter (RFC 8707). An explicitly
-    // configured resource is deployment policy and therefore requires one
-    // exact value. Without that policy, RFC 8707 §2.1 allows the authorization
-    // server to use a predefined default; the request origin is the safest
-    // interoperable default available to a co-located AS/RS deployment.
+    const clientInfo = await this.lookupClient(clientId);
+    if (!clientInfo) {
+      throw new AuthorizationError('invalid_request', { description: 'Invalid client_id' });
+    }
+
+    try {
+      validateRedirectUriScheme(redirectUri);
+    } catch {
+      throw new AuthorizationError('invalid_request', { description: 'Invalid redirect URI' });
+    }
+    if (!redirectUri || !isValidRedirectUri(redirectUri, clientInfo.redirectUris)) {
+      throw new AuthorizationError('invalid_request', { description: 'Invalid redirect URI' });
+    }
+
+    const withRedirect = (error: AuthorizationError): never => {
+      throw withAuthorizationRedirect(error, redirectUri, state || undefined, issuer);
+    };
+
+    // Resource, response type, and PKCE errors are redirectable only after the
+    // exact client redirect URI above has been validated.
     let resource = parseResourceParameter(resourceParam);
     if (resourceParam && !resource) {
-      throw new Error('The resource parameter must be a valid absolute URI without a fragment');
+      withRedirect(
+        new AuthorizationError('invalid_request', {
+          description: 'The resource parameter must be a valid absolute URI without a fragment',
+        })
+      );
     }
     const configuredResource = this.provider.options.resourceMetadata?.resource;
     if (configuredResource && !isExactResource(resource, configuredResource)) {
-      throw new Error(`The resource parameter must exactly match ${configuredResource}`);
+      withRedirect(
+        new AuthorizationError('invalid_request', {
+          description: `The resource parameter must exactly match ${configuredResource}`,
+        })
+      );
     }
     resource ??= url.origin;
 
-    // Validate the client ID and redirect URI
-    if (clientId) {
-      const clientInfo = await this.lookupClient(clientId);
-
-      if (!clientInfo) {
-        throw new Error(`Invalid client. The clientId provided does not match to this client.`);
-      }
-      if (!redirectUri || !isValidRedirectUri(redirectUri, clientInfo.redirectUris)) {
-        throw new Error(
-          `Invalid redirect URI. The redirect URI provided does not match any registered URI for this client.`
-        );
-      }
+    try {
       validateAuthorizationResponseType(this.provider.serverCapabilities, responseType, clientInfo.responseTypes);
       validateAuthorizationPkce(
         this.provider.serverCapabilities,
-        {
-          responseType,
-          codeChallenge,
-          codeChallengeMethod,
-        },
+        { responseType, codeChallenge, codeChallengeMethod },
         clientInfo
       );
+    } catch (error) {
+      if (error instanceof AuthorizationError) withRedirect(error);
+      throw error;
     }
 
     return {


### PR DESCRIPTION
## Summary

Export a structured `AuthorizationError` from `parseAuthRequest()` so applications can distinguish authorization failures that must be rendered locally from those safe to return through a validated OAuth error redirect.

```ts
try {
  request = await env.OAUTH_PROVIDER.parseAuthRequest(raw)
} catch (error) {
  if (!(error instanceof AuthorizationError)) throw error
  if (!error.redirectUri) return renderLocalError(error)
  return redirectOAuthError(error)
}
```

## Security contract

`redirectUri` presence is the redirect-safety proof:

- missing/unknown client and invalid redirect URI errors omit `redirectUri`, `state`, and `issuer`;
- only after exact client redirect validation succeeds do resource, response-type, and PKCE failures carry the validated `redirectUri`, original `state`, and RFC 9207 `issuer`;
- CIMD resolution remains the separate tagged `CimdFetchError`;
- KV, transport, and unexpected programming failures remain untagged and visible.

The error `code` is a typed OAuth authorization-endpoint vocabulary. Validation helpers also throw `AuthorizationError`, keeping `completeAuthorization()` revalidation consistent, but redirect context is attached only by `parseAuthRequest()`.

## Standards

- OAuth 2.1 §4.1.2.1: invalid client/redirect failures must not redirect
- OAuth 2.1 authorization errors: `invalid_request`, `unauthorized_client`, `unsupported_response_type`
- RFC 9207: error redirects include authorization server issuer identification
- MCP 2026-07-28 authorization response validation

## Validation

- `npm run check`: 8 files, 798 tests
- `npm run build`
