### PR TITLE
fix(cimd): negotiate token endpoint authentication method

### DIFF
--- a/.changeset/cimd-negotiate-token-auth-method.md
+++ b/.changeset/cimd-negotiate-token-auth-method.md
@@ -1,0 +1,9 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Negotiate the CIMD token endpoint authentication method instead of rejecting on the declared value
+
+A Client ID Metadata Document that declares `token_endpoint_auth_method: "private_key_jwt"` while advertising `token_endpoint_auth_methods_supported: ["none", "private_key_jwt"]` was rejected outright, because the declared value was treated as a requirement and the advertised list was never consulted. That is the document ChatGPT publishes, so its MCP connector could not authorize against any server using this library.
+
+The declared method is now a preference: it is kept when this server implements it, and otherwise the first mutually supported entry from `token_endpoint_auth_methods_supported` is selected. A document is refused only when it asked for something and offered nothing this server accepts, and the error now names what the client advertised. Documents that omit both fields, or that offer no acceptable method, behave exactly as before.

--- a/__tests__/oauth-capabilities.test.ts
+++ b/__tests__/oauth-capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   AuthorizationError,
   buildOAuthServerCapabilities,
   negotiateCimdClientCapabilities,
+  negotiateCimdTokenEndpointAuthMethod,
   normalizePkceCodeChallengeMethod,
   validateAuthorizationPkce,
   validateAuthorizationResponseType,
@@ -148,6 +149,44 @@ describe('OAuth server capabilities', () => {
         responseTypes: ['id_token'],
       })
     ).toThrow('grant_types authorization_code and response_types code must be registered together');
+  });
+});
+
+describe('CIMD token endpoint authentication method', () => {
+  it.each([
+    ['a document that says nothing about client authentication', undefined, undefined, undefined],
+    ['a declared method this server implements', 'none', undefined, 'none'],
+    ['a declared method backed by an equal list', 'none', ['none'], 'none'],
+    [
+      'a declared method this server does not implement, alongside one it does',
+      'private_key_jwt',
+      ['none', 'private_key_jwt'],
+      'none',
+    ],
+    ['a list alone that contains a method this server implements', undefined, ['private_key_jwt', 'none'], 'none'],
+  ])('selects %s', (_case, declared, supported, expected) => {
+    expect(negotiateCimdTokenEndpointAuthMethod(declared, supported)).toBe(expected);
+  });
+
+  it.each([
+    ['a declared method this server does not implement, with nothing to fall back to', 'private_key_jwt', undefined],
+    ['a list with no method this server implements', undefined, ['private_key_jwt']],
+    [
+      'a symmetric method, which a client with no pre-shared secret cannot use',
+      'client_secret_post',
+      ['client_secret_post'],
+    ],
+    ['an empty list, which offers nothing', undefined, []],
+  ])('rejects %s', (_case, declared, supported) => {
+    expect(() => negotiateCimdTokenEndpointAuthMethod(declared, supported)).toThrow(
+      'CIMD client does not support an accepted token endpoint authentication method'
+    );
+  });
+
+  it('names what the client advertised, so the mismatch is legible', () => {
+    expect(() => negotiateCimdTokenEndpointAuthMethod('private_key_jwt', ['tls_client_auth'])).toThrow(
+      'Supported methods: none. Client advertised: private_key_jwt, tls_client_auth'
+    );
   });
 });
 

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -11665,6 +11665,37 @@ describe('OAuthProvider', () => {
         expect(response.status).toBe(302);
       });
 
