### PR TITLE
fix(cimd): negotiate optional client capabilities

### DIFF
--- a/.changeset/calm-clients-negotiate.md
+++ b/.changeset/calm-clients-negotiate.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Negotiate Client ID Metadata Document grant and response types with the authorization server's supported capabilities instead of rejecting documents that advertise additional values.

--- a/__tests__/oauth-capabilities.test.ts
+++ b/__tests__/oauth-capabilities.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   AuthorizationError,
   buildOAuthServerCapabilities,
+  negotiateCimdClientCapabilities,
   normalizePkceCodeChallengeMethod,
   validateAuthorizationPkce,
   validateAuthorizationResponseType,
@@ -88,6 +89,65 @@ describe('OAuth server capabilities', () => {
         responseTypes: ['code'],
       })
     ).not.toThrow();
+  });
+
+  it('negotiates a supported CIMD subset from additional advertised capabilities', () => {
+    expect(
+      negotiateCimdClientCapabilities(defaults, {
+        tokenEndpointAuthMethod: 'none',
+        grantTypes: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+        responseTypes: ['code', 'id_token'],
+      })
+    ).toEqual({
+      tokenEndpointAuthMethod: 'none',
+      grantTypes: ['authorization_code', 'refresh_token'],
+      responseTypes: ['code'],
+    });
+  });
+
+  it('does not enable capabilities that a CIMD client omitted', () => {
+    expect(
+      negotiateCimdClientCapabilities(defaults, {
+        tokenEndpointAuthMethod: 'none',
+        grantTypes: ['urn:example:unsupported-grant'],
+        responseTypes: ['id_token'],
+      })
+    ).toEqual({
+      tokenEndpointAuthMethod: 'none',
+      grantTypes: [],
+      responseTypes: [],
+    });
+  });
+
+  it('retains JWT bearer when enterprise-managed authorization is enabled', () => {
+    const withEnterpriseManagedAuthorization = buildOAuthServerCapabilities({
+      allowImplicitFlow: false,
+      allowPlainPKCE: false,
+      allowTokenExchangeGrant: false,
+      enterpriseManagedAuthorization: true,
+    });
+
+    expect(
+      negotiateCimdClientCapabilities(withEnterpriseManagedAuthorization, {
+        tokenEndpointAuthMethod: 'none',
+        grantTypes: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+        responseTypes: ['code'],
+      })
+    ).toEqual({
+      tokenEndpointAuthMethod: 'none',
+      grantTypes: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+      responseTypes: ['code'],
+    });
+  });
+
+  it('rejects an inconsistent effective CIMD capability subset', () => {
+    expect(() =>
+      negotiateCimdClientCapabilities(defaults, {
+        tokenEndpointAuthMethod: 'none',
+        grantTypes: ['authorization_code', 'urn:example:unsupported-grant'],
+        responseTypes: ['id_token'],
+      })
+    ).toThrow('grant_types authorization_code and response_types code must be registered together');
   });
 });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -11073,11 +11073,30 @@ describe('OAuthProvider', () => {
         await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
       });
 
