### PR TITLE
refactor(auth): simplify client auth storage

### DIFF
--- a/.changeset/calm-clients-authenticate.md
+++ b/.changeset/calm-clients-authenticate.md
@@ -2,4 +2,4 @@
 '@cloudflare/workers-oauth-provider': patch
 ---
 
-Preserve Basic and POST authentication interoperability for legacy and defaulted confidential clients while keeping explicit registrations strict.
+Preserve Basic and POST authentication interoperability for legacy and defaulted confidential clients while enforcing explicitly selected methods.

--- a/README.md
+++ b/README.md
@@ -321,9 +321,9 @@ MCP 2026-07-28 deprecates DCR for new implementations in favor of CIMD. The endp
 
 Registration accepts only authentication methods, grants, and response types implemented by the configured provider, and rejects inconsistent grant/response combinations before storage. Omitted metadata uses the RFC 7591 defaults: `client_secret_basic`, `grant_types: ["authorization_code"]`, and `response_types: ["code"]`.
 
-An explicitly supplied `token_endpoint_auth_method` is enforced exactly. For compatibility with clients registered before method provenance was stored, confidential client records without provenance—and new registrations that default to `client_secret_basic`—may authenticate with either `client_secret_basic` or `client_secret_post`, but only after the same stored client secret validates. This compatibility never crosses between `none` and a secret method and does not apply to CIMD clients. Calling `OAuthHelpers.updateClient()` with an explicit `tokenEndpointAuthMethod` marks an older client strict; unrelated updates preserve its existing policy.
+An explicitly supplied `token_endpoint_auth_method` is enforced exactly. When it is omitted, no explicit-method marker is stored and the client may use either `client_secret_basic` or `client_secret_post`, provided the same stored secret validates. Client records written by earlier releases have no marker and receive the same compatibility. This never crosses between `none` and a secret method and does not apply to CIMD clients.
 
