### PR TITLE
fix(resource): preserve omission and legacy grants

### DIFF
--- a/.changeset/resource-parameter-compatibility.md
+++ b/.changeset/resource-parameter-compatibility.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Restore v0.8.2-compatible resource handling for grants without a stored RFC 8707 resource. Configured canonical resources are defaulted and inherited, bound grants reject explicit mismatches, and an unconfigured legacy grant can issue an unbound token or use an explicit token-request resource without persisting a new grant binding.
+
+Deprecate `resourceMatchOriginOnly` without changing its behavior.

--- a/README.md
+++ b/README.md
@@ -349,16 +349,11 @@ The provider owns `tokenEndpoint`. It exchanges authorization codes for tokens, 
 
 ## Resources and token audiences
 
-MCP clients must send the canonical MCP server URI as `resource` in authorization and token requests. The provider parses RFC 8707 resource indicators, stores the authorized resource on the grant, uses it as the access-token audience, and rejects resource expansion or audience mismatch.
+MCP clients are required to send the canonical MCP server URI as `resource` in authorization and token requests. The provider tolerates omission for compatibility: when `resourceMetadata.resource` is configured, it is used as the canonical default and inherited by later token requests; otherwise a token request inherits any resource already stored on the grant. An explicit resource that does not match a bound grant is rejected with `invalid_target`.
 
-Resource policy follows `resourceMetadata.resource`:
+Legacy grants may have no stored resource. With no configured canonical resource, omitting `resource` preserves that unbound state. If a client supplies a resource during code exchange or refresh, it applies to that issued token but is not persisted as a new grant binding. Path-aware audiences use path-boundary prefix matching, so a token for `https://example.com/mcp` can be used at `/mcp/tools`, but not at `/mcp-other`.
 
-- When configured, authorization requests, token requests, and externally resolved tokens must use that one exact resource. `resourceMatchOriginOnly` cannot weaken this policy.
-- When omitted, valid resources are accepted. Token requests may inherit the authorization resource. If the authorization request also omits it, the provider uses the request origin as the default and issues an origin-bound token.
-
-Path-aware audiences use path-boundary prefix matching. A token for `https://example.com/mcp` can be used at `/mcp/tools`, but not at `/mcp-other`. Split deployments and deployments requiring path isolation should configure the canonical resource explicitly.
-
-`resourceMatchOriginOnly` remains a migration option for grants created before path-aware resources were introduced. Do not enable it for a new deployment.
+`resourceMatchOriginOnly` is deprecated; its existing behavior is unchanged. Prefer `resourceMetadata.resource` for new deployments.
 
 ## Scopes and step-up authorization
 
@@ -435,7 +430,7 @@ Deleting a client through `OAuthHelpers.deleteClient()` also revokes its grants 
 | `allowTokenExchangeGrant`          | Enable RFC 8693                                          | `false`                                     |
 | `tokenExchangeCallback`            | Update props, scopes, or lifetimes during token exchange | None                                        |
 | `resolveExternalToken`             | Validate external bearer credentials (advanced)          | None                                        |
-| `resourceMatchOriginOnly`          | Migration mode for old origin-only resource grants       | `false`                                     |
+| `resourceMatchOriginOnly`          | Deprecated origin-only resource comparison               | `false`                                     |
 | `enterpriseManagedAuthorization`   | Enable experimental ID-JAG grant support                 | Disabled                                    |
 | `onError`                          | Observe or replace OAuth error responses                 | Logs a warning                              |
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -8,6 +8,7 @@ import {
   type OAuthHelpers,
   type OAuthProviderOptions,
   type OAuthTokenErrorCode,
+  type Grant,
   type Token,
 } from '../src/oauth-provider';
 import type { ExecutionContext } from '@cloudflare/workers-types';