-      it.each([
-        ['an unsupported grant type', { grant_types: ['password'], response_types: [] }],
-        ['an unsupported response type', { grant_types: [], response_types: ['id_token'] }],
-        ['an inconsistent grant and response type', { grant_types: ['authorization_code'], response_types: [] }],
-      ])('should reject CIMD metadata with %s', async (_label, metadata) => {
+      it('should negotiate supported capabilities from Claude.ai-style CIMD metadata', async () => {
+        const cimdUrl = 'https://claude.ai/oauth/mcp-oauth-client-metadata';
+        const metadata = {
+          client_id: cimdUrl,
+          client_name: 'Claude',
+          client_uri: 'https://claude.ai',
+          redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+          token_endpoint_auth_method: 'none',
+          grant_types: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+          response_types: ['code'],
+        };
+        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(metadata)));
+
+        const authRequest = createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}&redirect_uri=${encodeURIComponent('https://claude.ai/api/mcp/auth_callback')}&response_type=code&state=test-state&code_challenge=test-challenge&code_challenge_method=S256`,
+          'GET'
+        );
+
+        const authResponse = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+
+        expect(authResponse.status).toBe(302);
+      });
+
+      it('should reject CIMD metadata with inconsistent effective grant and response types', async () => {
         const cimdUrl = 'https://client.example.com/oauth/metadata.json';
         globalThis.fetch = vi.fn().mockResolvedValue(
           createMockFetchResponse({
@@ -11085,7 +11104,8 @@ describe('OAuthProvider', () => {
             client_name: 'Invalid Capabilities Client',
             redirect_uris: ['https://client.example.com/callback'],
             token_endpoint_auth_method: 'none',
-            ...metadata,
+            grant_types: ['authorization_code', 'urn:example:unsupported-grant'],
+            response_types: ['id_token'],
           })
         );
 

--- a/conformance/client-registration.test.ts
+++ b/conformance/client-registration.test.ts
@@ -102,7 +102,7 @@ describe.each(mcpAuthRevisionsSince('2025-11-25'))('MCP %s client registration c
     expect(tokens.access_token).toBeTruthy();
   });
 
-  it('advertises CIMD and completes a public-client flow from a metadata document', async () => {
+  it('negotiates CIMD capabilities and completes a public-client flow from a metadata document', async () => {
     const clientId = 'https://client.example.com/oauth/client-metadata.json';
     const client: OAuthClientCredentials = {
       clientId,
@@ -115,8 +115,8 @@ describe.each(mcpAuthRevisionsSince('2025-11-25'))('MCP %s client registration c
         client_id: clientId,
         client_name: 'MCP CIMD conformance client',
         redirect_uris: [CLIENT_REDIRECT_URI],
-        grant_types: ['authorization_code', 'refresh_token'],
-        response_types: ['code'],
+        grant_types: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+        response_types: ['code', 'id_token'],
         token_endpoint_auth_method: 'none',
       });
     });

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -112,6 +112,30 @@ export function validateClientCapabilities(server: OAuthServerCapabilities, clie
   }
 }
 
+/**
+ * Selects the capabilities from a Client ID Metadata Document that this
+ * authorization server supports. CIMD documents may advertise extension
+ * capabilities alongside the flow used with this server, so unsupported grant
+ * and response types are omitted from the effective client metadata instead of
+ * invalidating an otherwise usable client.
+ *
+ * The effective subset is still checked for grant/response consistency, and
+ * token endpoint authentication must have a mutually supported method.
+ */
+export function negotiateCimdClientCapabilities(
+  server: OAuthServerCapabilities,
+  client: ClientCapabilities
+): { grantTypes: string[]; responseTypes: string[]; tokenEndpointAuthMethod: string } {
+  const effective = {
+    grantTypes: client.grantTypes.filter((grantType) => server.grantTypes.includes(grantType)),
+    responseTypes: client.responseTypes.filter((responseType) => server.responseTypes.includes(responseType)),
+    tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+  };
+
+  validateClientCapabilities(server, effective);
+  return effective;
+}
+
 export function validateAuthorizationResponseType(
   server: OAuthServerCapabilities,
   responseType: string,

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -4,6 +4,7 @@ import {
   AuthorizationError,
   buildOAuthServerCapabilities,
   isValidOAuthScopeToken,
+  negotiateCimdClientCapabilities,
   normalizePkceCodeChallengeMethod,
   validateAuthorizationPkce,
   validateAuthorizationResponseType,
@@ -4451,17 +4452,18 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         );
       }
 
-      const grantTypes = OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
+      const advertisedGrantTypes = OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
         GrantType.AUTHORIZATION_CODE,
       ];
-      const responseTypes = OAuthProviderImpl.validateStringArray(rawMetadata.response_types, 'response_types') || [
-        'code',
-      ];
+      const advertisedResponseTypes = OAuthProviderImpl.validateStringArray(
+        rawMetadata.response_types,
+        'response_types'
+      ) || ['code'];
       const effectiveAuthMethod = tokenEndpointAuthMethod || 'none';
-      validateClientCapabilities(this.serverCapabilities, {
+      const { grantTypes, responseTypes } = negotiateCimdClientCapabilities(this.serverCapabilities, {
         tokenEndpointAuthMethod: effectiveAuthMethod,
-        grantTypes,
-        responseTypes,
+        grantTypes: advertisedGrantTypes,
+        responseTypes: advertisedResponseTypes,
       });
 
       return {


### PR DESCRIPTION
## Summary

- derive the effective CIMD grant and response types from the capabilities shared by the client and authorization server
- keep token endpoint authentication validation strict and preserve the existing strict DCR behavior
- cover Claude.ai-style metadata in unit, provider integration, and full Workerd conformance tests

## Why

Claude.ai's Client ID Metadata Document advertises `authorization_code` and `refresh_token` alongside the optional JWT bearer grant. A server without enterprise-managed authorization currently rejects the whole client document before the otherwise supported authorization-code flow can begin.

For CIMD, this change treats advertised grant and response types as capabilities to negotiate. It only removes values the server does not support, never enables a value omitted by the client, and validates the resulting subset for grant/response consistency. If enterprise-managed authorization is configured, JWT bearer remains in the effective metadata.

Dynamic client registration remains unchanged and continues to reject unsupported requested capabilities.

Related interoperability report: https://github.com/anthropics/claude-ai-mcp/issues/487

## Validation

- `npm run check` (typecheck and 801 tests)
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `npm pack --dry-run`

Includes a patch changeset.