-Clients that explicitly register one secret transport but present the other must be upgraded. A pre-policy record receives the migration fallback until it expires, but re-registering with an explicit method creates a strict record.
+Calling `OAuthHelpers.updateClient()` with `tokenEndpointAuthMethod` adds the marker; unrelated updates leave it unchanged.
 
 Related options:
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -954,8 +954,8 @@ describe('OAuthProvider', () => {
       expect(savedClient.clientId).toBe(registeredClient.client_id);
       // Secret should be stored as a hash
       expect(savedClient.clientSecret).not.toBe(registeredClient.client_secret);
-      expect(savedClient.tokenEndpointAuthMethodPolicy).toBe('strict');
-      expect(registeredClient.tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(savedClient.authMethodExplicit).toBe(true);
+      expect(registeredClient.authMethodExplicit).toBeUndefined();
     });
 
     it('should register a public client', async () => {
@@ -987,7 +987,7 @@ describe('OAuthProvider', () => {
       const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
       expect(savedClient).not.toBeNull();
       expect(savedClient.clientSecret).toBeUndefined(); // No secret stored
-      expect(savedClient.tokenEndpointAuthMethodPolicy).toBe('strict');
+      expect(savedClient.authMethodExplicit).toBe(true);
     });
 
     it('should apply RFC 7591 defaults and return the values actually registered', async () => {
@@ -1002,8 +1002,8 @@ describe('OAuthProvider', () => {
       const savedClient = await mockEnv.OAUTH_KV.get(`client:${registeredClient.client_id}`, { type: 'json' });
       expect(savedClient.grantTypes).toEqual(['authorization_code']);
       expect(savedClient.responseTypes).toEqual(['code']);
-      expect(savedClient.tokenEndpointAuthMethodPolicy).toBe('legacy-compatible');
-      expect(registeredClient.tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(savedClient.authMethodExplicit).toBeUndefined();
+      expect(registeredClient.authMethodExplicit).toBeUndefined();
     });
 
     it('should accept enabled extension grant and response types', async () => {
@@ -2421,7 +2421,7 @@ describe('OAuthProvider', () => {
       );
 
       // This intentionally mirrors the complete persisted client shape written by
-      // v0.8.2: it has a registered method but predates policy provenance.
+      // v0.8.2: it has a registered method but predates explicit-method provenance.
       await mockEnv.OAUTH_KV.put(
         `client:${clientId}`,
         JSON.stringify({
@@ -2550,7 +2550,7 @@ describe('OAuthProvider', () => {
       }
     );
 
-    it('requires the same stored secret before accepting a legacy-compatible transport', async () => {
+    it('requires the same stored secret before accepting an unmarked client transport', async () => {
       const client = await seedV082Client('client_secret_post');
       const response = await requestTokenWithClientAuthentication(
         { ...client, clientSecret: 'not-the-registered-secret' },
@@ -2560,7 +2560,7 @@ describe('OAuthProvider', () => {
       await expectBasicClientError(response, 'Client authentication failed: invalid client_secret');
     });
 
-    it('lets a newly defaulted confidential registration use Basic or POST without exposing policy metadata', async () => {
+    it('lets a newly defaulted confidential registration use Basic or POST without exposing internal metadata', async () => {
       const registrationResponse = await oauthProvider.fetch(
         createMockRequest(
           'https://example.com/oauth/register',
@@ -2581,7 +2581,7 @@ describe('OAuthProvider', () => {
         tokenEndpointAuthMethod: 'client_secret_basic',
       };
 
-      expect(registration.tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(registration.authMethodExplicit).toBeUndefined();
       for (const presentedMethod of ['client_secret_basic', 'client_secret_post'] as const) {
         const response = await requestTokenWithClientAuthentication(client, presentedMethod);
         expect(response.status).toBe(400);
@@ -2599,7 +2599,7 @@ describe('OAuthProvider', () => {
       expect(put).not.toHaveBeenCalled();
 
       const storedBeforeExpiry = await mockEnv.OAUTH_KV.get(`client:${client.clientId}`, { type: 'json' });
-      expect(storedBeforeExpiry.tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect(storedBeforeExpiry.authMethodExplicit).toBeUndefined();
       mockEnv.OAUTH_KV.advanceTime(61_000);
       expect(await mockEnv.OAUTH_KV.get(`client:${client.clientId}`, { type: 'json' })).toBeNull();
     });
@@ -2608,7 +2608,7 @@ describe('OAuthProvider', () => {
       ['client_secret_basic', 'client_secret_post'],
       ['client_secret_post', 'client_secret_basic'],
     ] as const)(
-      'uses %s-to-%s compatibility for revocation while keeping explicit clients strict',
+      'uses %s-to-%s compatibility for revocation while constraining explicit clients',
       async (registeredMethod, presentedMethod) => {
         const revoke = (client: TestClientCredentials): Promise<Response> => {
           const body = new URLSearchParams({ token: 'already-unknown-token' });
@@ -2629,12 +2629,12 @@ describe('OAuthProvider', () => {
         const legacyResponse = await revoke(await seedV082Client(registeredMethod));
         expect(legacyResponse.status).toBe(200);
 
-        const strictResponse = await revoke(await registerTestClient(registeredMethod));
-        expect(strictResponse.status).toBe(401);
-        expect(strictResponse.headers.get('WWW-Authenticate')).toBe(
+        const explicitResponse = await revoke(await registerTestClient(registeredMethod));
+        expect(explicitResponse.status).toBe(401);
+        expect(explicitResponse.headers.get('WWW-Authenticate')).toBe(
           presentedMethod === 'client_secret_basic' ? 'Basic realm="OAuth"' : null
         );
-        expect(await strictResponse.json<any>()).toEqual({
+        expect(await explicitResponse.json<any>()).toEqual({
           error: 'invalid_client',
           error_description: 'Client authentication failed',
         });
@@ -2650,9 +2650,9 @@ describe('OAuthProvider', () => {
         { suffix: 'unknown-method', tokenEndpointAuthMethod: 'private_key_jwt', includeSecret: true },
         { suffix: 'secretless', tokenEndpointAuthMethod: 'client_secret_basic', includeSecret: false },
         {
-          suffix: 'unknown-policy',
+          suffix: 'invalid-explicit-marker',
           tokenEndpointAuthMethod: 'client_secret_basic',
-          tokenEndpointAuthMethodPolicy: 'future-policy',
+          authMethodExplicit: false,
           includeSecret: true,
         },
       ];
@@ -2668,9 +2668,7 @@ describe('OAuthProvider', () => {
             ...(testCase.tokenEndpointAuthMethod === undefined
               ? {}
               : { tokenEndpointAuthMethod: testCase.tokenEndpointAuthMethod }),
-            ...('tokenEndpointAuthMethodPolicy' in testCase
-              ? { tokenEndpointAuthMethodPolicy: testCase.tokenEndpointAuthMethodPolicy }
-              : {}),
+            ...('authMethodExplicit' in testCase ? { authMethodExplicit: testCase.authMethodExplicit } : {}),
           })
         );
         const response = await requestTokenWithClientAuthentication(
@@ -2785,8 +2783,8 @@ describe('OAuthProvider', () => {
         tokenEndpoint: '/oauth/token',
         onError,
       });
-      const clientId = 'strict-mismatch-client';
-      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('strict-secret'));
+      const clientId = 'explicit-mismatch-client';
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('explicit-secret'));
       const clientSecret = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
       await mockEnv.OAUTH_KV.put(
         `client:${clientId}`,
@@ -2795,7 +2793,7 @@ describe('OAuthProvider', () => {
           clientSecret,
           redirectUris: ['https://client.example.com/callback'],
           tokenEndpointAuthMethod: 'client_secret_basic',
-          tokenEndpointAuthMethodPolicy: 'strict',
+          authMethodExplicit: true,
         })
       );
 
@@ -2808,7 +2806,7 @@ describe('OAuthProvider', () => {
             grant_type: 'authorization_code',
             code: 'invalid-code',
             client_id: clientId,
-            client_secret: 'strict-secret',
+            client_secret: 'explicit-secret',
           }).toString()
         ),
         mockEnv,
@@ -10073,7 +10071,7 @@ describe('OAuthProvider', () => {
       expect(clientsAfterDelete.items.length).toBe(0);
     });
 
-    it('keeps authentication provenance internal and makes explicit updates strict', async () => {
+    it('stores only explicit-method provenance and keeps it internal', async () => {
       await oauthProvider.fetch(createMockRequest('https://example.com/'), mockEnv, mockCtx);
       const helpers = mockEnv.OAUTH_PROVIDER!;
 
@@ -10087,35 +10085,31 @@ describe('OAuthProvider', () => {
         tokenEndpointAuthMethod: 'client_secret_post',
       });
 
-      expect((defaultedClient as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
-      expect((explicitClient as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect((defaultedClient as any).authMethodExplicit).toBeUndefined();
+      expect((explicitClient as any).authMethodExplicit).toBeUndefined();
       expect(
-        (await mockEnv.OAUTH_KV.get(`client:${defaultedClient.clientId}`, { type: 'json' }))
-          .tokenEndpointAuthMethodPolicy
-      ).toBe('legacy-compatible');
+        (await mockEnv.OAUTH_KV.get(`client:${defaultedClient.clientId}`, { type: 'json' })).authMethodExplicit
+      ).toBeUndefined();
       expect(
-        (await mockEnv.OAUTH_KV.get(`client:${explicitClient.clientId}`, { type: 'json' }))
-          .tokenEndpointAuthMethodPolicy
-      ).toBe('strict');
+        (await mockEnv.OAUTH_KV.get(`client:${explicitClient.clientId}`, { type: 'json' })).authMethodExplicit
+      ).toBe(true);
 
-      const preservedDefaultPolicy = await helpers.updateClient(defaultedClient.clientId, {
+      const updatedDefaultedClient = await helpers.updateClient(defaultedClient.clientId, {
         clientName: 'Renamed defaulted helper client',
       });
-      expect((preservedDefaultPolicy as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect((updatedDefaultedClient as any).authMethodExplicit).toBeUndefined();
       expect(
-        (await mockEnv.OAUTH_KV.get(`client:${defaultedClient.clientId}`, { type: 'json' }))
-          .tokenEndpointAuthMethodPolicy
-      ).toBe('legacy-compatible');
+        (await mockEnv.OAUTH_KV.get(`client:${defaultedClient.clientId}`, { type: 'json' })).authMethodExplicit
+      ).toBeUndefined();
 
       const attemptedDowngrade = await helpers.updateClient(explicitClient.clientId, {
-        clientName: 'Still strict',
-        tokenEndpointAuthMethodPolicy: 'legacy-compatible',
+        clientName: 'Still explicit',
+        authMethodExplicit: false,
       } as any);
-      expect((attemptedDowngrade as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect((attemptedDowngrade as any).authMethodExplicit).toBeUndefined();
       expect(
-        (await mockEnv.OAUTH_KV.get(`client:${explicitClient.clientId}`, { type: 'json' }))
-          .tokenEndpointAuthMethodPolicy
-      ).toBe('strict');
+        (await mockEnv.OAUTH_KV.get(`client:${explicitClient.clientId}`, { type: 'json' })).authMethodExplicit
+      ).toBe(true);
 
       const postResponse = await oauthProvider.fetch(
         createMockRequest(
@@ -10137,10 +10131,8 @@ describe('OAuthProvider', () => {
 
       const listed = await helpers.listClients();
       expect(listed.items).toHaveLength(2);
-      expect(listed.items.every((client) => (client as any).tokenEndpointAuthMethodPolicy === undefined)).toBe(true);
-      expect(
-        ((await helpers.lookupClient(defaultedClient.clientId)) as any).tokenEndpointAuthMethodPolicy
-      ).toBeUndefined();
+      expect(listed.items.every((client) => (client as any).authMethodExplicit === undefined)).toBe(true);
+      expect(((await helpers.lookupClient(defaultedClient.clientId)) as any).authMethodExplicit).toBeUndefined();
 
       const legacyClientId = 'unversioned-helper-client';
       await mockEnv.OAUTH_KV.put(
@@ -10155,18 +10147,16 @@ describe('OAuthProvider', () => {
       );
 
       const unrelatedUpdate = await helpers.updateClient(legacyClientId, { clientName: 'Renamed unversioned client' });
-      expect((unrelatedUpdate as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
+      expect((unrelatedUpdate as any).authMethodExplicit).toBeUndefined();
       expect(
-        (await mockEnv.OAUTH_KV.get(`client:${legacyClientId}`, { type: 'json' })).tokenEndpointAuthMethodPolicy
+        (await mockEnv.OAUTH_KV.get(`client:${legacyClientId}`, { type: 'json' })).authMethodExplicit
       ).toBeUndefined();
 
-      const strictUpdate = await helpers.updateClient(legacyClientId, {
+      const explicitUpdate = await helpers.updateClient(legacyClientId, {
         tokenEndpointAuthMethod: 'client_secret_basic',
       });
-      expect((strictUpdate as any).tokenEndpointAuthMethodPolicy).toBeUndefined();
-      expect(
-        (await mockEnv.OAUTH_KV.get(`client:${legacyClientId}`, { type: 'json' })).tokenEndpointAuthMethodPolicy
-      ).toBe('strict');
+      expect((explicitUpdate as any).authMethodExplicit).toBeUndefined();
+      expect((await mockEnv.OAUTH_KV.get(`client:${legacyClientId}`, { type: 'json' })).authMethodExplicit).toBe(true);
     });
   });
 

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -863,37 +863,28 @@ export interface ClientInfo {
   tokenEndpointAuthMethod: string;
 }
 
-/**
- * Internal storage provenance for token endpoint authentication policy.
- *
- * Records written before this field existed intentionally remain unversioned.
- * They receive the same narrow confidential-client transport compatibility as
- * newly defaulted registrations, while an explicitly selected method is strict.
- */
-type ClientAuthMethodPolicy = 'strict' | 'legacy-compatible';
-
 interface StoredClientInfo extends ClientInfo {
-  tokenEndpointAuthMethodPolicy?: ClientAuthMethodPolicy;
+  /** Present only when tokenEndpointAuthMethod was explicitly selected. */
+  authMethodExplicit?: true;
 }
 
 function toPublicClientInfo(client: StoredClientInfo): ClientInfo {
-  const { tokenEndpointAuthMethodPolicy: _policy, ...publicClient } = client;
+  const { authMethodExplicit: _explicit, ...publicClient } = client;
   return publicClient;
 }
 
-function canUseLegacyConfidentialClientAuthTransport(
+function isClientAuthMethodAllowed(
   client: StoredClientInfo,
   presentedMethod: string,
   isClientMetadataDocument: boolean
 ): boolean {
+  if (presentedMethod === client.tokenEndpointAuthMethod) return true;
+
   const isSecretMethod = (method: string): boolean =>
     method === 'client_secret_basic' || method === 'client_secret_post';
-  const isCompatiblePolicy =
-    client.tokenEndpointAuthMethodPolicy === undefined || client.tokenEndpointAuthMethodPolicy === 'legacy-compatible';
-
   return (
     !isClientMetadataDocument &&
-    isCompatiblePolicy &&
+    client.authMethodExplicit === undefined &&
     isSecretMethod(client.tokenEndpointAuthMethod) &&
     isSecretMethod(presentedMethod)
   );
@@ -2018,15 +2009,13 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         ? 'client_secret_post'
         : 'none';
     const registeredAuthMethod = clientInfo.tokenEndpointAuthMethod;
-    const canUseLegacyConfidentialTransport =
-      presentedAuthMethod !== registeredAuthMethod &&
-      canUseLegacyConfidentialClientAuthTransport(
+    if (
+      !isClientAuthMethodAllowed(
         clientInfo,
         presentedAuthMethod,
         !!this.options.clientIdMetadataDocumentEnabled && this.isClientMetadataUrl(clientInfo.clientId)
-      );
-
-    if (presentedAuthMethod !== registeredAuthMethod && !canUseLegacyConfidentialTransport) {
+      )
+    ) {
       return this.createInvalidClientResponse('Client authentication failed', basicAuthenticationAttempted, {
         category: 'client-authentication',
         reason: 'token_endpoint_auth_method_mismatch',
@@ -3747,7 +3736,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         responseTypes,
         registrationDate: Math.floor(Date.now() / 1000),
         tokenEndpointAuthMethod: authMethod,
-        tokenEndpointAuthMethodPolicy: authMethodWasExplicit ? 'strict' : 'legacy-compatible',
+        ...(authMethodWasExplicit ? { authMethodExplicit: true as const } : {}),
       };
 
       // Add client secret only for confidential clients
@@ -5838,7 +5827,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
       responseTypes: clientInfo.responseTypes || ['code'],
       registrationDate: Math.floor(Date.now() / 1000),
       tokenEndpointAuthMethod,
-      tokenEndpointAuthMethodPolicy: authMethodWasExplicit ? 'strict' : 'legacy-compatible',
+      ...(authMethodWasExplicit ? { authMethodExplicit: true as const } : {}),
     };
 
     // Validate each redirect URI scheme
@@ -5943,9 +5932,9 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
       ...updates,
       clientId: client.clientId, // Ensure clientId doesn't change
       tokenEndpointAuthMethod: authMethod, // Use determined auth method
-      // This is internal provenance: callers cannot inject or downgrade it through
+      // This is internal provenance: callers cannot inject or remove it through
       // the public Partial<ClientInfo> update object.
-      tokenEndpointAuthMethodPolicy: authMethodWasExplicit ? 'strict' : client.tokenEndpointAuthMethodPolicy,
+      authMethodExplicit: authMethodWasExplicit ? true : client.authMethodExplicit,
     };
 
     // Only include client secret for confidential clients

--- a/storage-schema.md
+++ b/storage-schema.md
@@ -48,7 +48,7 @@ Client records store OAuth client application information.
   "responseTypes": ["code"],
   "registrationDate": 1644256123,
   "tokenEndpointAuthMethod": "client_secret_basic",
-  "tokenEndpointAuthMethodPolicy": "strict"
+  "authMethodExplicit": true
 }
 ```
 
@@ -56,7 +56,7 @@ Client records store OAuth client application information.
 
 > **Note:** The optional `i18n` map holds RFC 7591 §2.2 internationalized variants of the human-readable metadata fields (`client_name`, `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`), keyed by the raw `field#<BCP 47 language tag>` member name. Canonical (un-tagged) values remain in their own fields. URI variants are validated as absolute http(s) URLs, the same as their canonical counterparts.
 
-> **Note:** `tokenEndpointAuthMethodPolicy` is internal storage metadata and is not returned by `OAuthHelpers`. `strict` means the stored `tokenEndpointAuthMethod` is enforced exactly. `legacy-compatible` marks a confidential registration whose method was defaulted. A missing policy identifies a pre-policy client record. For only `legacy-compatible` and missing-policy confidential records, `client_secret_basic` and `client_secret_post` are interchangeable after the stored secret validates. Public (`none`), CIMD, missing or unknown method, and secretless records remain strict. Authentication never rewrites the client record or its TTL; explicitly setting `tokenEndpointAuthMethod` with `OAuthHelpers.updateClient()` stores `strict`.
+> **Note:** `authMethodExplicit: true` is stored only when the client explicitly selects `tokenEndpointAuthMethod`, and is not returned by `OAuthHelpers`. When the marker is absent, confidential clients may use `client_secret_basic` or `client_secret_post` after the stored secret validates. Public (`none`), CIMD, missing or unknown methods, and secretless records do not receive this compatibility. Authentication never rewrites the client record or its TTL; setting `tokenEndpointAuthMethod` with `OAuthHelpers.updateClient()` adds the marker.
 
 **TTL:** Dynamically registered clients (DCR) default to 90 days. Clients created via `OAuthHelpers.createClient()` have no expiration. Configurable via the `clientRegistrationTTL` option.
 


### PR DESCRIPTION
## Summary

Follow-up to #287. This keeps its authentication behavior but removes the `strict | legacy-compatible` storage policy.

- Replace `tokenEndpointAuthMethodPolicy` with one optional, true-only `authMethodExplicit` marker.
- When the marker is absent, a confidential client may use Basic or POST with the same stored secret.
- When the marker is present, enforce the stored `tokenEndpointAuthMethod` exactly.
- Store the marker only when DCR or `OAuthHelpers` receives an explicit method.
- Keep the marker out of DCR responses, helper APIs, and the exported `ClientInfo` type.
- Preserve the existing public-client, CIMD, unknown-method, secretless, malformed, and mixed-authentication boundaries.

## Why

v0.8.2 stored the effective `tokenEndpointAuthMethod` even when it came from the RFC 7591 default, so the method field alone cannot distinguish old/defaulted records from explicit registrations. We still need one bit of provenance, but we do not need policy modes.

The storage rule is now just:

| Stored marker | Accepted transport |
| --- | --- |
| Absent | `client_secret_basic` or `client_secret_post`, with the stored secret |
| `authMethodExplicit: true` | The stored `tokenEndpointAuthMethod` only |

#287 is merged but has not been released, so this PR replaces its storage representation before publication. It updates the existing changeset rather than adding a second release note for the same fix.

## Validation

- `npm run check` (813 tests)
- `npm run test:conformance` (147 tests)
- `npm run build`
- `npx prettier --check .`
- `npx changeset status`
- `npm pack --dry-run`
- `git diff --check`