@@ -670,6 +671,11 @@ describe('OAuthProvider', () => {
       [
         'an invalid resource identifier',
         { resource: 'mcp.example.com' },
+        'resourceMetadata.resource must be an absolute HTTP(S) URI without a fragment',
+      ],
+      [
+        'an empty resource identifier',
+        { resource: '' },
         'resourceMetadata.resource must be an absolute HTTP(S) URI without a fragment',
       ],
       [
@@ -3963,6 +3969,22 @@ describe('OAuthProvider', () => {
       clientSecret = client.client_secret;
     }
 
+    async function rewriteSubjectAudience(audience: string | string[] | undefined): Promise<void> {
+      const tokenKey = (await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys[0].name;
+      const tokenData = (await mockEnv.OAUTH_KV.get(tokenKey, { type: 'json' })) as Token;
+      if (audience === undefined) delete tokenData.audience;
+      else tokenData.audience = audience;
+      await mockEnv.OAUTH_KV.put(tokenKey, JSON.stringify(tokenData));
+    }
+
+    async function rewriteGrantResource(resource: string | string[] | undefined): Promise<void> {
+      const grantKey = (await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys[0].name;
+      const grant = (await mockEnv.OAUTH_KV.get(grantKey, { type: 'json' })) as Grant;
+      if (resource === undefined) delete grant.resource;
+      else grant.resource = resource;
+      await mockEnv.OAUTH_KV.put(grantKey, JSON.stringify(grant));
+    }
+
     async function exchangeAccessToken(subjectToken: string, scope?: string) {
       const params = new URLSearchParams();
       params.append('grant_type', 'urn:ietf:params:oauth:grant-type:token-exchange');
@@ -4419,6 +4441,27 @@ describe('OAuthProvider', () => {
       expect(newToken.access_token).not.toBe(accessToken);
       expect(newToken.token_type).toBe('bearer');
       expect(newToken.expires_in).toBeDefined();
+    });
+
+    it('should preserve a subject audience that is absent from a legacy grant when resource is omitted', async () => {
+      const subjectResource = 'https://api.example.com/subject';
+      await rewriteSubjectAudience(subjectResource);
+      await rewriteGrantResource(undefined);
+
+      const exchanged = await (mockEnv.OAUTH_PROVIDER as OAuthHelpers).exchangeToken({ subjectToken: accessToken });
+
+      expect(exchanged.resource).toBe(subjectResource);
+    });
+
+    it('should not expand a subject audience from its broader grant when resource is omitted', async () => {
+      const resourceA = 'https://api.example.com/a';
+      const resourceB = 'https://api.example.com/b';
+      await rewriteSubjectAudience(resourceA);
+      await rewriteGrantResource([resourceA, resourceB]);
+
+      const exchanged = await (mockEnv.OAUTH_PROVIDER as OAuthHelpers).exchangeToken({ subjectToken: accessToken });
+
+      expect(exchanged.resource).toBe(resourceA);
     });
 
     it('should exchange token via OAuthHelpers with narrowed scopes', async () => {
@@ -7300,7 +7343,7 @@ describe('OAuthProvider', () => {
       provider: OAuthProvider<TestEnv>,
       client: any,
       code: string,
-      resource?: string
+      resource?: string | string[]
     ): Promise<Response> {
       const params = new URLSearchParams({
         grant_type: 'authorization_code',
@@ -7309,7 +7352,10 @@ describe('OAuthProvider', () => {
         client_id: client.client_id,
         client_secret: client.client_secret,
       });
-      if (resource) params.set('resource', resource);
+      if (resource !== undefined) {
+        const resources = Array.isArray(resource) ? resource : [resource];
+        resources.forEach((value) => params.append('resource', value));
+      }
       return provider.fetch(
         createMockRequest(
           'https://example.com/oauth/token',
@@ -7322,17 +7368,65 @@ describe('OAuthProvider', () => {
       );
     }
 
-    it('should bind an omitted resource to the authorization origin without explicit resource configuration', async () => {
+    async function getOnlyGrant(): Promise<{ key: string; grant: Grant }> {
+      const keys = (await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys;
+      expect(keys).toHaveLength(1);
+      const key = keys[0].name;
+      const grant = (await mockEnv.OAUTH_KV.get(key, { type: 'json' })) as Grant | null;
+      expect(grant).not.toBeNull();
+      return { key, grant: grant! };
+    }
+
+    async function rewriteAsV082MissingResourceGrant(): Promise<{ key: string; grant: Grant }> {
+      const { key, grant } = await getOnlyGrant();
+      delete grant.resource;
+      await mockEnv.OAUTH_KV.put(key, JSON.stringify(grant));
+      return { key, grant };
+    }
+
+    async function refresh(
+      provider: OAuthProvider<TestEnv>,
+      client: any,
+      refreshToken: string,
+      resource?: string | string[]
+    ): Promise<Response> {
+      const params = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      });
+      if (resource !== undefined) {
+        const resources = Array.isArray(resource) ? resource : [resource];
+        resources.forEach((value) => params.append('resource', value));
+      }
+      return provider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+    }
+
+    it('should preserve an unbound flow when neither the provider nor client supplies a resource', async () => {
       const provider = createProvider();
       const client = await registerClient(provider);
       const authorization = await authorize(provider, client.client_id);
       const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      const { grant: authorizationGrant } = await getOnlyGrant();
+      expect(authorizationGrant.resource).toBeUndefined();
 
       const response = await exchangeCode(provider, client, code);
 
       expect(response.status).toBe(200);
       const tokens = await response.json<any>();
-      expect(tokens.resource).toBe('https://example.com');
+      expect(tokens.resource).toBeUndefined();
+      const { grant: exchangedGrant } = await getOnlyGrant();
+      expect(exchangedGrant.resource).toBeUndefined();
       const apiResponse = await provider.fetch(
         createMockRequest('https://example.com/api/test', 'GET', {
           Authorization: `Bearer ${tokens.access_token}`,
@@ -7341,6 +7435,12 @@ describe('OAuthProvider', () => {
         mockCtx
       );
       expect(apiResponse.status).toBe(200);
+
+      const refreshed = await refresh(provider, client, tokens.refresh_token);
+      expect(refreshed.status).toBe(200);
+      await expect(refreshed.json()).resolves.not.toHaveProperty('resource');
+      const { grant: refreshedGrant } = await getOnlyGrant();
+      expect(refreshedGrant.resource).toBeUndefined();
     });
 
     it('should inherit an authorization resource when the token request omits it', async () => {
@@ -7355,113 +7455,277 @@ describe('OAuthProvider', () => {
       await expect(response.json()).resolves.toMatchObject({ resource: 'https://example.com/api' });
     });
 
-    it('should not let a token request replace the authorization origin default', async () => {
+    it('should complete a reconstructed authorization request without resource or issuer as unbound', async () => {
       const provider = createProvider();
-      const client = await registerClient(provider);
-      const authorization = await authorize(provider, client.client_id);
-      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      await provider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+      const client = await mockEnv.OAUTH_PROVIDER!.createClient({
+        redirectUris: [redirectUri],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      });
 
-      const upscope = await exchangeCode(provider, client, code, 'https://other.example/resource');
-      expect(upscope.status).toBe(400);
-      await expect(upscope.json()).resolves.toMatchObject({ error: 'invalid_target' });
+      const result = await mockEnv.OAUTH_PROVIDER!.completeAuthorization({
+        request: {
+          responseType: 'code',
+          clientId: client.clientId,
+          redirectUri,
+          scope: [],
+          state: '',
+        },
+        userId: 'unbound-resource-policy-user',
+        metadata: {},
+        scope: [],
+        props: {},
+      });
 
-      const retry = await exchangeCode(provider, client, code);
-      expect(retry.status).toBe(200);
-      await expect(retry.json()).resolves.toMatchObject({ resource: 'https://example.com' });
+      expect(new URL(result.redirectTo).searchParams.get('code')).toBeTruthy();
+      const { grant } = await getOnlyGrant();
+      expect(grant.resource).toBeUndefined();
     });
 
-    it('should require exactly one configured resource during authorization', async () => {
+    it('should default an omitted authorization resource to the configured canonical resource', async () => {
       const provider = createProvider(configuredResource);
       const client = await registerClient(provider);
 
-      await expect(authorize(provider, client.client_id)).rejects.toThrow(
-        `The resource parameter must exactly match ${configuredResource}`
-      );
+      expect((await authorize(provider, client.client_id)).status).toBe(302);
+      const { grant } = await getOnlyGrant();
+      expect(grant.resource).toBe(configuredResource);
+
       await expect(
         authorize(provider, client.client_id, [configuredResource, 'https://other.example/resource'])
-      ).rejects.toThrow(`The resource parameter must exactly match ${configuredResource}`);
-      expect((await authorize(provider, client.client_id, [configuredResource])).status).toBe(302);
+      ).rejects.toMatchObject({
+        code: 'invalid_target',
+        description: `The resource parameter must exactly match ${configuredResource}`,
+      });
+      await expect(authorize(provider, client.client_id, [''])).rejects.toMatchObject({
+        code: 'invalid_target',
+      });
     });
 
-    it('should re-apply configured resource policy in completeAuthorization', async () => {
+    it('should default a reconstructed authorization request to the configured resource', async () => {
       const provider = createProvider(configuredResource);
       await provider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
       const client = await mockEnv.OAUTH_PROVIDER!.createClient({
         redirectUris: [redirectUri],
-        tokenEndpointAuthMethod: 'none',
+        tokenEndpointAuthMethod: 'client_secret_post',
       });
 
-      await expect(
-        mockEnv.OAUTH_PROVIDER!.completeAuthorization({
-          request: {
-            responseType: 'code',
-            clientId: client.clientId,
-            redirectUri,
-            scope: [],
-            state: '',
-          },
-          userId: 'resource-policy-user',
-          metadata: {},
+      const result = await mockEnv.OAUTH_PROVIDER!.completeAuthorization({
+        request: {
+          responseType: 'code',
+          clientId: client.clientId,
+          redirectUri,
           scope: [],
-          props: {},
-        })
-      ).rejects.toThrow(`The resource parameter must exactly match ${configuredResource}`);
+          state: '',
+        },
+        userId: 'resource-policy-user',
+        metadata: {},
+        scope: [],
+        props: {},
+      });
+
+      expect(new URL(result.redirectTo).searchParams.get('code')).toBeTruthy();
+      const { grant } = await getOnlyGrant();
+      expect(grant.resource).toBe(configuredResource);
     });
 
-    it('should require the exact configured resource at the token endpoint without consuming the code', async () => {
-      const provider = createProvider(configuredResource, { resourceMatchOriginOnly: true });
+    it('should inherit the configured grant resource at code exchange without allowing an override', async () => {
+      const provider = createProvider(configuredResource);
       const client = await registerClient(provider);
-      const authorization = await authorize(provider, client.client_id, [configuredResource]);
+      const authorization = await authorize(provider, client.client_id);
       const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
-
-      const missing = await exchangeCode(provider, client, code);
-      expect(missing.status).toBe(400);
-      await expect(missing.json()).resolves.toMatchObject({ error: 'invalid_target' });
 
       const broad = await exchangeCode(provider, client, code, 'https://example.com');
       expect(broad.status).toBe(400);
       await expect(broad.json()).resolves.toMatchObject({ error: 'invalid_target' });
 
-      const exact = await exchangeCode(provider, client, code, configuredResource);
-      expect(exact.status).toBe(200);
-      await expect(exact.json()).resolves.toMatchObject({ resource: configuredResource });
+      const malformed = await exchangeCode(provider, client, code, '');
+      expect(malformed.status).toBe(400);
+      await expect(malformed.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      const multiple = await exchangeCode(provider, client, code, [configuredResource, configuredResource]);
+      expect(multiple.status).toBe(400);
+      await expect(multiple.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      const inherited = await exchangeCode(provider, client, code);
+      expect(inherited.status).toBe(200);
+      await expect(inherited.json()).resolves.toMatchObject({ resource: configuredResource });
     });
 
-    it('should require the exact configured resource during refresh', async () => {
+    it('should inherit the configured grant resource during refresh without allowing an override', async () => {
       const provider = createProvider(configuredResource);
       const client = await registerClient(provider);
       const authorization = await authorize(provider, client.client_id, [configuredResource]);
       const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
-      const tokenResponse = await exchangeCode(provider, client, code, configuredResource);
+      const tokenResponse = await exchangeCode(provider, client, code);
       const tokens = await tokenResponse.json<any>();
-      const refresh = async (resource?: string) => {
-        const params = new URLSearchParams({
-          grant_type: 'refresh_token',
-          refresh_token: tokens.refresh_token,
-          client_id: client.client_id,
-          client_secret: client.client_secret,
-        });
-        if (resource) params.set('resource', resource);
-        return provider.fetch(
-          createMockRequest(
-            'https://example.com/oauth/token',
-            'POST',
-            { 'Content-Type': 'application/x-www-form-urlencoded' },
-            params.toString()
-          ),
-          mockEnv,
-          mockCtx
-        );
-      };
+      const { key } = await getOnlyGrant();
+      const grantBefore = await mockEnv.OAUTH_KV.get(key);
+      const tokenCountBefore = (await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys.length;
 
-      expect((await refresh()).status).toBe(400);
-      expect((await refresh('https://example.com')).status).toBe(400);
-      const exact = await refresh(configuredResource);
-      expect(exact.status).toBe(200);
-      await expect(exact.json()).resolves.toMatchObject({ resource: configuredResource });
+      const broad = await refresh(provider, client, tokens.refresh_token, 'https://example.com');
+      expect(broad.status).toBe(400);
+      await expect(broad.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      const malformed = await refresh(provider, client, tokens.refresh_token, '');
+      expect(malformed.status).toBe(400);
+      await expect(malformed.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      const multiple = await refresh(provider, client, tokens.refresh_token, [configuredResource, configuredResource]);
+      expect(multiple.status).toBe(400);
+      await expect(multiple.json()).resolves.toMatchObject({ error: 'invalid_target' });
+
+      expect(await mockEnv.OAUTH_KV.get(key)).toBe(grantBefore);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(tokenCountBefore);
+
+      const inherited = await refresh(provider, client, tokens.refresh_token);
+      expect(inherited.status).toBe(200);
+      await expect(inherited.json()).resolves.toMatchObject({ resource: configuredResource });
     });
 
-    it('should require the exact configured resource during token exchange', async () => {
+    it('should use the configured resource for a v0.8.2-shaped code grant without rewriting it', async () => {
+      const provider = createProvider(configuredResource);
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      const { key } = await rewriteAsV082MissingResourceGrant();
+      const legacyGrantBefore = await mockEnv.OAUTH_KV.get(key);
+      const tokenCountBefore = (await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys.length;
+
+      const blocked = await exchangeCode(provider, client, code, 'https://example.com');
+      expect(blocked.status).toBe(400);
+      await expect(blocked.json()).resolves.toMatchObject({ error: 'invalid_target' });
+      expect(await mockEnv.OAUTH_KV.get(key)).toBe(legacyGrantBefore);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(tokenCountBefore);
+
+      const migrated = await exchangeCode(provider, client, code);
+      expect(migrated.status).toBe(200);
+      await expect(migrated.json()).resolves.toMatchObject({ resource: configuredResource });
+      const storedGrant = (await mockEnv.OAUTH_KV.get(key, { type: 'json' })) as Grant | null;
+      expect(storedGrant?.resource).toBeUndefined();
+    });
+
+    it.each([
+      ['omitted', undefined],
+      ['explicit canonical', configuredResource],
+    ])(
+      'should use the configured resource for a v0.8.2-shaped refresh grant when the client resource is %s',
+      async (_label, requestedResource) => {
+        const provider = createProvider(configuredResource);
+        const client = await registerClient(provider);
+        const authorization = await authorize(provider, client.client_id);
+        const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+        const tokenResponse = await exchangeCode(provider, client, code);
+        const tokens = await tokenResponse.json<any>();
+        const { key } = await rewriteAsV082MissingResourceGrant();
+        const migrated = await refresh(provider, client, tokens.refresh_token, requestedResource);
+        expect(migrated.status).toBe(200);
+        await expect(migrated.json()).resolves.toMatchObject({ resource: configuredResource });
+        const storedGrant = (await mockEnv.OAUTH_KV.get(key, { type: 'json' })) as Grant | null;
+        expect(storedGrant?.resource).toBeUndefined();
+      }
+    );
+
+    it('should use changing explicit resources for an unbound legacy grant without persisting either one', async () => {
+      const provider = createProvider();
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      const { key } = await rewriteAsV082MissingResourceGrant();
+
+      const first = await exchangeCode(provider, client, code, 'https://example.com/first');
+      expect(first.status).toBe(200);
+      const firstTokens = await first.json<any>();
+      expect(firstTokens.resource).toBe('https://example.com/first');
+      expect(((await mockEnv.OAUTH_KV.get(key, { type: 'json' })) as Grant | null)?.resource).toBeUndefined();
+
+      const second = await refresh(provider, client, firstTokens.refresh_token, 'https://example.com/second');
+      expect(second.status).toBe(200);
+      const secondTokens = await second.json<any>();
+      expect(secondTokens.resource).toBe('https://example.com/second');
+      expect(((await mockEnv.OAUTH_KV.get(key, { type: 'json' })) as Grant | null)?.resource).toBeUndefined();
+
+      const omitted = await refresh(provider, client, secondTokens.refresh_token);
+      expect(omitted.status).toBe(200);
+      await expect(omitted.json()).resolves.not.toHaveProperty('resource');
+      expect(((await mockEnv.OAUTH_KV.get(key, { type: 'json' })) as Grant | null)?.resource).toBeUndefined();
+    });
+
+    it('should let a v0.8.2 grant with a stored resource inherit it when upgraded clients omit token resources', async () => {
+      const provider = createProvider();
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id, ['https://example.com/api']);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+
+      const exchanged = await exchangeCode(provider, client, code);
+      expect(exchanged.status).toBe(200);
+      const tokens = await exchanged.json<any>();
+      expect(tokens.resource).toBe('https://example.com/api');
+
+      const refreshed = await refresh(provider, client, tokens.refresh_token);
+      expect(refreshed.status).toBe(200);
+      await expect(refreshed.json()).resolves.toMatchObject({ resource: 'https://example.com/api' });
+    });
+
+    it('should reject a malformed legacy refresh resource before mutation and preserve omission', async () => {
+      const provider = createProvider();
+      const client = await registerClient(provider);
+      const authorization = await authorize(provider, client.client_id);
+      const code = new URL(authorization.headers.get('Location')!).searchParams.get('code')!;
+      const tokenResponse = await exchangeCode(provider, client, code);
+      const tokens = await tokenResponse.json<any>();
+      const { key } = await rewriteAsV082MissingResourceGrant();
+      const legacyGrantBefore = await mockEnv.OAUTH_KV.get(key);
+      const tokenCountBefore = (await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys.length;
+
+      const malformed = await refresh(provider, client, tokens.refresh_token, '');
+      expect(malformed.status).toBe(400);
+      await expect(malformed.json()).resolves.toMatchObject({ error: 'invalid_target' });
+      expect(await mockEnv.OAUTH_KV.get(key)).toBe(legacyGrantBefore);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(tokenCountBefore);
+
+      const unbound = await refresh(provider, client, tokens.refresh_token);
+      expect(unbound.status).toBe(200);
+      const unboundTokens = await unbound.json<any>();
+      expect(unboundTokens.resource).toBeUndefined();
+      const stillLegacy = (await mockEnv.OAUTH_KV.get(key, { type: 'json' })) as Grant | null;
+      expect(stillLegacy?.resource).toBeUndefined();
+    });
+
+    it('should reject an explicitly malformed reconstructed resource before writing grants', async () => {
+      const provider = createProvider();
+      await provider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
+      const client = await mockEnv.OAUTH_PROVIDER!.createClient({
+        redirectUris: [redirectUri],
+        tokenEndpointAuthMethod: 'client_secret_post',
+      });
+      const baseRequest = {
+        responseType: 'code' as const,
+        clientId: client.clientId,
+        redirectUri,
+        scope: [],
+        state: '',
+      };
+
+      for (const request of [
+        { ...baseRequest, resource: [] },
+        { ...baseRequest, resource: ['not a URI'] },
+      ]) {
+        await expect(
+          mockEnv.OAUTH_PROVIDER!.completeAuthorization({
+            request,
+            userId: 'invalid-reconstructed-resource-user',
+            metadata: {},
+            scope: [],
+            props: {},
+          })
+        ).rejects.toMatchObject({ code: 'invalid_target' });
+      }
+
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'grant:' })).keys).toHaveLength(0);
+      expect((await mockEnv.OAUTH_KV.list({ prefix: 'token:' })).keys).toHaveLength(0);
+    });
+
+    it('should inherit the configured grant resource during token exchange', async () => {
       const provider = createProvider(configuredResource, { allowTokenExchangeGrant: true });
       const client = await registerClient(provider);
       const authorization = await authorize(provider, client.client_id, [configuredResource]);
@@ -7469,14 +7733,15 @@ describe('OAuthProvider', () => {
       const tokenResponse = await exchangeCode(provider, client, code, configuredResource);
       const tokens = await tokenResponse.json<any>();
 
-      await expect(mockEnv.OAUTH_PROVIDER!.exchangeToken({ subjectToken: tokens.access_token })).rejects.toMatchObject({
-        code: 'invalid_target',
-      });
-      const exchanged = await mockEnv.OAUTH_PROVIDER!.exchangeToken({
-        subjectToken: tokens.access_token,
-        aud: configuredResource,
-      });
+      const exchanged = await mockEnv.OAUTH_PROVIDER!.exchangeToken({ subjectToken: tokens.access_token });
       expect(exchanged.resource).toBe(configuredResource);
+
+      await expect(
+        mockEnv.OAUTH_PROVIDER!.exchangeToken({
+          subjectToken: tokens.access_token,
+          aud: 'https://example.com',
+        })
+      ).rejects.toMatchObject({ code: 'invalid_target' });
     });
 
     it('should reject a legacy origin-wide internal audience when a path resource is configured', async () => {

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -23,7 +23,7 @@ The matrix follows every dated authorization revision represented by the officia
 
 Requirements are enabled from the revision that introduced them. Shared OAuth behavior is exercised against every revision, with the target revision sent in the `MCP-Protocol-Version` header.
 
-These are compatibility profiles, not server-side protocol negotiation. The common server profile stays fixed while client request behavior changes by revision: `2025-03-26` omits the RFC 8707 `resource` parameter, while `2025-06-18` and later include it in authorization and token requests. Exact canonical-resource pinning is tested separately because a deployment that requires `resource` cannot also accept an unmodified `2025-03-26` client.
+These are compatibility profiles, not server-side protocol negotiation. The common server profile stays fixed while client request behavior changes by revision: `2025-03-26` omits the RFC 8707 `resource` parameter, while `2025-06-18` and later include it in authorization and token requests. Canonical-resource pinning is tested separately: omission defaults to or inherits the configured canonical value, while explicit malformed or mismatched values fail with `invalid_target`.
 
 ## Coverage and traceability
 
@@ -58,7 +58,7 @@ The official [`latest` specification](https://modelcontextprotocol.io/specificat
 | Scope accumulation during step-up (SEP-2350)           | Primarily MCP client; resource server supplies current-operation scopes | `insufficient_scope` challenge includes all scopes required for the current operation                        |
 | OAuth well-known discovery suffix rules (SEP-2351)     | MCP client discovers; AS/RS publish metadata                            | RFC 8414 authorization-server metadata plus root and path-specific RFC 9728 metadata/challenges              |
 | DCR deprecation in favor of CIMD                       | Authorization server                                                    | CIMD advertisement, document validation, pre-registration, and optional DCR compatibility                    |
-| RFC 8707 Resource Indicators and audience restriction  | Authorization server and protected resource                             | Resource in both OAuth stages, exact strict-profile pinning, token response resource, and audience rejection |
+| RFC 8707 Resource Indicators and audience restriction  | Authorization server and protected resource                             | Canonical default/inheritance, exact explicit-value pinning, token response resource, and audience rejection |
 
 The broader `2026-07-28` protocol changes—stateless request `_meta`, `server/discover`, MCP method headers, tools, and transport lifecycle—are intentionally out of scope because this package does not implement MCP transport or protocol methods.
 
@@ -68,7 +68,7 @@ Authorization extensions are versioned separately from the core release. Stable 
 
 The upstream `@modelcontextprotocol/conformance` authorization-server mode currently exposes two scenarios—metadata and authorization code grant—and applies both to all four dates. The real Worker fixture passed both upstream scenarios for every date using upstream `0.2.0-alpha.10` (`49103de`) over a local HTTPS issuer.
 
-The upstream authorization-code scenario does not send RFC 8707 `resource`, so it cannot establish `2025-06-18+` Resource Indicator conformance against a strict server. This suite covers those upstream checks and adds the revision-specific protected-resource, audience, registration, scope, refresh, revocation, and issuer scenarios listed above.
+The upstream authorization-code scenario does not send RFC 8707 `resource`. The provider safely defaults a configured canonical resource at authorization and inherits it at code exchange, so that compatibility scenario remains audience-bound. This suite also tests explicit Resource Indicators and adds the revision-specific protected-resource, audience, registration, scope, refresh, revocation, and issuer scenarios listed above.
 
 ## Test architecture
 
@@ -80,7 +80,7 @@ The upstream authorization-code scenario does not send RFC 8707 `resource`, so i
 - a protected `/mcp` handler that exposes only authenticated props; and
 - the canonical resource `https://mcp.example.com/mcp` where the revision requires Resource Indicators.
 
-`support/oauth-client.ts` is the OAuth HTTP client around the test harness. A typed Worker RPC selects either the fixed backwards-compatible profile or the strict canonical-resource profile and pre-registers clients through `OAuthHelpers`; DCR and every OAuth flow run over HTTP. The harness recreates local storage after each test.
+`support/oauth-client.ts` is the OAuth HTTP client around the test harness. A typed Worker RPC selects either the fixed backwards-compatible profile or the canonical-resource profile and pre-registers clients through `OAuthHelpers`; DCR and every OAuth flow run over HTTP. The harness recreates local storage after each test.
 
 Tests assert only observable HTTP responses, redirects, metadata, challenges, and token behavior. They do not access provider internals or stored records.
 

--- a/conformance/authorization-security.test.ts
+++ b/conformance/authorization-security.test.ts
@@ -145,25 +145,13 @@ describe.each(MCP_AUTH_REVISIONS)('MCP %s authorization security conformance', (
   );
 });
 
-describe('strict resource policy compatibility boundary', () => {
-  it('rejects a 2025-03-26 client that cannot send resource', async () => {
-    const oauth = await createMcpOAuthClient('2025-03-26', { resourcePolicy: 'strict' });
+describe('canonical resource policy compatibility boundary', () => {
+  it('defaults and inherits the canonical resource for a 2025-03-26 client that omits it', async () => {
+    const oauth = await createMcpOAuthClient('2025-03-26', { resourcePolicy: 'canonical' });
     const client = await oauth.createClient('none');
-    const params = new URLSearchParams({
-      response_type: 'code',
-      client_id: client.clientId,
-      redirect_uri: client.redirectUri,
-      scope: READ_SCOPE,
-      state: 'legacy-client',
-      code_challenge: 'a-valid-looking-conformance-code-challenge',
-      code_challenge_method: 'S256',
-    });
+    const { tokens } = await oauth.completeAuthorizationCodeFlow(client);
 
-    const response = await oauth.request(`/authorize?${params}`);
-    expect(response.status).toBe(400);
-    expect(await readJson<OAuthErrorBody>(response)).toMatchObject({
-      error_description: expect.stringContaining('resource parameter must exactly match'),
-    });
+    expect(tokens.resource).toBe(MCP_RESOURCE);
   });
 });
 
@@ -171,10 +159,10 @@ describe.each(mcpAuthRevisionsSince('2025-06-18'))('MCP %s Resource Indicator au
   let oauth: McpOAuthClient;
 
   beforeEach(async () => {
-    oauth = await createMcpOAuthClient(revision, { resourcePolicy: 'strict' });
+    oauth = await createMcpOAuthClient(revision, { resourcePolicy: 'canonical' });
   });
 
-  it('requires the configured canonical resource in the authorization request', async () => {
+  it('defaults an omitted authorization resource to the configured canonical resource', async () => {
     const client = await oauth.createClient('none');
     const params = new URLSearchParams({
       response_type: 'code',
@@ -188,12 +176,8 @@ describe.each(mcpAuthRevisionsSince('2025-06-18'))('MCP %s Resource Indicator au
 
     const response = await oauth.request(`/authorize?${params}`);
 
-    expect(response.status).toBe(400);
-    expect(response.headers.get('Location')).toBeNull();
-    expect(await readJson<OAuthErrorBody>(response)).toMatchObject({
-      error: 'invalid_request',
-      error_description: expect.stringContaining('resource parameter must exactly match'),
-    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).not.toBeNull();
   });
 
   it('rejects a resource URI containing a fragment', async () => {
@@ -213,9 +197,29 @@ describe.each(mcpAuthRevisionsSince('2025-06-18'))('MCP %s Resource Indicator au
 
     expect(response.status).toBe(400);
     expect(response.headers.get('Location')).toBeNull();
+    expect(await readJson<OAuthErrorBody>(response)).toMatchObject({ error: 'invalid_target' });
   });
 
-  it('requires the canonical resource throughout authorization and token exchange', async () => {
+  it('rejects an explicit resource that does not match the configured canonical resource', async () => {
+    const client = await oauth.createClient('none');
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: client.clientId,
+      redirect_uri: client.redirectUri,
+      scope: READ_SCOPE,
+      state: 'mismatched-resource',
+      code_challenge: 'a-valid-looking-conformance-code-challenge',
+      code_challenge_method: 'S256',
+      resource: `${CONFORMANCE_ORIGIN}/other`,
+    });
+
+    const response = await oauth.request(`/authorize?${params}`);
+
+    expect(response.status).toBe(400);
+    expect(await readJson<OAuthErrorBody>(response)).toMatchObject({ error: 'invalid_target' });
+  });
+
+  it('accepts the canonical resource throughout authorization and token exchange', async () => {
     const client = await oauth.createClient('none');
     const { tokens } = await oauth.completeAuthorizationCodeFlow(client);
     expect(tokens.resource).toBe(`${CONFORMANCE_ORIGIN}/mcp`);

--- a/conformance/authorization-server.test.ts
+++ b/conformance/authorization-server.test.ts
@@ -71,7 +71,7 @@ describe.each(MCP_AUTH_REVISIONS)('MCP %s authorization server conformance', (re
     expect(tokens.token_type.toLowerCase()).toBe('bearer');
     expect(tokens.expires_in).toBeGreaterThan(0);
     expect(tokens.scope).toBe(READ_SCOPE);
-    expect(tokens.resource).toBe(clientResourceForRevision(revision) ?? CONFORMANCE_ORIGIN);
+    expect(tokens.resource).toBe(clientResourceForRevision(revision));
 
     const protectedResponse = await oauth.request('/mcp', {
       headers: { Authorization: `Bearer ${tokens.access_token}` },

--- a/conformance/support/oauth-client.ts
+++ b/conformance/support/oauth-client.ts
@@ -65,7 +65,7 @@ interface DcrResponse {
 
 interface ConformanceClientOptions {
   dynamicClientRegistration?: boolean;
-  resourcePolicy?: 'compatible' | 'strict';
+  resourcePolicy?: 'compatible' | 'canonical';
   resourceScopes?: string[];
 }
 
@@ -82,7 +82,7 @@ export async function createMcpOAuthClient(
   const configuration: WorkerConfiguration = {
     dynamicClientRegistration: options.dynamicClientRegistration !== false,
     origin: CONFORMANCE_ORIGIN,
-    resource: options.resourcePolicy === 'strict' ? MCP_RESOURCE : undefined,
+    resource: options.resourcePolicy === 'canonical' ? MCP_RESOURCE : undefined,
     resourceScopes: options.resourceScopes ?? [READ_SCOPE],
   };
   const api = await worker.getExport();

--- a/conformance/worker/index.ts
+++ b/conformance/worker/index.ts
@@ -1,5 +1,6 @@
 import { WorkerEntrypoint } from 'cloudflare:workers';
 import {
+  AuthorizationError,
   ExternalTokenError,
   OAuthProvider,
   getOAuthApi,
@@ -62,7 +63,7 @@ function createProviderOptions(configuration: WorkerConfiguration): OAuthProvide
         } catch (error) {
           return Response.json(
             {
-              error: 'invalid_request',
+              error: error instanceof AuthorizationError ? error.code : 'invalid_request',
               error_description: error instanceof Error ? error.message : String(error),
             },
             { status: 400 }

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -2,6 +2,7 @@ const OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
 
 export type AuthorizationErrorCode =
   | 'invalid_request'
+  | 'invalid_target'
   | 'unauthorized_client'
   | 'access_denied'
   | 'unsupported_response_type'

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -525,14 +525,16 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   clientIdMetadataDocumentEnabled?: boolean;
 
   /**
-   * When true, resource validation during token exchange compares origins only
-   * (scheme + host + port) instead of exact URI matching. This allows grants issued
-   * with an origin-only resource (e.g. `https://server.com`) to be used with
-   * path-aware resource requests (e.g. `https://server.com/mcp`), enabling seamless
-   * migration from pre-0.4.0 versions that stored origin-only resource URIs.
-   * Explicit `resourceMetadata.resource` configuration always uses exact matching.
+   * When true, requested-vs-granted resource validation compares origins only
+   * (scheme + host + port) instead of exact URIs. This allows an origin-only
+   * grant such as `https://server.com` to accept `https://server.com/mcp`, but
+   * also ignores path and query differences. Configured canonical resources
+   * always use exact matching.
    *
    * Defaults to false (strict exact matching per RFC 8707).
+   *
+   * @deprecated This comparison is unsafe for shared-origin multi-path or
+   * multi-tenant deployments. Prefer configuring `resourceMetadata.resource`.
    */
   resourceMatchOriginOnly?: boolean;
 
@@ -547,10 +549,11 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
     /**
      * The protected resource identifier URL (RFC 9728 `resource` field).
      *
-     * Configuring this value pins authorization requests, token requests, and
-     * access-token audiences to this exact resource. If omitted, the provider
-     * accepts valid RFC 8707 resource indicators and uses the authorization
-     * request origin as the default when the client does not send one.
+     * Configuring this value pins grants and access-token audiences to this
+     * exact resource. An omitted authorization resource defaults to this value,
+     * and an omitted token-request resource inherits it from the grant. Without
+     * configuration, explicit RFC 8707 resource indicators are accepted and
+     * omission remains unbound for backwards compatibility.
      */
     resource?: string;
     /**
@@ -1574,7 +1577,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private validateResourceMetadataOptions(options: OAuthProviderOptions<Env>['resourceMetadata']): void {
     if (!options) return;
 
-    if (options.resource && !validateResourceUri(options.resource)) {
+    if (options.resource !== undefined && !validateResourceUri(options.resource)) {
       throw new TypeError('resourceMetadata.resource must be an absolute HTTP(S) URI without a fragment');
     }
 
@@ -3008,7 +3011,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         description: 'Subject token is not bound to the configured resource',
       });
     }
-    const newAudience = this.resolveTokenResource(requestedResource, grantData.resource);
+    // v0.8.2 inherited the subject token's audience when token exchange omitted
+    // `resource`. Re-resolving omission from the backing grant can drop an
+    // audience carried only by a legacy token, or expand a downscoped subject
+    // back to the grant's broader resource set.
+    const newAudience =
+      requestedResource === undefined
+        ? tokenSummary.audience
+        : this.resolveTokenResource(requestedResource, grantData.resource);
 
     // Determine TTL for new token
     const now = Math.floor(Date.now() / 1000);
@@ -4142,43 +4152,49 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
   /**
    * Resolves an access-token audience from a token request and its authorization grant.
-   * Explicit resource configuration requires one exact value in both places. Without
-   * configuration, RFC 8707 downscoping is allowed and omission inherits the grant.
+   * A configured canonical resource is inherited when omitted but cannot be overridden.
+   * Without configuration, RFC 8707 downscoping is allowed, omission inherits a
+   * bound grant, and a legacy unbound grant retains the v0.8.2 behavior.
    */
   private resolveTokenResource(
     requestedResource: string | string[] | undefined,
     grantedResource: string | string[] | undefined
   ): string | string[] | undefined {
+    const resourceWasProvided = requestedResource !== undefined;
     const requestedAudience = parseResourceParameter(requestedResource);
-    if (requestedResource && !requestedAudience) {
+    if (resourceWasProvided && !requestedAudience) {
       throw new OAuthError('invalid_target', {
         description: 'The resource parameter must be a valid absolute URI without a fragment',
       });
     }
+    const grantResourceWasStored = grantedResource !== undefined;
     const grantedAudience = parseResourceParameter(grantedResource);
-    if (grantedResource && !grantedAudience) {
+    if (grantResourceWasStored && !grantedAudience) {
       throw new OAuthError('invalid_target', {
         description: 'The authorization grant contains an invalid resource',
       });
     }
 
     const configuredResource = this.options.resourceMetadata?.resource;
-    if (
-      configuredResource &&
-      (!isExactResource(grantedResource, configuredResource) || !isExactResource(requestedResource, configuredResource))
-    ) {
+    if (configuredResource) {
+      if (resourceWasProvided && !isExactResource(requestedResource, configuredResource)) {
+        throw new OAuthError('invalid_target', {
+          description: `The resource parameter must exactly match ${configuredResource}`,
+        });
+      }
+      if (isExactResource(grantedResource, configuredResource)) {
+        return configuredResource;
+      }
+      if (!grantResourceWasStored) {
+        return configuredResource;
+      }
       throw new OAuthError('invalid_target', {
-        description: `The resource parameter must exactly match ${configuredResource}`,
-      });
-    }
-    if (!configuredResource && requestedResource && !grantedResource) {
-      throw new OAuthError('invalid_target', {
-        description: 'Requested resource was not included in the authorization request',
+        description: 'The authorization grant is not bound to the configured resource',
       });
     }
 
-    const originOnly = configuredResource ? false : !!this.options.resourceMatchOriginOnly;
-    if (requestedResource && grantedResource) {
+    const originOnly = !!this.options.resourceMatchOriginOnly;
+    if (resourceWasProvided && grantResourceWasStored) {
       const requestedResources = Array.isArray(requestedResource) ? requestedResource : [requestedResource];
       const grantedResources = Array.isArray(grantedResource) ? grantedResource : [grantedResource];
       for (const requested of requestedResources) {
@@ -5008,6 +5024,9 @@ function parseResourceParameter(value: string | string[] | undefined): string | 
 
   // Validate all URIs (RFC 8707 Section 2)
   const uris = Array.isArray(value) ? value : [value];
+  if (uris.length === 0) {
+    return undefined;
+  }
   for (const uri of uris) {
     if (typeof uri !== 'string' || !validateResourceUri(uri)) {
       // Invalid resource URI - return undefined to trigger error
@@ -5529,23 +5548,26 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
 
     // Resource, response type, and PKCE errors are redirectable only after the
     // exact client redirect URI above has been validated.
+    const resourceWasProvided = resourceParam !== undefined;
     let resource = parseResourceParameter(resourceParam);
-    if (resourceParam && !resource) {
+    if (resourceWasProvided && !resource) {
       withRedirect(
-        new AuthorizationError('invalid_request', {
+        new AuthorizationError('invalid_target', {
           description: 'The resource parameter must be a valid absolute URI without a fragment',
         })
       );
     }
     const configuredResource = this.provider.options.resourceMetadata?.resource;
-    if (configuredResource && !isExactResource(resource, configuredResource)) {
-      withRedirect(
-        new AuthorizationError('invalid_request', {
-          description: `The resource parameter must exactly match ${configuredResource}`,
-        })
-      );
+    if (configuredResource) {
+      if (resourceWasProvided && !isExactResource(resource, configuredResource)) {
+        withRedirect(
+          new AuthorizationError('invalid_target', {
+            description: `The resource parameter must exactly match ${configuredResource}`,
+          })
+        );
+      }
+      resource = configuredResource;
     }
-    resource ??= url.origin;
 
     try {
       validateAuthorizationResponseType(this.provider.serverCapabilities, responseType, clientInfo.responseTypes);
@@ -5620,14 +5642,24 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     // completeAuthorization() is a public helper and callers can pass a
     // reconstructed AuthRequest rather than one returned directly by
     // parseAuthRequest(). Re-apply configured resource policy here before
-    // creating any grant. For an unconfigured provider, retain the parsed
-    // resource or use the recorded authorization-server origin as the RFC 8707
-    // default when available.
+    // creating any grant. A configured canonical resource is the RFC 8707
+    // default when the caller omitted the wire parameter. For an unconfigured
+    // provider, retain an explicit resource and preserve omission for backwards
+    // compatibility with v0.8.2 grants and callers.
     const configuredResource = this.provider.options.resourceMetadata?.resource;
-    if (configuredResource && !isExactResource(options.request.resource, configuredResource)) {
-      throw new Error(`The resource parameter must exactly match ${configuredResource}`);
+    const resourceWasProvided = options.request.resource !== undefined;
+    const parsedResource = parseResourceParameter(options.request.resource);
+    if (resourceWasProvided && !parsedResource) {
+      throw new AuthorizationError('invalid_target', {
+        description: 'The resource parameter must be a valid absolute URI without a fragment',
+      });
     }
-    const effectiveResource = options.request.resource ?? options.request.issuer;
+    if (configuredResource && resourceWasProvided && !isExactResource(parsedResource, configuredResource)) {
+      throw new AuthorizationError('invalid_target', {
+        description: `The resource parameter must exactly match ${configuredResource}`,
+      });
+    }
+    const effectiveResource = configuredResource ?? parsedResource;
 
     // Re-apply PKCE policy after client, redirect, response-type, and resource
     // validation, preserving their established error precedence while still

--- a/storage-schema.md
+++ b/storage-schema.md
@@ -80,6 +80,7 @@ Grant records store information about permissions a user has granted to an appli
   },
   "encryptedProps": "AES-GCM encrypted base64-encoded string",
   "createdAt": 1644256123,
+  "resource": "https://example.com/mcp",
   "authCodeId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
   "authCodeWrappedKey": "base64-encoded wrapped encryption key",
   "codeChallenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
@@ -101,6 +102,7 @@ Grant records store information about permissions a user has granted to an appli
   },
   "encryptedProps": "AES-GCM encrypted base64-encoded string",
   "createdAt": 1644256123,
+  "resource": "https://example.com/mcp",
   "authCodeId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
   "refreshTokenId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
   "refreshTokenWrappedKey": "base64-encoded wrapped encryption key"
@@ -121,6 +123,7 @@ Grant records store information about permissions a user has granted to an appli
   },
   "encryptedProps": "AES-GCM encrypted base64-encoded string",
   "createdAt": 1644256123,
+  "resource": "https://example.com/mcp",
   "refreshTokenId": "7f2ab876c546a9e9f988ba7645af78239cfe980a4231ab38fcb895cb244a0a12",
   "refreshTokenWrappedKey": "base64-encoded wrapped encryption key",
   "previousRefreshTokenId": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
@@ -134,6 +137,8 @@ Grant records store information about permissions a user has granted to an appli
 - After code exchange, TTL matches the refresh token expiration (defaults to 30 days, configurable via `refreshTokenTTL`)
 
 > **Note:** The grant record includes the hash of the authorization code initially, which is replaced by the hash of the refresh token after the code is exchanged. The record has a 10-minute TTL during authorization, which is replaced by the refresh token TTL when the code is exchanged.
+
+> **Note:** The optional `resource` field stores the RFC 8707 resource authorized for the grant. Grants created by older releases may not contain it. When neither the grant nor provider configuration supplies a resource, the grant remains unbound.
 
 ### Tokens
 
@@ -150,6 +155,7 @@ Token records store metadata about issued access tokens, including denormalized 
   "userId": "user123",
   "createdAt": 1644256123,
   "expiresAt": 1644259723,
+  "audience": "https://example.com/mcp",
   "wrappedEncryptionKey": "base64-encoded wrapped encryption key",
   "grant": {
     "clientId": "abc123",
@@ -160,6 +166,8 @@ Token records store metadata about issued access tokens, including denormalized 
 ```
 
 > **Note:** The token format is `{userId}:{grantId}:{random-secret}` which embeds the identifiers needed for efficient lookups. The token key format includes the user ID and grant ID to enable efficient revocation of all tokens for a specific grant. The token record contains denormalized grant information to eliminate the need for a separate grant lookup during token validation. The token also carries a wrapped encryption key that can only be unwrapped using the actual token string, allowing decryption of the encrypted props.
+
+> **Note:** The optional `audience` field records the resource restriction for an access token. It may be absent when a legacy grant has no stored resource, no canonical resource is configured, and the token request omits `resource`.
 
 **TTL:** Access tokens typically have a 1 hour (3600 seconds) TTL by default
 


### PR DESCRIPTION
## Summary

Restore v0.8.2-compatible RFC 8707 resource handling without adding a feature flag or a persisted policy version.

- A configured `resourceMetadata.resource` is the canonical default when clients omit `resource`, and bound grants inherit it on code exchange and refresh.
- Explicit malformed or mismatched resources fail with `invalid_target` before authorization-code consumption, callbacks, refresh rotation, or storage mutation.
- An unconfigured grant with no stored resource remains usable and unbound when the client also omits `resource`.
- If an old unbound grant supplies `resource` during code exchange or refresh, that value applies only to the issued access token. It is not persisted, matching v0.8.2 behavior and allowing a later token request to choose a different resource.
- A grant that already stores a resource continues to inherit it when clients omit the parameter.
- Token exchange without an explicit resource inherits the subject token's audience, so it cannot accidentally drop or expand an existing restriction.
- `resourceMatchOriginOnly` is deprecated without changing its behavior.

There is no new KV schema state, migration marker, compatibility flag, or TOFU binding in this PR.

## Client compatibility

| Client behavior | Result |
| --- | --- |
| Omits `resource` everywhere | Succeeds; uses the configured canonical resource when present, otherwise remains unbound. |
| Sends it at authorization but omits it on code exchange or refresh | Inherits the resource stored on the grant. |
| Old grant has no resource; refresh supplies one | Issues that token for the requested resource without rewriting the grant. |
| Old grant has no resource; later refresh supplies a different one | Succeeds for the later resource; the grant remains unbound. |
| Explicit value conflicts with a configured or stored resource | Fails with `invalid_target` before state mutation. |

This covers the observed HubSpot, Slack, Perplexity, Microsoft 365 Copilot, GitHub, Claude Code, Codex, Claude.ai, ChatGPT, Cursor, Grok, and long-tail omission/presence patterns without requiring `resource` on every wire leg.

Strict canonical audience binding and the removal of `resourceMatchOriginOnly` remain in the separate 1.0 follow-up PR, #289. Broader token-exchange policy tightening is also left to that breaking release; this PR only preserves v0.8.2 subject-audience inheritance when the exchange omits `resource`.

## Validation

- `npm run check` — 826 tests
- `npm run test:conformance` — 150 tests across represented MCP authorization revisions
- `npm run build`
- `npx prettier --check .`
- `git diff --check`

The regression suite includes exact missing-resource grant state, reconstructed v0.8.2-style authorization input, changing per-token resources without persistence, configured-resource fallback, subject-audience inheritance, and unchanged `resourceMatchOriginOnly` behavior.
