### PR TITLE
fix(auth): preserve legacy client-secret transports

### DIFF
--- a/.changeset/calm-clients-authenticate.md
+++ b/.changeset/calm-clients-authenticate.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Preserve Basic and POST authentication interoperability for legacy and defaulted confidential clients while keeping explicit registrations strict.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,10 @@ MCP 2026-07-28 deprecates DCR for new implementations in favor of CIMD. The endp
 
 Registration accepts only authentication methods, grants, and response types implemented by the configured provider, and rejects inconsistent grant/response combinations before storage. Omitted metadata uses the RFC 7591 defaults: `client_secret_basic`, `grant_types: ["authorization_code"]`, and `response_types: ["code"]`.
 
+An explicitly supplied `token_endpoint_auth_method` is enforced exactly. For compatibility with clients registered before method provenance was stored, confidential client records without provenance—and new registrations that default to `client_secret_basic`—may authenticate with either `client_secret_basic` or `client_secret_post`, but only after the same stored client secret validates. This compatibility never crosses between `none` and a secret method and does not apply to CIMD clients. Calling `OAuthHelpers.updateClient()` with an explicit `tokenEndpointAuthMethod` marks an older client strict; unrelated updates preserve its existing policy.
+
+Clients that explicitly register one secret transport but present the other must be upgraded. A pre-policy record receives the migration fallback until it expires, but re-registering with an explicit method creates a strict record.
+
 Related options:
 
 - `clientRegistrationTTL` controls the lifetime of dynamically registered clients. The default is 90 days.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -954,6 +954,8 @@ describe('OAuthProvider', () => {
       expect(savedClient.clientId).toBe(registeredClient.client_id);
       // Secret should be stored as a hash
       expect(savedClient.clientSecret).not.toBe(registeredClient.client_secret);
+      expect(savedClient.tokenEndpointAuthMethodPolicy).toBe('strict');
+      expect(registeredClient.tokenEndpointAuthMethodPolicy).toBeUndefined();
     });
 
     it('should register a public client', async () => {
@@ -985,6 +987,7 @@ describe('OAuthProvider', () => {
       const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
       expect(savedClient).not.toBeNull();
       expect(savedClient.clientSecret).toBeUndefined(); // No secret stored
+      expect(savedClient.tokenEndpointAuthMethodPolicy).toBe('strict');
     });
 
     it('should apply RFC 7591 defaults and return the values actually registered', async () => {
@@ -999,6 +1002,8 @@ describe('OAuthProvider', () => {
       const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
       expect(savedClient.grantTypes).toEqual(['authorization_code']);
       expect(savedClient.responseTypes).toEqual(['code']);
+      expect(savedClient.tokenEndpointAuthMethodPolicy).toBe('legacy-compatible');
+      expect(registeredClient.tokenEndpointAuthMethodPolicy).toBeUndefined();
     });
 
     it('should accept enabled extension grant and response types', async () => {
@@ -2404,6 +2409,38 @@ describe('OAuthProvider', () => {
       };
     }
 
+    async function seedV082Client(
+      tokenEndpointAuthMethod: 'client_secret_basic' | 'client_secret_post',
+      options?: { expirationTtl?: number }
+    ): Promise<TestClientCredentials> {
+      const clientId = `v0.8.2-${tokenEndpointAuthMethod}-${crypto.randomUUID()}`;
+      const clientSecret = 'v0.8.2-client-secret';
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(clientSecret));
+      const clientSecretHash = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join(
+        ''
+      );
+
+      // This intentionally mirrors the complete persisted client shape written by
+      // v0.8.2: it has a registered method but predates policy provenance.
+      await mockEnv.OAUTH_KV.put(
+        `client:${clientId}`,
+        JSON.stringify({
+          clientId,
+          clientSecret: clientSecretHash,
+          redirectUris: ['https://client.example.com/callback'],
+          clientName: 'v0.8.2 Client',
+          contacts: ['owner@example.com'],
+          grantTypes: ['authorization_code', 'refresh_token'],
+          responseTypes: ['code'],
+          registrationDate: 1_754_000_000,
+          tokenEndpointAuthMethod,
+        }),
+        options
+      );
+
+      return { clientId, clientSecret, tokenEndpointAuthMethod };
+    }
+
     // Helper to create a test client before authorization tests
     async function createTestClient(tokenEndpointAuthMethod: TokenEndpointAuthMethod = 'client_secret_post') {
       const client = await registerTestClient(tokenEndpointAuthMethod);
@@ -2498,6 +2535,306 @@ describe('OAuthProvider', () => {
         );
       }
     );
+
+    it.each([
+      ['client_secret_basic', 'client_secret_post'],
+      ['client_secret_post', 'client_secret_basic'],
+    ] as const)(
+      'accepts %s-to-%s transport interoperability for an exact v0.8.2 client record',
+      async (registeredMethod, presentedMethod) => {
+        const client = await seedV082Client(registeredMethod);
+        const response = await requestTokenWithClientAuthentication(client, presentedMethod);
+
+        expect(response.status).toBe(400);
+        expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+      }
+    );
+
+    it('requires the same stored secret before accepting a legacy-compatible transport', async () => {
+      const client = await seedV082Client('client_secret_post');
+      const response = await requestTokenWithClientAuthentication(
+        { ...client, clientSecret: 'not-the-registered-secret' },
+        'client_secret_basic'
+      );
+
+      await expectBasicClientError(response, 'Client authentication failed: invalid client_secret');
+    });
+
+    it('lets a newly defaulted confidential registration use Basic or POST without exposing policy metadata', async () => {
+      const registrationResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: ['https://client.example.com/callback'],
+            client_name: 'Defaulted Client',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const registration = await registrationResponse.json<any>();
+      const client: TestClientCredentials = {
+        clientId: registration.client_id,
+        clientSecret: registration.client_secret,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+      };
+
+      expect(registration.tokenEndpointAuthMethodPolicy).toBeUndefined();
+      for (const presentedMethod of ['client_secret_basic', 'client_secret_post'] as const) {
+        const response = await requestTokenWithClientAuthentication(client, presentedMethod);
+        expect(response.status).toBe(400);
+        expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+      }
+    });
+
+    it('does not rewrite or extend a legacy client record while authenticating it', async () => {
+      const client = await seedV082Client('client_secret_basic', { expirationTtl: 60 });
+      const put = vi.spyOn(mockEnv.OAUTH_KV, 'put');
+
+      const response = await requestTokenWithClientAuthentication(client, 'client_secret_post');
+      expect(response.status).toBe(400);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_grant' });
+      expect(put).not.toHaveBeenCalled();
+
+      const storedBeforeExpiry = await mockEnv.OAUTH_KV.get(`client:${client.clientId}`, { type: 'json' });
+      expect(storedBeforeExpiry.tokenEndpointAuthMethodPolicy).toBeUndefined();
+      mockEnv.OAUTH_KV.advanceTime(61_000);
+      expect(await mockEnv.OAUTH_KV.get(`client:${client.clientId}`, { type: 'json' })).toBeNull();
+    });
+
+    it.each([
+      ['client_secret_basic', 'client_secret_post'],
+      ['client_secret_post', 'client_secret_basic'],
+    ] as const)(
+      'uses %s-to-%s compatibility for revocation while keeping explicit clients strict',
+      async (registeredMethod, presentedMethod) => {
+        const revoke = (client: TestClientCredentials): Promise<Response> => {
+          const body = new URLSearchParams({ token: 'already-unknown-token' });
+          const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded' };
+          if (presentedMethod === 'client_secret_basic') {
+            headers.Authorization = `Basic ${btoa(`${client.clientId}:${client.clientSecret}`)}`;
+          } else {
+            body.set('client_id', client.clientId);
+            body.set('client_secret', client.clientSecret!);
+          }
+          return oauthProvider.fetch(
+            createMockRequest('https://example.com/oauth/token', 'POST', headers, body.toString()),
+            mockEnv,
+            mockCtx
+          );
+        };
+
+        const legacyResponse = await revoke(await seedV082Client(registeredMethod));
+        expect(legacyResponse.status).toBe(200);
+
+        const strictResponse = await revoke(await registerTestClient(registeredMethod));
+        expect(strictResponse.status).toBe(401);
+        expect(strictResponse.headers.get('WWW-Authenticate')).toBe(
+          presentedMethod === 'client_secret_basic' ? 'Basic realm="OAuth"' : null
+        );
+        expect(await strictResponse.json<any>()).toEqual({
+          error: 'invalid_client',
+          error_description: 'Client authentication failed',
+        });
+      }
+    );
+
+    it('does not broaden compatibility to public, malformed, unknown, or secretless records', async () => {
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('stored-secret'));
+      const clientSecret = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+      const cases = [
+        { suffix: 'public', tokenEndpointAuthMethod: 'none', includeSecret: false },
+        { suffix: 'missing-method', tokenEndpointAuthMethod: undefined, includeSecret: true },
+        { suffix: 'unknown-method', tokenEndpointAuthMethod: 'private_key_jwt', includeSecret: true },
+        { suffix: 'secretless', tokenEndpointAuthMethod: 'client_secret_basic', includeSecret: false },
+        {
+          suffix: 'unknown-policy',
+          tokenEndpointAuthMethod: 'client_secret_basic',
+          tokenEndpointAuthMethodPolicy: 'future-policy',
+          includeSecret: true,
+        },
+      ];
+
+      for (const testCase of cases) {
+        const clientId = `legacy-${testCase.suffix}`;
+        await mockEnv.OAUTH_KV.put(
+          `client:${clientId}`,
+          JSON.stringify({
+            clientId,
+            ...(testCase.includeSecret ? { clientSecret } : {}),
+            redirectUris: ['https://client.example.com/callback'],
+            ...(testCase.tokenEndpointAuthMethod === undefined
+              ? {}
+              : { tokenEndpointAuthMethod: testCase.tokenEndpointAuthMethod }),
+            ...('tokenEndpointAuthMethodPolicy' in testCase
+              ? { tokenEndpointAuthMethodPolicy: testCase.tokenEndpointAuthMethodPolicy }
+              : {}),
+          })
+        );
+        const response = await requestTokenWithClientAuthentication(
+          {
+            clientId,
+            clientSecret: 'stored-secret',
+            tokenEndpointAuthMethod: 'client_secret_post',
+          },
+          'client_secret_post'
+        );
+        expect(response.status, testCase.suffix).toBe(401);
+        expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
+      }
+
+      const confidentialClient = await seedV082Client('client_secret_basic');
+      const unauthenticatedResponse = await requestTokenWithClientAuthentication(confidentialClient, 'none');
+      expect(unauthenticatedResponse.status).toBe(401);
+      expect(await unauthenticatedResponse.json<any>()).toMatchObject({ error: 'invalid_client' });
+    });
+
+    it('treats a URL-shaped v0.8.2 KV client as stored metadata when CIMD is disabled', async () => {
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('stored-secret'));
+      const clientSecret = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+      const metadataUrlClientId = 'https://client.example.com/oauth/client.json';
+      await mockEnv.OAUTH_KV.put(
+        `client:${metadataUrlClientId}`,
+        JSON.stringify({
+          clientId: metadataUrlClientId,
+          clientSecret,
+          redirectUris: ['https://client.example.com/callback'],
+          tokenEndpointAuthMethod: 'client_secret_basic',
+        })
+      );
+      const metadataUrlResponse = await requestTokenWithClientAuthentication(
+        {
+          clientId: metadataUrlClientId,
+          clientSecret: 'stored-secret',
+          tokenEndpointAuthMethod: 'client_secret_post',
+        },
+        'client_secret_post'
+      );
+      expect(metadataUrlResponse.status).toBe(400);
+      expect(await metadataUrlResponse.json<any>()).toMatchObject({ error: 'invalid_grant' });
+    });
+
+    it('rejects missing secrets plus malformed and mixed Basic authentication for legacy records', async () => {
+      const client = await seedV082Client('client_secret_post');
+      const tokenBody = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: 'invalid-code',
+      });
+
+      const missingSecretResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.clientId}:`)}`,
+          },
+          tokenBody.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      await expectBasicClientError(missingSecretResponse, 'Client authentication failed: missing client_secret');
+
+      const malformedResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: 'Basic definitely-not-base64',
+          },
+          tokenBody.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      await expectBasicClientError(malformedResponse, 'Client authentication failed: invalid Basic credentials');
+
+      tokenBody.set('client_id', client.clientId);
+      tokenBody.set('client_secret', client.clientSecret!);
+      const mixedResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${btoa(`${client.clientId}:${client.clientSecret}`)}`,
+          },
+          tokenBody.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(mixedResponse.status).toBe(400);
+      expect(await mixedResponse.json<any>()).toEqual({
+        error: 'invalid_request',
+        error_description: 'Client must not use multiple authentication methods',
+      });
+    });
+
+    it('reports a stable internal mismatch reason while keeping the wire error generic', async () => {
+      const onError = vi.fn();
+      const provider = new OAuthProvider<TestEnv>({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        onError,
+      });
+      const clientId = 'strict-mismatch-client';
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('strict-secret'));
+      const clientSecret = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+      await mockEnv.OAUTH_KV.put(
+        `client:${clientId}`,
+        JSON.stringify({
+          clientId,
+          clientSecret,
+          redirectUris: ['https://client.example.com/callback'],
+          tokenEndpointAuthMethod: 'client_secret_basic',
+          tokenEndpointAuthMethodPolicy: 'strict',
+        })
+      );
+
+      const response = await provider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          new URLSearchParams({
+            grant_type: 'authorization_code',
+            code: 'invalid-code',
+            client_id: clientId,
+            client_secret: 'strict-secret',
+          }).toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json<any>()).toEqual({
+        error: 'invalid_client',
+        error_description: 'Client authentication failed',
+      });
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'invalid_client',
+          internal: {
+            category: 'client-authentication',
+            reason: 'token_endpoint_auth_method_mismatch',
+            detail: {
+              clientId,
+              registeredMethod: 'client_secret_basic',
+              presentedMethod: 'client_secret_post',
+            },
+          },
+        })
+      );
+    });
 
     it('should exchange auth code for tokens', async () => {
       // First get an auth code
@@ -9734,6 +10071,102 @@ describe('OAuthProvider', () => {
       // Verify client was deleted
       const clientsAfterDelete = await mockEnv.OAUTH_PROVIDER!.listClients();
       expect(clientsAfterDelete.items.length).toBe(0);
+    });
+
+    it('keeps authentication provenance internal and makes explicit updates strict', async () => {
+      await oauthProvider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+      const helpers = mockEnv.OAUTH_PROVIDER!;
+
+      const defaultedClient = await helpers.createClient({
+        redirectUris: ['https://defaulted.example.com/callback'],
+        clientName: 'Defaulted helper client',
+      });
+      const explicitClient = await helpers.createClient({
+        redirectUris: ['https://explicit.example.com/callback'],
+        clientName: 'Explicit helper client',
+        tokenEndpointAuthMethod: 'client_secret_post',
+      });
+
+      expect((defaultedClient as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect((explicitClient as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(
+        (await mockEnv.OAUTH_KV.get(`client:${defaultedClient.clientId}`, { type: 'json' }))
+          .tokenEndpointAuthMethodPolicy
+      ).toBe('legacy-compatible');
+      expect(
+        (await mockEnv.OAUTH_KV.get(`client:${explicitClient.clientId}`, { type: 'json' }))
+          .tokenEndpointAuthMethodPolicy
+      ).toBe('strict');
+
+      const preservedDefaultPolicy = await helpers.updateClient(defaultedClient.clientId, {
+        clientName: 'Renamed defaulted helper client',
+      });
+      expect((preservedDefaultPolicy as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(
+        (await mockEnv.OAUTH_KV.get(`client:${defaultedClient.clientId}`, { type: 'json' }))
+          .tokenEndpointAuthMethodPolicy
+      ).toBe('legacy-compatible');
+
+      const attemptedDowngrade = await helpers.updateClient(explicitClient.clientId, {
+        clientName: 'Still strict',
+        tokenEndpointAuthMethodPolicy: 'legacy-compatible',
+      } as any);
+      expect((attemptedDowngrade as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(
+        (await mockEnv.OAUTH_KV.get(`client:${explicitClient.clientId}`, { type: 'json' }))
+          .tokenEndpointAuthMethodPolicy
+      ).toBe('strict');
+
+      const postResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          new URLSearchParams({
+            grant_type: 'authorization_code',
+            code: 'invalid-code',
+            client_id: defaultedClient.clientId,
+            client_secret: defaultedClient.clientSecret!,
+          }).toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(postResponse.status).toBe(400);
+      expect(await postResponse.json<any>()).toMatchObject({ error: 'invalid_grant' });
+
+      const listed = await helpers.listClients();
+      expect(listed.items).toHaveLength(2);
+      expect(listed.items.every((client) => (client as any).tokenEndpointAuthMethodPolicy === undefined)).toBe(true);
+      expect(
+        ((await helpers.lookupClient(defaultedClient.clientId)) as any).tokenEndpointAuthMethodPolicy
+      ).toBeUndefined();
+
+      const legacyClientId = 'unversioned-helper-client';
+      await mockEnv.OAUTH_KV.put(
+        `client:${legacyClientId}`,
+        JSON.stringify({
+          clientId: legacyClientId,
+          clientSecret: 'pre-hashed-secret',
+          redirectUris: ['https://legacy.example.com/callback'],
+          clientName: 'Unversioned client',
+          tokenEndpointAuthMethod: 'client_secret_basic',
+        })
+      );
+
+      const unrelatedUpdate = await helpers.updateClient(legacyClientId, { clientName: 'Renamed unversioned client' });
+      expect((unrelatedUpdate as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(
+        (await mockEnv.OAUTH_KV.get(`client:${legacyClientId}`, { type: 'json' })).tokenEndpointAuthMethodPolicy
+      ).toBeUndefined();
+
+      const strictUpdate = await helpers.updateClient(legacyClientId, {
+        tokenEndpointAuthMethod: 'client_secret_basic',
+      });
+      expect((strictUpdate as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(
+        (await mockEnv.OAUTH_KV.get(`client:${legacyClientId}`, { type: 'json' })).tokenEndpointAuthMethodPolicy
+      ).toBe('strict');
     });
   });
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -864,6 +864,42 @@ export interface ClientInfo {
 }
 
 /**
+ * Internal storage provenance for token endpoint authentication policy.
+ *
+ * Records written before this field existed intentionally remain unversioned.
+ * They receive the same narrow confidential-client transport compatibility as
+ * newly defaulted registrations, while an explicitly selected method is strict.
+ */
+type ClientAuthMethodPolicy = 'strict' | 'legacy-compatible';
+
+interface StoredClientInfo extends ClientInfo {
+  tokenEndpointAuthMethodPolicy?: ClientAuthMethodPolicy;
+}
+
+function toPublicClientInfo(client: StoredClientInfo): ClientInfo {
+  const { tokenEndpointAuthMethodPolicy: _policy, ...publicClient } = client;
+  return publicClient;
+}
+
+function canUseLegacyConfidentialClientAuthTransport(
+  client: StoredClientInfo,
+  presentedMethod: string,
+  isClientMetadataDocument: boolean
+): boolean {
+  const isSecretMethod = (method: string): boolean =>
+    method === 'client_secret_basic' || method === 'client_secret_post';
+  const isCompatiblePolicy =
+    client.tokenEndpointAuthMethodPolicy === undefined || client.tokenEndpointAuthMethodPolicy === 'legacy-compatible';
+
+  return (
+    !isClientMetadataDocument &&
+    isCompatiblePolicy &&
+    isSecretMethod(client.tokenEndpointAuthMethod) &&
+    isSecretMethod(presentedMethod)
+  );
+}
+
+/**
  * Options for completing an authorization request
  */
 export interface CompleteAuthorizationOptions {
@@ -1947,7 +1983,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     }
 
     // Verify client exists
-    let clientInfo: ClientInfo | null;
+    let clientInfo: StoredClientInfo | null;
     try {
       clientInfo = await this.getClient(env, clientId);
     } catch (error) {
@@ -1981,8 +2017,25 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       : formData.has('client_secret')
         ? 'client_secret_post'
         : 'none';
-    if (presentedAuthMethod !== clientInfo.tokenEndpointAuthMethod) {
-      return this.createInvalidClientResponse('Client authentication failed', basicAuthenticationAttempted);
+    const registeredAuthMethod = clientInfo.tokenEndpointAuthMethod;
+    const canUseLegacyConfidentialTransport =
+      presentedAuthMethod !== registeredAuthMethod &&
+      canUseLegacyConfidentialClientAuthTransport(
+        clientInfo,
+        presentedAuthMethod,
+        !!this.options.clientIdMetadataDocumentEnabled && this.isClientMetadataUrl(clientInfo.clientId)
+      );
+
+    if (presentedAuthMethod !== registeredAuthMethod && !canUseLegacyConfidentialTransport) {
+      return this.createInvalidClientResponse('Client authentication failed', basicAuthenticationAttempted, {
+        category: 'client-authentication',
+        reason: 'token_endpoint_auth_method_mismatch',
+        detail: {
+          clientId: clientInfo.clientId,
+          registeredMethod: registeredAuthMethod,
+          presentedMethod: presentedAuthMethod,
+        },
+      });
     }
 
     // For confidential clients, validate the secret
@@ -3621,10 +3674,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       return this.createErrorResponse('invalid_request', { description: 'Invalid JSON payload', statusCode: 400 });
     }
 
+    let authMethodWasExplicit: boolean;
     let authMethod: string;
     let grantTypes: string[];
     let responseTypes: string[];
     try {
+      authMethodWasExplicit = clientMetadata.token_endpoint_auth_method !== undefined;
       authMethod =
         OAuthProviderImpl.validateStringField(clientMetadata.token_endpoint_auth_method) || 'client_secret_basic';
       grantTypes = OAuthProviderImpl.validateStringArray(clientMetadata.grant_types, 'grant_types') || [
@@ -3664,7 +3719,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       hashedSecret = await hashSecret(clientSecret);
     }
 
-    let clientInfo: ClientInfo;
+    let clientInfo: StoredClientInfo;
     try {
       // Validate redirect URIs - must exist and have at least one entry
       const redirectUris = OAuthProviderImpl.validateStringArray(clientMetadata.redirect_uris);
@@ -3692,6 +3747,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         responseTypes,
         registrationDate: Math.floor(Date.now() / 1000),
         tokenEndpointAuthMethod: authMethod,
+        tokenEndpointAuthMethodPolicy: authMethodWasExplicit ? 'strict' : 'legacy-compatible',
       };
 
       // Add client secret only for confidential clients
@@ -4055,7 +4111,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
    * propagate, and a CIMD metadata fetch failure throws `CimdFetchError`), so an
    * upstream outage is distinguishable from an unregistered client.
    */
-  async getClient(env: Env & ProviderEnv, clientId: string): Promise<ClientInfo | null> {
+  async getClient(env: Env & ProviderEnv, clientId: string): Promise<StoredClientInfo | null> {
     // Check if this is a CIMD (Client ID Metadata Document) URL
     if (this.isClientMetadataUrl(clientId)) {
       if (!this.options.clientIdMetadataDocumentEnabled) {
@@ -5528,7 +5584,8 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
    * validating the metadata document fails.
    */
   async lookupClient(clientId: string): Promise<ClientInfo | null> {
-    return await this.provider.getClient(this.env, clientId);
+    const client = await this.provider.getClient(this.env, clientId);
+    return client ? toPublicClientInfo(client) : null;
   }
 
   /**
@@ -5757,11 +5814,12 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     const clientId = generateRandomString(16);
 
     // Determine token endpoint auth method
+    const authMethodWasExplicit = clientInfo.tokenEndpointAuthMethod !== undefined;
     const tokenEndpointAuthMethod = clientInfo.tokenEndpointAuthMethod || 'client_secret_basic';
     const isPublicClient = tokenEndpointAuthMethod === 'none';
 
     // Create a new client object
-    const newClient: ClientInfo = {
+    const newClient: StoredClientInfo = {
       clientId,
       redirectUris: clientInfo.redirectUris || [],
       clientName: clientInfo.clientName,
@@ -5780,6 +5838,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
       responseTypes: clientInfo.responseTypes || ['code'],
       registrationDate: Math.floor(Date.now() / 1000),
       tokenEndpointAuthMethod,
+      tokenEndpointAuthMethodPolicy: authMethodWasExplicit ? 'strict' : 'legacy-compatible',
     };
 
     // Validate each redirect URI scheme
@@ -5798,7 +5857,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     await this.env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(newClient));
 
     // Create the response object
-    const clientResponse = { ...newClient };
+    const clientResponse = toPublicClientInfo(newClient);
 
     // Return confidential clients with their unhashed secret
     if (!isPublicClient && clientSecret) {
@@ -5836,7 +5895,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
       const clientId = key.name.substring('client:'.length);
       const client = await this.provider.getClient(this.env, clientId);
       if (client) {
-        clients.push(client);
+        clients.push(toPublicClientInfo(client));
       }
     });
 
@@ -5862,7 +5921,8 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     }
 
     // Determine token endpoint auth method
-    let authMethod = updates.tokenEndpointAuthMethod || client.tokenEndpointAuthMethod || 'client_secret_basic';
+    const authMethodWasExplicit = updates.tokenEndpointAuthMethod !== undefined;
+    const authMethod = updates.tokenEndpointAuthMethod || client.tokenEndpointAuthMethod || 'client_secret_basic';
     const isPublicClient = authMethod === 'none';
 
     // Handle changes in auth method
@@ -5878,11 +5938,14 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
       secretToStore = await hashSecret(updates.clientSecret);
     }
 
-    const updatedClient: ClientInfo = {
+    const updatedClient: StoredClientInfo = {
       ...client,
       ...updates,
       clientId: client.clientId, // Ensure clientId doesn't change
       tokenEndpointAuthMethod: authMethod, // Use determined auth method
+      // This is internal provenance: callers cannot inject or downgrade it through
+      // the public Partial<ClientInfo> update object.
+      tokenEndpointAuthMethodPolicy: authMethodWasExplicit ? 'strict' : client.tokenEndpointAuthMethodPolicy,
     };
 
     // Only include client secret for confidential clients
@@ -5900,7 +5963,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     await this.env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(updatedClient), clientKvOptions);
 
     // Create a response object
-    const response = { ...updatedClient };
+    const response = toPublicClientInfo(updatedClient);
 
     // For confidential clients, return unhashed secret if a new one was provided
     if (!isPublicClient && originalSecret) {

--- a/storage-schema.md
+++ b/storage-schema.md
@@ -46,13 +46,17 @@ Client records store OAuth client application information.
   "contacts": ["dev@example.com"],
   "grantTypes": ["authorization_code", "refresh_token"],
   "responseTypes": ["code"],
-  "registrationDate": 1644256123
+  "registrationDate": 1644256123,
+  "tokenEndpointAuthMethod": "client_secret_basic",
+  "tokenEndpointAuthMethodPolicy": "strict"
 }
 ```
 
 > **Note:** The `clientSecret` is stored as a SHA-256 hash, not in plaintext. The actual secret is only returned to the client when initially created or updated, and never stored.
 
 > **Note:** The optional `i18n` map holds RFC 7591 §2.2 internationalized variants of the human-readable metadata fields (`client_name`, `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`), keyed by the raw `field#<BCP 47 language tag>` member name. Canonical (un-tagged) values remain in their own fields. URI variants are validated as absolute http(s) URLs, the same as their canonical counterparts.
