### PR TITLE
chore: release resource compatibility as patch

### DIFF
--- a/.changeset/resource-parameter-compatibility.md
+++ b/.changeset/resource-parameter-compatibility.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/workers-oauth-provider': minor
+'@cloudflare/workers-oauth-provider': patch
 ---
 
 Restore v0.8.2-compatible resource handling for grants without a stored RFC 8707 resource. Configured canonical resources are defaulted and inherited, bound grants reject explicit mismatches, and an unconfigured legacy grant can issue an unbound token or use an explicit token-request resource without persisting a new grant binding.


### PR DESCRIPTION
Changes the resource compatibility changeset from minor to patch.

This release restores previously working behavior and contains backwards-compatible fixes. Changesets now resolves the pending package release as a patch (0.10.1) instead of a minor (0.11.0).

Validation:
- changeset status reports patch only
- Prettier check passes
- git diff --check passes