### PR TITLE
feat(metadata): add opt-in issParameterCompat to omit the RFC 9207 advertisement

### DIFF
--- a/.changeset/iss-parameter-compat.md
+++ b/.changeset/iss-parameter-compat.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Add an opt-in `issParameterCompat` option that omits the RFC 9207 `authorization_response_iss_parameter_supported` advertisement from authorization server metadata for clients that mishandle it (e.g. Codex CLI 0.143 and later, which drops the `iss` callback parameter before validating it — see openai/codex#31573). The `iss` authorization-response parameter is still always sent, so conforming clients keep authorization-server mix-up protection. Defaults to false.

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Deleting a client through `OAuthHelpers.deleteClient()` also revokes its grants 
 | `clientIdMetadataDocumentEnabled`  | Enable CIMD lookup and advertisement                     | `false`                                     |
 | `allowPlainPKCE`                   | Permit the legacy plain PKCE method                      | `false`                                     |
 | `allowImplicitFlow`                | Enable implicit token responses                          | `false`                                     |
+| `issParameterCompat`               | Omit the RFC 9207 advertisement (`iss` is still sent)    | `false`                                     |
 | `disallowPublicClientRegistration` | Reject public clients at DCR                             | `false`                                     |
 | `clientRegistrationCallback`       | Apply application policy before storing a DCR client     | None                                        |
 | `allowTokenExchangeGrant`          | Enable RFC 8693                                          | `false`                                     |

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -358,6 +358,24 @@ describe('OAuthProvider', () => {
       expect(metadata.authorization_response_iss_parameter_supported).toBe(true);
     });
 
+    it('should omit the RFC 9207 advertisement when issParameterCompat is enabled', async () => {
+      const providerWithIssCompat = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        issParameterCompat: true,
+      });
+      const request = createMockRequest('https://example.com/.well-known/oauth-authorization-server');
+      const response = await providerWithIssCompat.fetch(request, mockEnv, mockCtx);
+
+      expect(response.status).toBe(200);
+
+      const metadata = await response.json<any>();
+      expect(metadata).not.toHaveProperty('authorization_response_iss_parameter_supported');
+    });
+
     it('should not include token response type when implicit flow is disabled', async () => {
       // Create a provider with implicit flow disabled
       const providerWithoutImplicit = new OAuthProvider({
@@ -1399,6 +1417,35 @@ describe('OAuthProvider', () => {
       // Verify a grant was created in KV
       const grants = await mockEnv.OAUTH_KV.list({ prefix: 'grant:' });
       expect(grants.keys.length).toBe(1);
+    });
+
+    it('should still include the iss parameter on redirects when issParameterCompat is enabled', async () => {
+      const providerWithIssCompat = new OAuthProvider({
+        apiRoute: ['/api/'],
+        apiHandler: TestApiHandler,
+        defaultHandler: testDefaultHandler,
+        authorizeEndpoint: '/authorize',
+        tokenEndpoint: '/oauth/token',
+        scopesSupported: ['read', 'write', 'profile'],
+        issParameterCompat: true,
+      });
+
+      const authRequest = createMockRequest(
+        `https://example.com/authorize?response_type=code&client_id=${clientId}` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+          `&scope=read%20write&state=xyz123`
+      );
+
+      const response = await providerWithIssCompat.fetch(authRequest, mockEnv, mockCtx);
+
+      expect(response.status).toBe(302);
+
+      // The compat flag only hides the metadata advertisement — the authorization
+      // response must still carry the iss parameter (RFC 9207 mix-up protection).
+      const location = response.headers.get('Location');
+      const url = new URL(location!);
+      expect(url.searchParams.get('code')).not.toBeNull();
+      expect(url.searchParams.get('iss')).toBe('https://example.com');
     });
 
     it.each([

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -437,6 +437,19 @@ export interface OAuthProviderOptions<Env = Cloudflare.Env> {
   allowPlainPKCE?: boolean;
 
   /**
+   * Temporary compatibility flag. Defaults to false.
+   * When true, the authorization server metadata omits the
+   * `authorization_response_iss_parameter_supported` (RFC 9207) advertisement entirely.
+   * The `iss` parameter itself is STILL included on every authorization response
+   * regardless of this flag, so conforming clients retain authorization-server
+   * mix-up protection.
+   * Known affected client: Codex CLI (0.143 and later, at the time of writing) drops
+   * the `iss` callback parameter before validating it (openai/codex#31573). Enable
+   * this only if you must support such a client, and remove it once clients update.
+   */
+  issParameterCompat?: boolean;
+
+  /**
    * Controls whether OAuth 2.0 Token Exchange (RFC 8693) is allowed.
    * When false, the token exchange grant type will not be advertised in metadata
    * and token exchange requests will be rejected.
@@ -2241,7 +2254,9 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       // not implemented: introspection_endpoint_auth_methods_supported
       // not implemented: introspection_endpoint_auth_signing_alg_values_supported
       code_challenge_methods_supported: this.serverCapabilities.codeChallengeMethods,
-      authorization_response_iss_parameter_supported: true,
+      // RFC 9207 advertisement. Omitted entirely when issParameterCompat is set, for clients
+      // that mishandle the advertisement; the iss parameter itself is still always sent.
+      ...(this.options.issParameterCompat ? {} : { authorization_response_iss_parameter_supported: true }),
       // MCP Client ID Metadata Document support (CIMD)
       // Only enabled when global_fetch_strictly_public compat flag is set (for SSRF protection)
       client_id_metadata_document_supported:


### PR DESCRIPTION
## Motivation

Staging results for 0.10.2: Claude.ai, Claude Code, Cursor, and ChatGPT CIMD all pass. Codex CLI 0.143–0.146 fails because it drops the RFC 9207 `iss` callback parameter before validating it (openai/codex#31573). 0.10.2 exposes this by correctly advertising `authorization_response_iss_parameter_supported: true` — Codex's OAuth stack sees the advertisement, expects to validate `iss`, and fails on its own dropped parameter.

## Change

New opt-in provider option `issParameterCompat` (default `false`):

- When `true`, the RFC 8414 authorization server metadata **omits** `authorization_response_iss_parameter_supported` entirely (absent, not `false`).
- The `iss` parameter itself is **still sent on every authorization response** (code-flow query param and implicit-flow fragment), unconditionally — this flag never touches it. Clients that implement RFC 9207 validation keep full authorization-server mix-up protection.
- Default behavior is byte-identical: same key, same position in the serialized metadata.

The JSDoc marks it as a temporary compatibility flag to be removed once affected clients update.

## Note on Codex versions

The staging report said this was fixed in Codex 0.147, but upstream openai/codex#31573 was still open with no fix release at the time of writing, so the docs say "0.143 and later, at the time of writing" and cite the issue. Happy to tighten to a version range if you've verified 0.147.

## Testing

- New test: with the flag set, metadata has no `authorization_response_iss_parameter_supported` property (mutation-checked: reverting the metadata line fails this test).
- New test: with the flag set, a completed authorization redirect still carries `iss=https://example.com` (and a real `code`).
- Existing default-behavior tests (advertised `true`) untouched and passing.
- `npm run check`: tsc clean, 850/850 tests, prettier clean.

Includes a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)