### PR TITLE
fix(cimd): scope default grant revocation to the authorizing redirect URI

### DIFF
--- a/.changeset/cimd-install-scoped-revocation.md
+++ b/.changeset/cimd-install-scoped-revocation.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Scope default grant revocation to the authorizing redirect URI for Client ID Metadata Document clients. A CIMD client_id is the metadata document URL shared by every installation of the client, so `completeAuthorization()`'s default revocation logged the user out of all their other devices; it now revokes only grants created from the same redirect URI. Grants now record the redirect URI that created them, and grants created before this release are never auto-revoked by CIMD clients. Revocation for pre-registered and dynamically registered clients is unchanged.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ A typical flow has three steps:
 
 `completeAuthorization()` stores a new grant and, by default, revokes existing grants for the same user and client after the new grant is safely stored. Set `revokeExistingGrants: false` only when the application intentionally allows concurrent grants for the same user and client.
 
+For Client ID Metadata Document clients, whose client_id is the metadata URL shared by every installation, default revocation is additionally scoped to grants created from the same redirect URI, so one installation's re-authorization does not revoke another's. Grants created before the redirect URI was recorded are never auto-revoked by CIMD clients.
+
 For users with many grants, `revokeExistingGrantsBatchSize` controls the KV page size used during that scan. It defaults to `50` and is capped at KV's maximum page size of `1000`.
 
 ### Authorization response issuer

--- a/__tests__/oauth-cimd.test.ts
+++ b/__tests__/oauth-cimd.test.ts
@@ -1199,4 +1199,163 @@ describe('Client ID Metadata Document (CIMD)', () => {
       );
     });
   });