+
+> **Note:** `tokenEndpointAuthMethodPolicy` is internal storage metadata and is not returned by `OAuthHelpers`. `strict` means the stored `tokenEndpointAuthMethod` is enforced exactly. `legacy-compatible` marks a confidential registration whose method was defaulted. A missing policy identifies a pre-policy client record. For only `legacy-compatible` and missing-policy confidential records, `client_secret_basic` and `client_secret_post` are interchangeable after the stored secret validates. Public (`none`), CIMD, missing or unknown method, and secretless records remain strict. Authentication never rewrites the client record or its TTL; explicitly setting `tokenEndpointAuthMethod` with `OAuthHelpers.updateClient()` stores `strict`.
 
 **TTL:** Dynamically registered clients (DCR) default to 90 days. Clients created via `OAuthHelpers.createClient()` have no expiration. Configurable via the `clientRegistrationTTL` option.
 


### PR DESCRIPTION
## Summary

Preserve upgrades across the stricter token authentication enforcement introduced by #276 without weakening authentication for new explicit registrations.

- Store internal token-auth method provenance on new client records.
- Keep an explicitly registered or explicitly updated `token_endpoint_auth_method` strict.
- Let pre-policy confidential records and newly defaulted confidential registrations use either `client_secret_basic` or `client_secret_post`, but only when the same stored client secret validates.
- Apply the same compatibility rule to token issuance and revocation.
- Never relax `none` to a secret method, CIMD clients, unknown methods or policies, secretless records, malformed Basic credentials, or mixed authentication.
- Treat an HTTPS-shaped client ID as CIMD only when CIMD is enabled, so legacy URL-shaped KV client IDs retain the same migration behavior.
- Never write the client record or extend its KV TTL during authentication.
- Keep the policy marker out of DCR responses, helper APIs, and the exported `ClientInfo` type.