+      it('should negotiate none when ChatGPT declares private_key_jwt and supports none', async () => {
+        // The document ChatGPT actually publishes: the declared method is a preference,
+        // and the list underneath is what there is to negotiate against.
+        const cimdUrl = 'https://chatgpt.com/oauth/IbUR3zxyNQ16/client.json';
+        const validMetadata = {
+          client_id: cimdUrl,
+          client_uri: 'https://chatgpt.com/',
+          client_name: 'ChatGPT',
+          redirect_uris: ['https://chatgpt.com/connector/oauth/IbUR3zxyNQ16'],
+          token_endpoint_auth_method: 'private_key_jwt',
+          token_endpoint_auth_methods_supported: ['none', 'private_key_jwt'],
+          token_endpoint_auth_signing_alg: 'RS256',
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          jwks_uri: 'https://chatgpt.com/oauth/jwks.json',
+        };
+
+        globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(validMetadata)));
+        const authRequest = createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}` +
+            `&redirect_uri=${encodeURIComponent(validMetadata.redirect_uris[0])}` +
+            `&response_type=code&state=test-state` +
+            `&code_challenge=test-challenge&code_challenge_method=S256`,
+          'GET'
+        );
+
+        const response = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+
+        expect(response.status).toBe(302);
+      });
+
       it('should reject private_key_jwt until token-endpoint assertion validation is implemented', async () => {
         const cimdUrl = 'https://client.example.com/oauth/metadata.json';
         const validMetadata = {

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -114,6 +114,52 @@ export function validateClientCapabilities(server: OAuthServerCapabilities, clie
 }
 
 /**
+ * Token endpoint authentication methods a Client ID Metadata Document may use.
+ *
+ * CIMD clients have no pre-shared secret, so the symmetric methods are out.
+ * `private_key_jwt` can be added once token-endpoint assertion validation is
+ * implemented. Accepting it in metadata before then creates clients that can
+ * authorize but never exchange a code.
+ */
+export const CIMD_SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS: readonly string[] = ['none'];
+
+/**
+ * Selects the token endpoint authentication method for a Client ID Metadata
+ * Document.
+ *
+ * `token_endpoint_auth_method` is the client's preference and
+ * `token_endpoint_auth_methods_supported` is the set it can negotiate within,
+ * so a document naming a method this server does not implement is only unusable
+ * when it offers no alternative alongside it. Preferring the declared method
+ * keeps a document that names an acceptable one unaffected.
+ *
+ * Returns undefined for a document that says nothing about client
+ * authentication, leaving the caller's default in place.
+ *
+ * @throws Error if the document asked for something and nothing was mutually supported
+ */
+export function negotiateCimdTokenEndpointAuthMethod(
+  declaredMethod: string | undefined,
+  supportedMethods: readonly string[] | undefined
+): string | undefined {
+  const isSupported = (method: string) => CIMD_SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS.includes(method);
+
+  if (declaredMethod !== undefined && isSupported(declaredMethod)) return declaredMethod;
+
+  const negotiated = supportedMethods?.find(isSupported);
+  if (negotiated !== undefined) return negotiated;
+
+  if (declaredMethod === undefined && supportedMethods === undefined) return undefined;
+
+  const advertised = [...(declaredMethod === undefined ? [] : [declaredMethod]), ...(supportedMethods ?? [])];
+  throw new Error(
+    `CIMD client does not support an accepted token endpoint authentication method. ` +
+      `Supported methods: ${CIMD_SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS.join(', ')}. ` +
+      `Client advertised: ${advertised.join(', ')}`
+  );
+}
+
+/**
  * Selects the capabilities from a Client ID Metadata Document that this
  * authorization server supports. CIMD documents may advertise extension
  * capabilities alongside the flow used with this server, so unsupported grant

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -5,6 +5,7 @@ import {
   buildOAuthServerCapabilities,
   isValidOAuthScopeToken,
   negotiateCimdClientCapabilities,
+  negotiateCimdTokenEndpointAuthMethod,
   normalizePkceCodeChallengeMethod,
   validateAuthorizationPkce,
   validateAuthorizationResponseType,
@@ -4309,14 +4310,6 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
   private static readonly CIMD_FETCH_TIMEOUT_MS = 10_000;
 
   /**
-   * Allowed authentication methods for CIMD clients (per IETF spec)
-   * CIMD clients cannot use symmetric secrets since there's no pre-shared secret
-   */
-  // private_key_jwt can be added once token-endpoint assertion validation is implemented.
-  // Accepting it in metadata before then creates clients that can authorize but never exchange a code.
-  private static readonly CIMD_ALLOWED_AUTH_METHODS = ['none'];
-
-  /**
    * Validates that a field is a string or undefined
    * @param field - The field value to validate
    * @param fieldName - Name of the field for error messages
@@ -4487,7 +4480,6 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         rawMetadata.token_endpoint_auth_methods_supported,
         'token_endpoint_auth_methods_supported'
       );
-      const tokenEndpointAuthMethod = declaredAuthMethod ?? (authMethodChoices?.includes('none') ? 'none' : undefined);
 
       // Validate that client_id matches the URL (required by spec)
       if (clientId !== metadataUrl) {
@@ -4502,16 +4494,7 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
         throw new Error('redirect_uris is required and must not be empty');
       }
 
-      if (
-        (declaredAuthMethod && !OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(declaredAuthMethod)) ||
-        (authMethodChoices &&
-          !authMethodChoices.some((method) => OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.includes(method)))
-      ) {
-        throw new Error(
-          `CIMD client does not support an accepted token endpoint authentication method. ` +
-            `Supported methods: ${OAuthProviderImpl.CIMD_ALLOWED_AUTH_METHODS.join(', ')}`
-        );
-      }
+      const tokenEndpointAuthMethod = negotiateCimdTokenEndpointAuthMethod(declaredAuthMethod, authMethodChoices);
 
       const advertisedGrantTypes = OAuthProviderImpl.validateStringArray(rawMetadata.grant_types, 'grant_types') || [
         GrantType.AUTHORIZATION_CODE,


### PR DESCRIPTION
Fixes #293.

## Summary

- treat a CIMD document's `token_endpoint_auth_method` as a preference and negotiate against `token_endpoint_auth_methods_supported`, rather than rejecting on the declared value alone
- move the allowed-method policy into `src/oauth-capabilities.ts` as `negotiateCimdTokenEndpointAuthMethod`, next to `negotiateCimdClientCapabilities`
- name what the client advertised in the error, so a rejected document says why
- leave dynamic client registration untouched

## Why

A document that declares `token_endpoint_auth_method: "private_key_jwt"` **and** advertises `token_endpoint_auth_methods_supported: ["none", "private_key_jwt"]` was refused outright, even though `none` is mutually supported:

```
CIMD client does not support an accepted token endpoint authentication method. Supported methods: none
```

That is the document ChatGPT publishes, so its MCP connector could not authorize against any server using this library.

`fetchClientMetadataDocument` computed the method with `??`, which lets the declared value win whenever it is present, so the fallback to `none` was only ever reachable for a document that omitted `token_endpoint_auth_method` entirely. The guard sixteen lines below then rejected on the declared value in its first clause, before the second clause had a chance to accept the advertised list.

#285 established that CIMD capabilities are negotiated rather than demanded, and `negotiateCimdClientCapabilities`'s docstring already says token endpoint authentication "must have a mutually supported method". For ChatGPT's document there is one. This extends the same treatment to the auth method, and is distinct from #264: supporting `private_key_jwt` end to end is a feature, while selecting `none` when the client says it supports `none` is the behavior #264's description already assumes exists.

## Behavior

| `token_endpoint_auth_method` | `token_endpoint_auth_methods_supported` | Before | After |
| --- | --- | --- | --- |
| absent | absent | `none` | `none` |
| `none` | absent | `none` | `none` |
| `private_key_jwt` | `["none", "private_key_jwt"]` | rejected | `none` |
| `private_key_jwt` | absent | rejected | rejected |
| absent | `["private_key_jwt"]` | rejected | rejected |
| `client_secret_post` | `["client_secret_post"]` | rejected | rejected |

Only the third row changes. A CIMD client still cannot end up with a symmetric method or with `private_key_jwt`, so nothing reaches the token endpoint that it could not authenticate before.

The negotiation now runs after the `client_id`, `client_name` and `redirect_uris` checks rather than before them, so a malformed document still reports the structural problem first.

## Tests

`__tests__/oauth-capabilities.test.ts` covers every row of the table above plus the enriched error message.

`__tests__/oauth-provider.test.ts` gains a case built from ChatGPT's live document. Worth noting: the existing `should negotiate none from ChatGPT-style authentication method choices` test omits `token_endpoint_auth_method`, so it passes today and does not exercise the failure. The new case includes it, and fails on `main`.

## Validation

- `npm run check` (typecheck and 837 tests)
- `npm run test:conformance` (150 tests)
- `npm run build`
- `npx prettier --check .`

Includes a patch changeset.