+
+  describe('Grant Revocation Scoping', () => {
+    // A CIMD client_id is the metadata document URL, shared by every installation of
+    // the client. Two loopback redirect URIs stand in for two installations (devices).
+    const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+    const installA = 'http://127.0.0.1:49152/callback';
+    const installB = 'http://127.0.0.1:49153/callback';
+    const cimdMetadata = {
+      client_id: cimdUrl,
+      client_name: 'Multi-Install CIMD Client',
+      redirect_uris: [installA, installB],
+      token_endpoint_auth_method: 'none',
+    };
+    const codeVerifier = 'grant-scoping-code-verifier-that-is-at-least-43-characters';
+    let codeChallenge: string;
+
+    beforeEach(async () => {
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+      codeChallenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+    });
+
+    async function authorizeAndGetCode(clientId: string, redirectUri: string): Promise<string> {
+      const authResponse = await oauthProvider.fetch(
+        createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&state=test-state&code_challenge=${codeChallenge}&code_challenge_method=S256`,
+          'GET'
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(authResponse.status).toBe(302);
+      return new URL(authResponse.headers.get('Location')!).searchParams.get('code')!;
+    }
+
+    async function exchangeCodeForTokens(clientId: string, code: string, redirectUri: string): Promise<any> {
+      const tokenResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/token',
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          `grant_type=authorization_code&code=${encodeURIComponent(code)}&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&code_verifier=${codeVerifier}`
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(tokenResponse.status).toBe(200);
+      return tokenResponse.json<any>();
+    }
+
+    async function callApi(accessToken: string): Promise<number> {
+      const apiResponse = await oauthProvider.fetch(
+        createMockRequest('https://example.com/api/test', 'GET', { Authorization: `Bearer ${accessToken}` }),
+        mockEnv,
+        mockCtx
+      );
+      return apiResponse.status;
+    }
+
+    it('should keep grants from other installations of the same CIMD client', async () => {
+      globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(cimdMetadata)));
+
+      const codeA = await authorizeAndGetCode(cimdUrl, installA);
+      const tokensA = await exchangeCodeForTokens(cimdUrl, codeA, installA);
+
+      const codeB = await authorizeAndGetCode(cimdUrl, installB);
+      const tokensB = await exchangeCodeForTokens(cimdUrl, codeB, installB);
+
+      // Installation A's grant survives installation B's authorization.
+      expect(await callApi(tokensA.access_token)).toBe(200);
+      expect(await callApi(tokensB.access_token)).toBe(200);
+
+      const grants = await mockEnv.OAUTH_PROVIDER!.listUserGrants('test-user-123');
+      expect(grants.items.length).toBe(2);
+      expect(grants.items.map((grant) => grant.redirectUri).sort()).toEqual([installA, installB]);
+    });
+
+    it('should revoke the previous grant when the same installation re-authorizes', async () => {
+      globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(cimdMetadata)));
+
+      const codeA = await authorizeAndGetCode(cimdUrl, installA);
+      const tokensA = await exchangeCodeForTokens(cimdUrl, codeA, installA);
+      expect(await callApi(tokensA.access_token)).toBe(200);
+
+      // Same installation authorizes again with the same redirect URI.
+      const codeB = await authorizeAndGetCode(cimdUrl, installA);
+      const tokensB = await exchangeCodeForTokens(cimdUrl, codeB, installA);
+
+      expect(await callApi(tokensA.access_token)).toBe(401);
+      expect(await callApi(tokensB.access_token)).toBe(200);
+
+      const grants = await mockEnv.OAUTH_PROVIDER!.listUserGrants('test-user-123');
+      expect(grants.items.length).toBe(1);
+    });
+
+    it('should leave grants recorded before redirectUri existed untouched', async () => {
+      // A grant persisted by a release that predates the redirectUri field.
+      await mockEnv.OAUTH_KV.put(
+        'grant:test-user-123:legacygrant1',
+        JSON.stringify({
+          id: 'legacygrant1',
+          clientId: cimdUrl,
+          userId: 'test-user-123',
+          scope: ['read'],
+          metadata: {},
+          encryptedProps: 'legacy-ciphertext',
+          createdAt: 1700000000,
+        })
+      );
+      globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse(cimdMetadata)));
+
+      const code = await authorizeAndGetCode(cimdUrl, installA);
+      expect(code).toBeTruthy();
+
+      const grants = await mockEnv.OAUTH_PROVIDER!.listUserGrants('test-user-123');
+      expect(grants.items.length).toBe(2);
+      expect(grants.items.some((grant) => grant.id === 'legacygrant1')).toBe(true);
+    });
+
+    it('should still revoke by client alone for non-CIMD clients with a different redirect URI', async () => {
+      const registerResponse = await oauthProvider.fetch(
+        createMockRequest(
+          'https://example.com/oauth/register',
+          'POST',
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({
+            redirect_uris: [
+              'https://dcr-client.example.com/callback-one',
+              'https://dcr-client.example.com/callback-two',
+            ],
+            client_name: 'DCR Test Client',
+            token_endpoint_auth_method: 'none',
+          })
+        ),
+        mockEnv,
+        mockCtx
+      );
+      const { client_id: dcrClientId } = await registerResponse.json<any>();
+
+      const codeOne = await authorizeAndGetCode(dcrClientId, 'https://dcr-client.example.com/callback-one');
+      const tokensOne = await exchangeCodeForTokens(
+        dcrClientId,
+        codeOne,
+        'https://dcr-client.example.com/callback-one'
+      );
+      expect(await callApi(tokensOne.access_token)).toBe(200);
+
+      // A DCR client_id is unique to one installation, so a re-authorization from a
+      // different redirect URI still revokes the existing grant.
+      const codeTwo = await authorizeAndGetCode(dcrClientId, 'https://dcr-client.example.com/callback-two');
+      expect(codeTwo).toBeTruthy();
+
+      expect(await callApi(tokensOne.access_token)).toBe(401);
+      const grants = await mockEnv.OAUTH_PROVIDER!.listUserGrants('test-user-123');
+      expect(grants.items.length).toBe(1);
+    });
+  });
 });

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1043,6 +1043,14 @@ export interface Grant {
    * Indicates the protected resource(s) for which access is requested
    */
   resource?: string | string[];
+
+  /**
+   * The exact redirect URI used in the authorization request that created this grant
+   * Recorded so that default grant revocation can be scoped to a single installation
+   * of a CIMD client (whose client_id is shared across all installations). Absent on
+   * grants created before this field was introduced.
+   */
+  redirectUri?: string;
 }
 
 /**
@@ -1289,6 +1297,14 @@ export interface GrantSummary {
    * Unix timestamp when the grant expires (if TTL is configured)
    */
   expiresAt?: number;
+
+  /**
+   * The exact redirect URI used in the authorization request that created this grant
+   * Recorded so that default grant revocation can be scoped to a single installation
+   * of a CIMD client (whose client_id is shared across all installations). Absent on
+   * grants created before this field was introduced.
+   */
+  redirectUri?: string;
 }
 
 /**
@@ -5280,12 +5296,18 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
     // This avoids a data-loss window where the user has no grants if creation fails.
     let grantsToRevoke: string[] = [];
     if (options.revokeExistingGrants !== false) {
+      // A CIMD client_id is the metadata document URL, shared across all installations of
+      // the client, so revoking by clientId alone would log the user out everywhere. The
+      // redirect URI identifies the installation, so scope revocation to it. Legacy grants
+      // without a stored redirectUri never match and are left alone — the bug being fixed
+      // is over-revocation, so not revoking is the safe direction.
+      const isCimdClient = this.provider.isClientMetadataUrl(clientId);
       const batchSize = getRevokeExistingGrantsBatchSize(options.revokeExistingGrantsBatchSize);
       let cursor: string | undefined;
       do {
         const page = await this.listUserGrants(options.userId, { cursor, limit: batchSize });
         for (const grant of page.items) {
-          if (grant.clientId === clientId) {
+          if (grant.clientId === clientId && (!isCimdClient || grant.redirectUri === options.request.redirectUri)) {
             grantsToRevoke.push(grant.id);
           }
         }
@@ -5334,6 +5356,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
         encryptedProps: encryptedData,
         createdAt: now,
         resource: effectiveResource,
+        redirectUri: options.request.redirectUri,
       };
 
       // Store the grant with a key that includes the user ID
@@ -5417,6 +5440,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
         codeChallenge: options.request.codeChallenge,
         codeChallengeMethod: options.request.codeChallengeMethod,
         resource: effectiveResource,
+        redirectUri: options.request.redirectUri,
       };
 
       // Store the grant with a key that includes the user ID
@@ -5691,6 +5715,7 @@ class OAuthHelpersImpl<Env = Cloudflare.Env> implements OAuthHelpers {
           metadata: grantData.metadata,
           createdAt: grantData.createdAt,
           expiresAt: grantData.expiresAt,
+          redirectUri: grantData.redirectUri,
         };
         grantSummaries.push(summary);
       }


### PR DESCRIPTION
Fixes #297

## Problem

`completeAuthorization()` revokes existing grants for the same `(userId, clientId)` pair by default. For DCR clients each installation gets its own generated `client_id`, so that means "drop this device's stale sessions". A CIMD `client_id` is the metadata document URL — shared by every installation — so the same sweep logs the user out of **all their other devices**: device B authorizing kills device A's access and refresh tokens.

## Change

An additive installation indicator on the grant, per the discussion in #297 (option 2):

- `Grant` and `GrantSummary` gain an optional `redirectUri` field recording the exact redirect URI of the authorization that created the grant; `listUserGrants()` includes it in summaries. Persisted for all clients.
- In the `revokeExistingGrants` sweep, when `isClientMetadataUrl(clientId)` is true the predicate additionally requires `grant.redirectUri === request.redirectUri` — one installation's re-authorization only revokes that installation's stale grants.
- **Legacy grants** (created before the field existed) never match, so a CIMD client's re-auth leaves them alone — the bug is over-revocation, so not revoking is the safe direction.
- **Non-CIMD clients are byte-for-byte unchanged** (clientId-only predicate).

## Notes for review

- `isClientMetadataUrl()` is shape-based (same as the orphaned-grant purge logic), so a hand-pre-registered client whose `client_id` is an HTTPS URL also gets installation-scoped revocation. Generated DCR/pre-registered IDs are random strings, so this shouldn't occur in practice; such clients converge to same-redirect-URI revocation after one re-auth since the field is now stored on every new grant.
- Two loopback ports count as two installations (exact string match). A CLI re-authorizing on a fresh ephemeral port accumulates grants rather than pruning them — the lesser evil vs. cross-device logout; #232 tracks bounding the sweep's KV work.
- Additive-only storage change: previously issued tokens still validate, so the changeset is a patch bump per AGENTS.md's storage-format rule.

## Testing

New "Grant Revocation Scoping" suite in `__tests__/oauth-cimd.test.ts` (full flows: authorize → exchange → API call):

- Two installations (distinct loopback ports) of one CIMD client: both grants survive, both tokens keep working.
- Same installation re-authorizing: old grant **is** revoked (default preserved within an installation).
- Legacy grant seeded without `redirectUri`: untouched by a new CIMD authorization.
- DCR client re-authorizing from a different registered redirect URI: still revoked (unchanged behavior).

Mutation-checked: reverting only `src` makes the first and third tests fail while the other two still pass. `npm run check`: tsc clean, 852/852 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)