### PR TITLE
feat: support private_key_jwt for CIMD clients

### DIFF
--- a/.changeset/strong-carrots-sign.md
+++ b/.changeset/strong-carrots-sign.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/workers-oauth-provider': minor
+---
+
+Support `private_key_jwt` authentication for Client ID Metadata Document clients, including inline and remote JWKS validation, signed client assertions, and replay protection.

--- a/README.md
+++ b/README.md
@@ -306,11 +306,13 @@ CIMD validation follows [draft-ietf-oauth-client-id-metadata-document-00](https:
 - Exact authorization-request redirect URI validation, with RFC 8252 loopback port handling.
 - A 5 KB response size limit and a 10 second timeout covering both headers and body.
 - Valid UTF-8 JSON object syntax and safe URI schemes for client metadata fields.
-- No embedded client secrets or private JWK material.
+- No embedded client secrets or private or symmetric JWK material.
 
 Validated documents are cached according to their `Cache-Control` headers, capped at 7 days. Error responses and invalid documents are never cached, and a cached document that stops validating is evicted and re-resolved from origin within the same request.
 
-CIMD token endpoint authentication is negotiated from `token_endpoint_auth_method` and the OpenID RP Metadata Choices field `token_endpoint_auth_methods_supported`. The provider currently implements only `none`: a client may prefer `private_key_jwt` while also offering `none`, in which case the provider selects `none` and applies public-client PKCE requirements. A client that offers only `private_key_jwt` is rejected until assertion validation is implemented.
+CIMD token endpoint authentication is negotiated from `token_endpoint_auth_method` and the OpenID RP Metadata Choices field `token_endpoint_auth_methods_supported`. The provider supports `none` and `private_key_jwt`. When a client offers both methods, the provider retains the public-client `none` path; clients that require `private_key_jwt` use signed assertions.
+
+Clients using `private_key_jwt` must publish exactly one of `jwks` or an HTTPS `jwks_uri`. Assertions may use `RS256` or `ES256`; `iss` and `sub` must equal the CIMD `client_id`, `aud` must include the token endpoint URL, and `exp` must still be valid. A non-empty `jti` makes each assertion single-use. Remote JWKS responses have a 64 KB limit and a 10 second timeout, and their fetches are protected by the same `global_fetch_strictly_public` requirement as the metadata document.
 
 When a CIMD document cannot be fetched or validated, the token endpoint returns a generic `invalid_client` response and reports diagnostics through `onError.internal`. `OAuthHelpers` methods that resolve a CIMD client throw the exported `CimdFetchError`, allowing applications to distinguish an upstream metadata failure from a client that does not exist. See [Advanced configuration](https://github.com/cloudflare/workers-oauth-provider/blob/main/docs/advanced-configuration.md#cimd-fetch-errors) for an example.
 

--- a/__tests__/oauth-capabilities.test.ts
+++ b/__tests__/oauth-capabilities.test.ts
@@ -165,16 +165,14 @@ describe('CIMD token endpoint authentication negotiation', () => {
     ['defaults an omitted method', undefined, undefined, 'none'],
     ['keeps an implemented preference', 'none', undefined, 'none'],
     ['selects an implemented choice', undefined, ['private_key_jwt', 'none'], 'none'],
-    ['falls back from an unsupported preference', 'private_key_jwt', ['none', 'private_key_jwt'], 'none'],
+    ['keeps the public fallback when both methods are offered', 'private_key_jwt', ['none', 'private_key_jwt'], 'none'],
+    ['accepts private_key_jwt without choices', 'private_key_jwt', undefined, 'private_key_jwt'],
+    ['selects private_key_jwt when it is the only choice', undefined, ['private_key_jwt'], 'private_key_jwt'],
   ])('%s', (_label, preferred, choices, expected) => {
     expect(negotiateAuthMethod(preferred, choices)).toBe(expected);
   });
 
-  it.each([
-    ['an unsupported preference without choices', 'private_key_jwt', undefined],
-    ['unsupported choices without a preference', undefined, ['private_key_jwt']],
-    ['an empty choice list', undefined, []],
-  ])('rejects %s', (_label, preferred, choices) => {
+  it.each([['an empty choice list', undefined, []]])('rejects %s', (_label, preferred, choices) => {
     expect(() => negotiateAuthMethod(preferred, choices)).toThrow(
       'CIMD client does not support an accepted token endpoint authentication method'
     );

--- a/__tests__/oauth-cimd.test.ts
+++ b/__tests__/oauth-cimd.test.ts
@@ -13,6 +13,66 @@ let oauthProvider: OAuthProvider<TestEnv>;
 let mockEnv: TestEnv;
 let mockCtx: MockExecutionContext;
 
+type TestJsonWebKey = JsonWebKey & { kid?: string };
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function jsonToBase64Url(value: Record<string, unknown>): string {
+  return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+async function createRsaClientKey(kid: string): Promise<{ privateKey: CryptoKey; publicJwk: TestJsonWebKey }> {
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify']
+  )) as CryptoKeyPair;
+  const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as TestJsonWebKey;
+  return {
+    privateKey: keyPair.privateKey,
+    publicJwk: { ...publicJwk, kid, alg: 'RS256', use: 'sig', key_ops: ['verify'] },
+  };
+}
+
+async function createEcClientKey(kid: string): Promise<{ privateKey: CryptoKey; publicJwk: TestJsonWebKey }> {
+  const keyPair = (await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as TestJsonWebKey;
+  return {
+    privateKey: keyPair.privateKey,
+    publicJwk: { ...publicJwk, kid, alg: 'ES256', use: 'sig', key_ops: ['verify'] },
+  };
+}
+
+async function signClientAssertion(
+  privateKey: CryptoKey,
+  claims: Record<string, unknown>,
+  kid: string,
+  headerOverrides: Record<string, unknown> = {}
+): Promise<string> {
+  const header = { alg: 'RS256', typ: 'JWT', kid, ...headerOverrides };
+  const encodedHeader = jsonToBase64Url(header);
+  const encodedClaims = jsonToBase64Url(claims);
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const signature = await crypto.subtle.sign(
+    header.alg === 'ES256' ? { name: 'ECDSA', hash: 'SHA-256' } : { name: 'RSASSA-PKCS1-v1_5' },
+    privateKey,
+    new TextEncoder().encode(signingInput)
+  );
+  return `${signingInput}.${bytesToBase64Url(new Uint8Array(signature))}`;
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
   mockEnv = createMockEnv();
@@ -132,6 +192,8 @@ describe('Client ID Metadata Document (CIMD)', () => {
       const metadata = await metadataResponse.json<any>();
 
       expect(metadata.client_id_metadata_document_supported).toBe(true);
+      expect(metadata.token_endpoint_auth_methods_supported).toContain('private_key_jwt');
+      expect(metadata.token_endpoint_auth_signing_alg_values_supported).toEqual(['RS256', 'ES256']);
     });
 
     it('should accept a CIMD document with localized metadata variants', async () => {
@@ -408,7 +470,7 @@ describe('Client ID Metadata Document (CIMD)', () => {
       });
     });
 
-    it('should reject private_key_jwt until token-endpoint assertion validation is implemented', async () => {
+    it('should accept private_key_jwt metadata with a public JWKS URI', async () => {
       const cimdUrl = 'https://client.example.com/oauth/metadata.json';
       const validMetadata = {
         client_id: cimdUrl,
@@ -425,7 +487,249 @@ describe('Client ID Metadata Document (CIMD)', () => {
         'GET'
       );
 
-      await expect(oauthProvider.fetch(authRequest, mockEnv, mockCtx)).rejects.toThrow(CimdFetchError);
+      const response = await oauthProvider.fetch(authRequest, mockEnv, mockCtx);
+      expect(response.status).toBe(302);
+    });
+  });
+
+  describe('private_key_jwt Token Endpoint Authentication', () => {
+    const cimdUrl = 'https://client.example.com/oauth/metadata.json';
+    const redirectUri = 'https://client.example.com/callback';
+    const tokenEndpoint = 'https://example.com/oauth/token';
+    const assertionType = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+    const codeVerifier = 'private-key-jwt-verifier-that-is-at-least-43-characters';
+    let codeChallenge: string;
+    let signingKey: Awaited<ReturnType<typeof createRsaClientKey>>;
+
+    beforeEach(async () => {
+      signingKey = await createRsaClientKey('client-key-1');
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+      codeChallenge = bytesToBase64Url(new Uint8Array(digest));
+    });
+
+    function inlineMetadata(publicJwk: TestJsonWebKey = signingKey.publicJwk) {
+      return {
+        client_id: cimdUrl,
+        client_name: 'Private Key CIMD Client',
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: 'private_key_jwt',
+        token_endpoint_auth_signing_alg: 'RS256',
+        jwks: { keys: [publicJwk] },
+      };
+    }
+
+    function installInlineMetadata(publicJwk?: TestJsonWebKey): void {
+      globalThis.fetch = vi
+        .fn()
+        .mockImplementation(() => Promise.resolve(createMockFetchResponse(inlineMetadata(publicJwk))));
+    }
+
+    async function authorizeAndGetCode(): Promise<string> {
+      const response = await oauthProvider.fetch(
+        createMockRequest(
+          `https://example.com/authorize?client_id=${encodeURIComponent(cimdUrl)}` +
+            `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+            `&response_type=code&state=test-state&code_challenge=${codeChallenge}&code_challenge_method=S256`,
+          'GET'
+        ),
+        mockEnv,
+        mockCtx
+      );
+      expect(response.status).toBe(302);
+      return new URL(response.headers.get('Location')!).searchParams.get('code')!;
+    }
+
+    async function createAssertion(
+      overrides: Record<string, unknown> = {},
+      key = signingKey,
+      kid = key.publicJwk.kid!,
+      headerOverrides: Record<string, unknown> = {}
+    ): Promise<string> {
+      const now = Math.floor(Date.now() / 1000);
+      return signClientAssertion(
+        key.privateKey,
+        {
+          iss: cimdUrl,
+          sub: cimdUrl,
+          aud: tokenEndpoint,
+          exp: now + 300,
+          iat: now,
+          jti: crypto.randomUUID(),
+          ...overrides,
+        },
+        kid,
+        headerOverrides
+      );
+    }
+
+    async function exchangeCode(code: string, assertion: string, includeClientId = false): Promise<Response> {
+      const params = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+        code_verifier: codeVerifier,
+        client_assertion_type: assertionType,
+        client_assertion: assertion,
+      });
+      if (includeClientId) params.set('client_id', cimdUrl);
+      return oauthProvider.fetch(
+        createMockRequest(
+          tokenEndpoint,
+          'POST',
+          { 'Content-Type': 'application/x-www-form-urlencoded' },
+          params.toString()
+        ),
+        mockEnv,
+        mockCtx
+      );
+    }
+
+    it('authenticates an authorization-code exchange from an inline JWKS', async () => {
+      installInlineMetadata();
+      const code = await authorizeAndGetCode();
+      const response = await exchangeCode(code, await createAssertion());
+
+      expect(response.status).toBe(200);
+      expect(await response.json<any>()).toMatchObject({ token_type: 'bearer' });
+    });
+
+    it('authenticates an ES256 client assertion', async () => {
+      const ecKey = await createEcClientKey('client-ec-key');
+      signingKey = ecKey;
+      globalThis.fetch = vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          createMockFetchResponse({
+            ...inlineMetadata(ecKey.publicJwk),
+            token_endpoint_auth_signing_alg: 'ES256',
+          })
+        )
+      );
+      const code = await authorizeAndGetCode();
+      const response = await exchangeCode(
+        code,
+        await createAssertion({}, ecKey, ecKey.publicJwk.kid!, { alg: 'ES256' })
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json<any>()).toMatchObject({ token_type: 'bearer' });
+    });
+
+    it('rejects an assertion replay before processing the grant again', async () => {
+      installInlineMetadata();
+      const code = await authorizeAndGetCode();
+      const assertion = await createAssertion({ jti: 'one-time-assertion' });
+
+      expect((await exchangeCode(code, assertion)).status).toBe(200);
+      const replay = await exchangeCode(code, assertion);
+      expect(replay.status).toBe(401);
+      expect(await replay.json<any>()).toEqual({
+        error: 'invalid_client',
+        error_description: 'Client authentication failed',
+      });
+    });
+
+    it.each([
+      ['a different issuer', { iss: 'https://other.example.com/client.json' }],
+      ['a different subject', { sub: 'https://other.example.com/client.json' }],
+      ['a different audience', { aud: 'https://other.example.com/oauth/token' }],
+      ['an expired timestamp', { exp: 1 }],
+      ['no unique identifier', { jti: undefined }],
+    ])('rejects an assertion with %s', async (_label, overrides) => {
+      installInlineMetadata();
+      const code = await authorizeAndGetCode();
+      const response = await exchangeCode(code, await createAssertion(overrides), true);
+
+      expect(response.status).toBe(401);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
+    });
+
+    it('rejects an assertion signed by an unknown key', async () => {
+      installInlineMetadata();
+      const code = await authorizeAndGetCode();
+      const unknownKey = await createRsaClientKey('unknown-key');
+      const response = await exchangeCode(code, await createAssertion({}, unknownKey));
+
+      expect(response.status).toBe(401);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
+    });
+
+    it('rejects a malformed assertion', async () => {
+      installInlineMetadata();
+      const code = await authorizeAndGetCode();
+      const response = await exchangeCode(code, 'not.a.jwt', true);
+
+      expect(response.status).toBe(401);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
+    });
+
+    it('rejects unsupported critical JOSE extensions', async () => {
+      installInlineMetadata();
+      const code = await authorizeAndGetCode();
+      const assertion = await createAssertion({}, signingKey, signingKey.publicJwk.kid!, {
+        crit: ['example'],
+        example: true,
+      });
+      const response = await exchangeCode(code, assertion);
+
+      expect(response.status).toBe(401);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
+    });
+
+    it('rejects an assertion algorithm excluded by client metadata', async () => {
+      globalThis.fetch = vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          createMockFetchResponse({
+            ...inlineMetadata(),
+            token_endpoint_auth_signing_alg: 'ES256',
+          })
+        )
+      );
+      const code = await authorizeAndGetCode();
+      const response = await exchangeCode(code, await createAssertion());
+
+      expect(response.status).toBe(401);
+      expect(await response.json<any>()).toMatchObject({ error: 'invalid_client' });
+    });
+
+    it('loads a rotated key from a protected HTTPS jwks_uri', async () => {
+      const jwksUri = 'https://client.example.com/.well-known/jwks.json';
+      let activeKey = signingKey;
+      const metadata = { ...inlineMetadata(), jwks: undefined, jwks_uri: jwksUri };
+      globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+        const url = input instanceof Request ? input.url : String(input);
+        return Promise.resolve(createMockFetchResponse(url === jwksUri ? { keys: [activeKey.publicJwk] } : metadata));
+      });
+
+      const firstCode = await authorizeAndGetCode();
+      expect((await exchangeCode(firstCode, await createAssertion())).status).toBe(200);
+
+      activeKey = await createRsaClientKey('client-key-2');
+      signingKey = activeKey;
+      const secondCode = await authorizeAndGetCode();
+      expect((await exchangeCode(secondCode, await createAssertion())).status).toBe(200);
+    });
+
+    it('rejects a non-HTTPS jwks_uri before authorization', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        createMockFetchResponse({
+          ...inlineMetadata(),
+          jwks: undefined,
+          jwks_uri: 'http://127.0.0.1/jwks.json',
+        })
+      );
+
+      await expect(authorizeAndGetCode()).rejects.toThrow(CimdFetchError);
+    });
+
+    it('rejects an empty inline JWKS before authorization', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        createMockFetchResponse({
+          ...inlineMetadata(),
+          jwks: { keys: [] },
+        })
+      );
+
+      await expect(authorizeAndGetCode()).rejects.toThrow(CimdFetchError);
     });
   });
 
@@ -930,9 +1234,13 @@ describe('Client ID Metadata Document (CIMD)', () => {
 
       const metadataRequest = createMockRequest('https://example.com/.well-known/oauth-authorization-server', 'GET');
       const response = await oauthProvider.fetch(metadataRequest, mockEnv, mockCtx);
-      const metadata = (await response.json()) as { client_id_metadata_document_supported: boolean };
+      const metadata = (await response.json()) as {
+        client_id_metadata_document_supported: boolean;
+        token_endpoint_auth_methods_supported: string[];
+      };
 
       expect(metadata.client_id_metadata_document_supported).toBe(false);
+      expect(metadata.token_endpoint_auth_methods_supported).not.toContain('private_key_jwt');
     });
 
     it('should report client_id_metadata_document_supported as false when Cloudflare global is undefined', async () => {

--- a/src/oauth-capabilities.ts
+++ b/src/oauth-capabilities.ts
@@ -167,10 +167,16 @@ function negotiateCimdTokenEndpointAuthMethod(
   const acceptedMethods = server.tokenEndpointAuthMethods.filter(
     (method) => !SHARED_SECRET_TOKEN_ENDPOINT_AUTH_METHODS.has(method)
   );
+  acceptedMethods.push('private_key_jwt');
+  // Preserve the existing public-client path when a CIMD client offers it.
+  // This keeps clients such as ChatGPT, which prefer private_key_jwt but also
+  // advertise none, compatible while enabling clients that require a key.
+  const effectivePreference =
+    preferredMethod === 'private_key_jwt' && supportedMethods?.includes('none') ? undefined : preferredMethod;
   return negotiateTokenEndpointAuthMethod({
     acceptedMethods,
     defaultMethod: 'none',
-    preferredMethod,
+    preferredMethod: effectivePreference,
     supportedMethods,
     context: 'CIMD client',
   });
@@ -214,6 +220,10 @@ export function negotiateCimdClientCapabilities(
   server: OAuthServerCapabilities,
   client: ClientMetadataCapabilities
 ): { grantTypes: string[]; responseTypes: string[]; tokenEndpointAuthMethod: string } {
+  const cimdServer = {
+    ...server,
+    tokenEndpointAuthMethods: [...server.tokenEndpointAuthMethods, 'private_key_jwt'],
+  };
   const effective = {
     grantTypes: client.grantTypes.filter((grantType) => server.grantTypes.includes(grantType)),
     responseTypes: client.responseTypes.filter((responseType) => server.responseTypes.includes(responseType)),
@@ -224,7 +234,7 @@ export function negotiateCimdClientCapabilities(
     ),
   };
 
-  validateClientCapabilities(server, effective);
+  validateClientCapabilities(cimdServer, effective);
   return effective;
 }
 

--- a/src/oauth-client-metadata.ts
+++ b/src/oauth-client-metadata.ts
@@ -8,6 +8,16 @@ const CIMD_MAX_SIZE_BYTES = 5 * 1024;
 const CIMD_FETCH_TIMEOUT_MS = 10_000;
 const CIMD_CACHE_NAME = 'workers-oauth-provider:cimd:v1';
 const CIMD_CACHE_MAX_TTL_SECONDS = 7 * 24 * 60 * 60;
+const PRIVATE_KEY_JWT_SIGNING_ALGORITHMS = new Set(['RS256', 'ES256']);
+
+/** Public JSON Web Key supplied by an OAuth client. */
+export type OAuthClientJsonWebKey = JsonWebKey & { kid?: string };
+
+/** Public JSON Web Key Set supplied by an OAuth client. */
+export interface OAuthClientJsonWebKeySet {
+  /** Public keys that may verify client-signed assertions. */
+  keys: OAuthClientJsonWebKey[];
+}
 
 /** Human-readable and key-discovery client metadata shared by DCR and CIMD clients. */
 interface OAuthClientDisplayMetadata {
@@ -43,6 +53,8 @@ interface ParsedOAuthClientMetadata extends OAuthClientDisplayMetadata {
   tokenEndpointAuthMethod?: string;
   /** Token endpoint authentication methods supported by the client. */
   tokenEndpointAuthMethodsSupported?: string[];
+  /** Inline client JSON Web Key Set. */
+  jwks?: OAuthClientJsonWebKeySet;
   /** Preferred signing algorithm for JWT client authentication. */
   tokenEndpointAuthSigningAlg?: string;
   /** JWT client-authentication signing algorithms supported by the client. */
@@ -77,6 +89,12 @@ export interface ResolvedClientIdMetadataDocument extends OAuthClientDisplayMeta
   responseTypes: string[];
   /** Mutually supported token endpoint authentication method. */
   tokenEndpointAuthMethod: string;
+  /** Inline client JSON Web Key Set. */
+  jwks?: OAuthClientJsonWebKeySet;
+  /** Required signing algorithm for JWT client authentication. */
+  tokenEndpointAuthSigningAlg?: string;
+  /** JWT client-authentication signing algorithms supported by the client. */
+  tokenEndpointAuthSigningAlgValuesSupported?: string[];
 }
 
 export function requireJsonObject(value: unknown): Record<string, unknown> {
@@ -121,6 +139,25 @@ function optionalHttpUri(value: unknown, fieldName: string): string | undefined 
   }
 
   return uri;
+}
+
+function optionalPublicJwks(value: unknown): OAuthClientJsonWebKeySet | undefined {
+  if (value === undefined) return undefined;
+
+  const jwks = requireJsonObject(value);
+  if (!Array.isArray(jwks.keys)) throw new Error('Invalid jwks: keys must be an array');
+
+  const privateMembers = new Set(['d', 'p', 'q', 'dp', 'dq', 'qi', 'oth', 'k']);
+  const keys = jwks.keys.map((value) => {
+    const key = requireJsonObject(value);
+    if (typeof key.kty !== 'string' || key.kty.length === 0) throw new Error('Invalid jwks: key kty is required');
+    if (Object.keys(key).some((member) => privateMembers.has(member))) {
+      throw new Error('CIMD documents must not contain private or symmetric key material');
+    }
+    return { ...key } as unknown as OAuthClientJsonWebKey;
+  });
+
+  return { keys };
 }
 
 const I18N_FIELDS: Record<string, 'string' | 'uri'> = {
@@ -195,6 +232,7 @@ function parseOAuthClientMetadata(raw: Record<string, unknown>): ParsedOAuthClie
     policyUri: optionalHttpUri(raw.policy_uri, 'policy_uri'),
     tosUri: optionalHttpUri(raw.tos_uri, 'tos_uri'),
     jwksUri: optionalHttpUri(raw.jwks_uri, 'jwks_uri'),
+    jwks: optionalPublicJwks(raw.jwks),
     i18n: extractI18nFields(raw),
     contacts: optionalStringArray(raw.contacts, 'contacts'),
     grantTypes: optionalStringArray(raw.grant_types, 'grant_types'),
@@ -330,19 +368,6 @@ export function isClientIdMetadataDocumentUrl(clientId: string): boolean {
   }
 }
 
-function containsPrivateJwkMaterial(value: unknown): boolean {
-  if (value === undefined) return false;
-  const jwks = requireJsonObject(value);
-  if (!Array.isArray(jwks.keys)) throw new Error('Invalid jwks: keys must be an array');
-
-  const privateMembers = new Set(['d', 'p', 'q', 'dp', 'dq', 'qi', 'oth', 'k']);
-  for (const value of jwks.keys) {
-    const key = requireJsonObject(value);
-    if (Object.keys(key).some((member) => privateMembers.has(member))) return true;
-  }
-  return false;
-}
-
 function resolveClientIdMetadataDocument(
   metadataUrl: string,
   value: unknown,
@@ -360,9 +385,7 @@ function resolveClientIdMetadataDocument(
   if ('client_secret' in raw || 'client_secret_expires_at' in raw) {
     throw new Error('CIMD documents must not contain client secrets');
   }
-  if (containsPrivateJwkMaterial(raw.jwks)) {
-    throw new Error('CIMD documents must not contain private key material');
-  }
+  if (metadata.jwks && metadata.jwksUri) throw new Error('jwks and jwks_uri must not both be present');
 
   const capabilities = negotiateCimdClientCapabilities(server, {
     tokenEndpointAuthMethod: metadata.tokenEndpointAuthMethod,
@@ -371,8 +394,43 @@ function resolveClientIdMetadataDocument(
     responseTypes: metadata.responseTypes ?? ['code'],
   });
 
+  if (capabilities.tokenEndpointAuthMethod === 'private_key_jwt') {
+    if (!metadata.jwks && !metadata.jwksUri) {
+      throw new Error('private_key_jwt requires jwks or jwks_uri');
+    }
+    if (metadata.jwks && metadata.jwks.keys.length === 0) {
+      throw new Error('private_key_jwt jwks must contain at least one public key');
+    }
+    if (metadata.jwksUri) {
+      const jwksUrl = new URL(metadata.jwksUri);
+      if (jwksUrl.protocol !== 'https:') throw new Error('private_key_jwt jwks_uri must use HTTPS');
+      if (jwksUrl.username || jwksUrl.password) throw new Error('private_key_jwt jwks_uri must not contain userinfo');
+      if (jwksUrl.hash) throw new Error('private_key_jwt jwks_uri must not contain a fragment');
+    }
+    if (metadata.tokenEndpointAuthSigningAlg === 'none') {
+      throw new Error('token_endpoint_auth_signing_alg must not be none');
+    }
+    if (
+      metadata.tokenEndpointAuthSigningAlg &&
+      !PRIVATE_KEY_JWT_SIGNING_ALGORITHMS.has(metadata.tokenEndpointAuthSigningAlg)
+    ) {
+      throw new Error(`Unsupported token_endpoint_auth_signing_alg: ${metadata.tokenEndpointAuthSigningAlg}`);
+    }
+    if (
+      metadata.tokenEndpointAuthSigningAlgValuesSupported &&
+      !metadata.tokenEndpointAuthSigningAlgValuesSupported.some((algorithm) =>
+        PRIVATE_KEY_JWT_SIGNING_ALGORITHMS.has(algorithm)
+      )
+    ) {
+      throw new Error('Client does not support an accepted token endpoint authentication signing algorithm');
+    }
+  }
+
   return {
     ...pickDisplayMetadata(metadata),
+    jwks: metadata.jwks,
+    tokenEndpointAuthSigningAlg: metadata.tokenEndpointAuthSigningAlg,
+    tokenEndpointAuthSigningAlgValuesSupported: metadata.tokenEndpointAuthSigningAlgValuesSupported,
     clientId: metadata.clientId,
     clientName: metadata.clientName,
     redirectUris,

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -19,6 +19,7 @@ import {
   requireJsonObject,
   resolveDynamicClientRegistrationMetadata,
   validateRedirectUriScheme,
+  type OAuthClientJsonWebKeySet,
   type ResolvedDynamicClientRegistrationMetadata,
 } from './oauth-client-metadata';
 import {
@@ -44,6 +45,11 @@ import {
   validateIdJagClaims,
   validateIdJagHeader,
 } from './ema/validators';
+import {
+  JWT_BEARER_CLIENT_ASSERTION_TYPE,
+  authenticatePrivateKeyJwt,
+  readPrivateKeyJwtClientId,
+} from './private-key-jwt';
 
 export { AuthorizationError } from './oauth-capabilities';
 export type { AuthorizationErrorCode, AuthorizationErrorOptions } from './oauth-capabilities';
@@ -826,6 +832,21 @@ export interface ClientInfo {
    * URL to the client's JSON Web Key Set for validating signatures
    */
   jwksUri?: string;
+
+  /**
+   * Inline public JSON Web Key Set for validating client assertions.
+   */
+  jwks?: OAuthClientJsonWebKeySet;
+
+  /**
+   * Required signing algorithm for JWT client authentication.
+   */
+  tokenEndpointAuthSigningAlg?: string;
+
+  /**
+   * JWT client-authentication signing algorithms supported by the client.
+   */
+  tokenEndpointAuthSigningAlgValuesSupported?: string[];
 
   /**
    * RFC 7591 §2.2 internationalized variants of the human-readable client
@@ -1969,11 +1990,12 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // Get client credentials from HTTP Basic auth or form parameters.
     const basicAuthorization = parseBasicAuthorizationHeader(request.headers.get('Authorization'));
     const basicAuthenticationAttempted = basicAuthorization.kind !== 'not-basic';
+    const clientAssertionAttempted = formData.has('client_assertion') || formData.has('client_assertion_type');
     let clientId = '';
     let clientSecret = '';
 
     if (basicAuthenticationAttempted) {
-      if (formData.has('client_id') || formData.has('client_secret')) {
+      if (formData.has('client_id') || formData.has('client_secret') || clientAssertionAttempted) {
         return this.createErrorResponse('invalid_request', {
           description: 'Client must not use multiple authentication methods',
           statusCode: 400,
@@ -1989,6 +2011,14 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
 
       clientId = basicAuthorization.clientId;
       clientSecret = basicAuthorization.clientSecret;
+    } else if (clientAssertionAttempted) {
+      if (formData.has('client_secret')) {
+        return this.createErrorResponse('invalid_request', {
+          description: 'Client must not use multiple authentication methods',
+          statusCode: 400,
+        });
+      }
+      clientId = body.client_id || readPrivateKeyJwtClientId(body.client_assertion) || '';
     } else {
       clientId = body.client_id;
       clientSecret = body.client_secret || '';
@@ -2030,9 +2060,11 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
     // presence rather than truthiness so an empty secret still counts as a POST attempt.
     const presentedAuthMethod = basicAuthenticationAttempted
       ? 'client_secret_basic'
-      : formData.has('client_secret')
-        ? 'client_secret_post'
-        : 'none';
+      : clientAssertionAttempted
+        ? 'private_key_jwt'
+        : formData.has('client_secret')
+          ? 'client_secret_post'
+          : 'none';
     const registeredAuthMethod = clientInfo.tokenEndpointAuthMethod;
     if (
       !isClientAuthMethodAllowed(
@@ -2052,8 +2084,32 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       });
     }
 
-    // For confidential clients, validate the secret
-    if (presentedAuthMethod !== 'none') {
+    if (presentedAuthMethod === 'private_key_jwt') {
+      if (body.client_assertion_type !== JWT_BEARER_CLIENT_ASSERTION_TYPE) {
+        return this.createInvalidClientResponse('Client authentication failed', basicAuthenticationAttempted);
+      }
+
+      const result = await authenticatePrivateKeyJwt({
+        assertion: body.client_assertion,
+        client: clientInfo,
+        tokenEndpoint: this.getFullEndpointUrl(this.options.tokenEndpoint, new URL(request.url)),
+        now: Math.floor(Date.now() / 1000),
+        env,
+      });
+      if (!result.ok) {
+        return this.createInvalidClientResponse(
+          'Client authentication failed',
+          basicAuthenticationAttempted,
+          {
+            category: 'client-authentication',
+            reason: 'private_key_jwt_validation_failed',
+            detail: { clientId: clientInfo.clientId, reason: result.reason },
+          },
+          request
+        );
+      }
+    } else if (presentedAuthMethod !== 'none') {
+      // For shared-secret methods, validate the stored secret.
       if (!clientSecret) {
         return this.createInvalidClientResponse(
           'Client authentication failed: missing client_secret',
@@ -2244,8 +2300,15 @@ class OAuthProviderImpl<Env = Cloudflare.Env> {
       ...(authorizationGrantProfilesSupported.length > 0
         ? { authorization_grant_profiles_supported: authorizationGrantProfilesSupported }
         : {}),
-      token_endpoint_auth_methods_supported: this.serverCapabilities.tokenEndpointAuthMethods,
-      // not implemented: token_endpoint_auth_signing_alg_values_supported
+      token_endpoint_auth_methods_supported: [
+        ...this.serverCapabilities.tokenEndpointAuthMethods,
+        ...(this.options.clientIdMetadataDocumentEnabled && this.hasGlobalFetchStrictlyPublic()
+          ? ['private_key_jwt']
+          : []),
+      ],
+      ...(this.options.clientIdMetadataDocumentEnabled && this.hasGlobalFetchStrictlyPublic()
+        ? { token_endpoint_auth_signing_alg_values_supported: ['RS256', 'ES256'] }
+        : {}),
       // not implemented: service_documentation
       // not implemented: ui_locales_supported
       // not implemented: op_policy_uri

--- a/src/private-key-jwt.ts
+++ b/src/private-key-jwt.ts
@@ -1,0 +1,308 @@
+import type { OAuthClientJsonWebKey, OAuthClientJsonWebKeySet } from './oauth-client-metadata';
+
+/** RFC 7523 client assertion type used by `private_key_jwt`. */
+export const JWT_BEARER_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
+const PRIVATE_KEY_JWT_MAX_BYTES = 16 * 1024;
+const PRIVATE_KEY_JWT_JWKS_MAX_BYTES = 64 * 1024;
+const PRIVATE_KEY_JWT_JWKS_TIMEOUT_MS = 10_000;
+const PRIVATE_KEY_JWT_CLOCK_SKEW_SECONDS = 60;
+const PRIVATE_KEY_JWT_REPLAY_PREFIX = 'private-key-jwt:';
+const PRIVATE_KEY_JWT_SUPPORTED_ALGORITHMS = new Set(['RS256', 'ES256']);
+
+/** Client metadata needed to authenticate a `private_key_jwt` assertion. */
+export interface PrivateKeyJwtClient {
+  clientId: string;
+  jwksUri?: string;
+  jwks?: OAuthClientJsonWebKeySet;
+  tokenEndpointAuthSigningAlg?: string;
+  tokenEndpointAuthSigningAlgValuesSupported?: string[];
+}
+
+/** Stable internal reason for a rejected `private_key_jwt` assertion. */
+export type PrivateKeyJwtErrorReason =
+  | 'assertion_malformed'
+  | 'algorithm_not_allowed'
+  | 'claims_invalid'
+  | 'jwks_fetch_failed'
+  | 'key_not_found'
+  | 'signature_invalid'
+  | 'assertion_replayed';
+
+export type PrivateKeyJwtResult = { ok: true } | { ok: false; reason: PrivateKeyJwtErrorReason };
+
+interface ParsedClientAssertion {
+  header: Record<string, unknown>;
+  claims: Record<string, unknown>;
+  signingInput: Uint8Array;
+  signature: Uint8Array;
+}
+
+/**
+ * Reads an unverified client identifier solely to locate the client's
+ * registered metadata. Authentication still requires full claim and signature
+ * validation against that metadata.
+ */
+export function readPrivateKeyJwtClientId(assertion: unknown): string | undefined {
+  const parsed = parseClientAssertion(assertion);
+  const issuer = parsed?.claims.iss;
+  return typeof issuer === 'string' && issuer.length > 0 ? issuer : undefined;
+}
+
+/** Validates and consumes a `private_key_jwt` client assertion. */
+export async function authenticatePrivateKeyJwt(input: {
+  assertion: unknown;
+  client: PrivateKeyJwtClient;
+  tokenEndpoint: string;
+  now: number;
+  env: { OAUTH_KV: KVNamespace };
+}): Promise<PrivateKeyJwtResult> {
+  const parsed = parseClientAssertion(input.assertion);
+  if (!parsed) return { ok: false, reason: 'assertion_malformed' };
+
+  const algorithm = readAlgorithm(parsed.header, input.client);
+  if (!algorithm) return { ok: false, reason: 'algorithm_not_allowed' };
+
+  const jwks = input.client.jwks ?? (await fetchPublicJwks(input.client.jwksUri));
+  if (!jwks) return { ok: false, reason: 'jwks_fetch_failed' };
+
+  const jwk = selectVerificationKey(jwks, algorithm, parsed.header.kid);
+  if (!jwk) return { ok: false, reason: 'key_not_found' };
+
+  if (!(await verifySignature(algorithm, jwk, parsed.signingInput, parsed.signature))) {
+    return { ok: false, reason: 'signature_invalid' };
+  }
+
+  const claims = validateClaims(parsed.claims, input.client.clientId, input.tokenEndpoint, input.now);
+  if (!claims) return { ok: false, reason: 'claims_invalid' };
+
+  const replayKey = `${PRIVATE_KEY_JWT_REPLAY_PREFIX}${await sha256Hex(`${input.client.clientId}\n${claims.jti}`)}`;
+  if (await input.env.OAUTH_KV.get(replayKey)) return { ok: false, reason: 'assertion_replayed' };
+
+  // KV is eventually consistent, so this is best-effort across simultaneous
+  // requests in different colos. The short-lived signed assertion still
+  // bounds the race, and the marker remains until the assertion expires.
+  await input.env.OAUTH_KV.put(replayKey, '1', {
+    expirationTtl: Math.max(60, claims.exp - input.now),
+  });
+
+  return { ok: true };
+}
+
+function parseClientAssertion(assertion: unknown): ParsedClientAssertion | undefined {
+  if (typeof assertion !== 'string' || assertion.length === 0 || assertion.length > PRIVATE_KEY_JWT_MAX_BYTES) {
+    return undefined;
+  }
+
+  const parts = assertion.split('.');
+  if (parts.length !== 3 || parts.some((part) => !/^[A-Za-z0-9_-]+$/.test(part))) return undefined;
+
+  try {
+    const [encodedHeader, encodedClaims, encodedSignature] = parts;
+    return {
+      header: parseJsonObject(encodedHeader),
+      claims: parseJsonObject(encodedClaims),
+      signingInput: new TextEncoder().encode(`${encodedHeader}.${encodedClaims}`),
+      signature: base64UrlToBytes(encodedSignature),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function readAlgorithm(header: Record<string, unknown>, client: PrivateKeyJwtClient): string | undefined {
+  // This verifier does not implement any critical JOSE extensions or the
+  // unencoded-payload option from RFC 7797.
+  if (header.crit !== undefined || header.b64 !== undefined) return undefined;
+
+  const algorithm = header.alg;
+  if (typeof algorithm !== 'string' || !PRIVATE_KEY_JWT_SUPPORTED_ALGORITHMS.has(algorithm)) return undefined;
+  if (client.tokenEndpointAuthSigningAlg && algorithm !== client.tokenEndpointAuthSigningAlg) return undefined;
+  if (
+    client.tokenEndpointAuthSigningAlgValuesSupported &&
+    !client.tokenEndpointAuthSigningAlgValuesSupported.includes(algorithm)
+  ) {
+    return undefined;
+  }
+  return algorithm;
+}
+
+function validateClaims(
+  claims: Record<string, unknown>,
+  clientId: string,
+  tokenEndpoint: string,
+  now: number
+): { jti: string; exp: number } | undefined {
+  if (claims.iss !== clientId || claims.sub !== clientId) return undefined;
+
+  const audience = claims.aud;
+  if (
+    !(
+      audience === tokenEndpoint ||
+      (Array.isArray(audience) &&
+        audience.length > 0 &&
+        audience.every((value) => typeof value === 'string') &&
+        audience.includes(tokenEndpoint))
+    )
+  ) {
+    return undefined;
+  }
+
+  const exp = claims.exp;
+  if (typeof exp !== 'number' || !Number.isInteger(exp) || exp + PRIVATE_KEY_JWT_CLOCK_SKEW_SECONDS <= now) {
+    return undefined;
+  }
+
+  const jti = claims.jti;
+  if (typeof jti !== 'string' || jti.length === 0) return undefined;
+
+  if (claims.nbf !== undefined) {
+    const nbf = claims.nbf;
+    if (typeof nbf !== 'number' || !Number.isInteger(nbf) || nbf > now + PRIVATE_KEY_JWT_CLOCK_SKEW_SECONDS) {
+      return undefined;
+    }
+  }
+
+  if (claims.iat !== undefined) {
+    const iat = claims.iat;
+    if (typeof iat !== 'number' || !Number.isInteger(iat) || iat > now + PRIVATE_KEY_JWT_CLOCK_SKEW_SECONDS) {
+      return undefined;
+    }
+  }
+
+  return { jti, exp };
+}
+
+function selectVerificationKey(
+  jwks: OAuthClientJsonWebKeySet,
+  algorithm: string,
+  kid: unknown
+): OAuthClientJsonWebKey | undefined {
+  if (kid !== undefined && (typeof kid !== 'string' || kid.length === 0)) return undefined;
+
+  const keys = jwks.keys.filter((key) => {
+    if (kid && key.kid !== kid) return false;
+    if (key.alg && key.alg !== algorithm) return false;
+    if (key.use && key.use !== 'sig') return false;
+    if (key.key_ops && !key.key_ops.includes('verify')) return false;
+    if (algorithm === 'RS256' && key.kty !== 'RSA') return false;
+    if (algorithm === 'ES256' && key.kty !== 'EC') return false;
+    return true;
+  });
+
+  if (kid) return keys[0];
+  return keys.length === 1 ? keys[0] : undefined;
+}
+
+async function verifySignature(
+  algorithm: string,
+  jwk: OAuthClientJsonWebKey,
+  signingInput: Uint8Array,
+  signature: Uint8Array
+): Promise<boolean> {
+  try {
+    const importAlgorithm: Parameters<SubtleCrypto['importKey']>[2] =
+      algorithm === 'RS256' ? { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' } : { name: 'ECDSA', namedCurve: 'P-256' };
+    const verifyAlgorithm: Parameters<SubtleCrypto['verify']>[0] =
+      algorithm === 'RS256' ? { name: 'RSASSA-PKCS1-v1_5' } : { name: 'ECDSA', hash: 'SHA-256' };
+    const key = await crypto.subtle.importKey('jwk', jwk, importAlgorithm, false, ['verify']);
+    return await crypto.subtle.verify(verifyAlgorithm, key, signature, signingInput);
+  } catch {
+    return false;
+  }
+}
+
+async function fetchPublicJwks(jwksUri: string | undefined): Promise<OAuthClientJsonWebKeySet | undefined> {
+  if (!jwksUri) return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(jwksUri);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'https:' || url.username || url.password || url.hash) return undefined;
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), PRIVATE_KEY_JWT_JWKS_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json', 'Cache-Control': 'no-store' },
+      signal: abortController.signal,
+      cache: 'no-store',
+    });
+    if (!response.ok) return undefined;
+
+    const value = await readJsonWithSizeLimit(response, PRIVATE_KEY_JWT_JWKS_MAX_BYTES);
+    return parsePublicJwks(value);
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function readJsonWithSizeLimit(response: Response, maxBytes: number): Promise<unknown> {
+  const contentLength = response.headers.get('Content-Length');
+  if (contentLength !== null && Number(contentLength) > maxBytes) throw new Error('JWKS response is too large');
+
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('JWKS response body is empty');
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new Error('JWKS response is too large');
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return JSON.parse(new TextDecoder('utf-8', { fatal: true, ignoreBOM: false }).decode(bytes));
+}
+
+function parsePublicJwks(value: unknown): OAuthClientJsonWebKeySet | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const keys = (value as { keys?: unknown }).keys;
+  if (!Array.isArray(keys)) return undefined;
+
+  const privateMembers = new Set(['d', 'p', 'q', 'dp', 'dq', 'qi', 'oth', 'k']);
+  const publicKeys: OAuthClientJsonWebKey[] = [];
+  for (const value of keys) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+    const key = value as Record<string, unknown>;
+    if (typeof key.kty !== 'string' || key.kty.length === 0) return undefined;
+    if (Object.keys(key).some((member) => privateMembers.has(member))) return undefined;
+    publicKeys.push({ ...key } as unknown as OAuthClientJsonWebKey);
+  }
+  return { keys: publicKeys };
+}
+
+function parseJsonObject(encoded: string): Record<string, unknown> {
+  const parsed = JSON.parse(
+    new TextDecoder('utf-8', { fatal: true, ignoreBOM: false }).decode(base64UrlToBytes(encoded))
+  );
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('Expected object');
+  return parsed as Record<string, unknown>;
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '='));
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}


### PR DESCRIPTION
## Summary

- Adds `private_key_jwt` token endpoint authentication for CIMD clients that do not offer `none`.
- Accepts one inline `jwks` or HTTPS `jwks_uri` and verifies `RS256` and `ES256` client assertions.
- Validates `iss`, `sub`, `aud`, `exp`, optional `iat` and `nbf`, and single-use `jti` values. Replay markers are hashed and retained in `OAUTH_KV` until the assertion expires.
- Preserves the existing public-client path when a CIMD document offers both `none` and `private_key_jwt`, including the current ChatGPT metadata shape.
- Advertises `private_key_jwt` and its signing algorithms only when CIMD and `global_fetch_strictly_public` are both enabled.

Closes #264

## Security boundaries

- Rejects mixed client authentication methods, unsupported JOSE extensions, private or symmetric JWK material, and ambiguous key selection.
- Limits client assertions to 16 KB and remote JWKS responses to 64 KB with a 10 second timeout.
- Requires HTTPS for remote JWKS and relies on the existing `global_fetch_strictly_public` requirement to block private-network fetches.
- Uses the same best-effort KV replay model as the existing EMA assertion path; simultaneous requests in different colos remain subject to KV's eventual consistency.

## Validation

- `npm run check`: 9 test files, 867 tests passed
- `npm run build`
- Prettier on all changed source, test, documentation, and changeset files
- `git diff --check`