An explicit `OAuthHelpers.updateClient()` call with `tokenEndpointAuthMethod` marks an older record strict. Unrelated updates preserve its current provenance.

## Why

RFC 7591 defaults an omitted `token_endpoint_auth_method` to `client_secret_basic`, while many existing SDKs subsequently send the same secret with `client_secret_post`. The hard enforcement in #276 exposed that historical mismatch at upgrade time: post-deploy telemetry rose from near zero to roughly 11,000 `invalid_client` responses per 30 minutes across Copilot, Mistral, GitHub, and long-tail DCR clients.

This is a migration boundary, not a public-client relaxation. Both confidential transports still require the exact registered secret. New clients that explicitly choose a transport are enforced exactly. Clients that explicitly register one method but present the other must upgrade; after a pre-policy record expires, an explicit re-registration creates a strict record.

Standards context:

- [RFC 7591 Section 2](https://www.rfc-editor.org/rfc/rfc7591.html#section-2) defines the registration default.
- [RFC 6749 Section 2.3.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1) requires Basic support and permits request-body credentials.

## Compatibility matrix

| Stored client | Presented transport | Result |
| --- | --- | --- |
| Pre-policy/defaulted confidential | Basic or POST | Same secret required; accepted |
| Explicit strict confidential | Registered transport | Same secret required; accepted |
| Explicit strict confidential | Other transport | `401 invalid_client` |
| Public `none` | Any secret transport | Rejected |
| CIMD, unknown, malformed, or secretless | Fallback attempt | Rejected |

## Validation

- Exact serialized v0.8.2 client fixtures in both Basic-to-POST directions
- Token and revocation coverage
- Wrong/missing secret, public/secret boundary, CIMD, unknown policy/method, malformed Basic, and mixed-auth coverage
- URL-shaped v0.8.2 KV client coverage while CIMD is disabled
- No authentication-time KV write or TTL extension
- No marker leakage through DCR or OAuth helpers
- Explicit and unrelated update provenance coverage
- `npm run check` — 813 tests
- `npm run test:conformance` — 147 tests
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `npm pack --dry-run`
- `git diff --check`

Includes a patch changeset.
