### PR TITLE
fix(ema): floor the jti replay marker TTL at KV's minimum

### DIFF
--- a/.changeset/ema-jti-ttl-floor.md
+++ b/.changeset/ema-jti-ttl-floor.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/workers-oauth-provider': patch
+---
+
+Fix uncaught 500 when an ID-JAG assertion has under 60 seconds left. The EMA replay marker
+took its KV TTL straight from the assertion's remaining lifetime, so KV rejected the write
+and the request crashed instead of exchanging. The marker's TTL is now floored at 60s.

--- a/__tests__/oauth-provider.test.ts
+++ b/__tests__/oauth-provider.test.ts
@@ -4571,6 +4571,15 @@ describe('OAuthProvider', () => {
       expect(defaultMetadata.authorization_grant_profiles_supported).toBeUndefined();
     });
 
+    it("should exchange an ID-JAG whose remaining lifetime is under KV's minimum expiration", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const tokenResponse = await exchangeAssertion(await createAssertion({ iat: now, exp: now + 30 }));
+
+      expect(tokenResponse.status).toBe(200);
+      const tokens = await tokenResponse.json<any>();
+      expect(tokens.access_token).toBeDefined();
+    });
+
     it('should exchange a valid ID-JAG for an access token with mapped props', async () => {
       const tokenResponse = await exchangeAssertion(await createAssertion());
       expect(tokenResponse.status).toBe(200);

--- a/src/ema/constants.ts
+++ b/src/ema/constants.ts
@@ -40,6 +40,9 @@ export const EMA_DEFAULT_MAX_ASSERTION_LIFETIME_SECONDS = 5 * 60;
  */
 export const EMA_JWKS_FORCE_REFRESH_COOLDOWN_SECONDS = 30;
 
+/** Floor for the `jti` replay marker's KV TTL; KV rejects a sub-60s expiration. */
+export const EMA_JTI_MIN_TTL_SECONDS = 60;
+
 /** Default JWT signing algorithm assumed for a trusted issuer. */
 export const EMA_DEFAULT_JWT_ALGORITHM = 'RS256';
 

--- a/src/ema/jti.ts
+++ b/src/ema/jti.ts
@@ -8,6 +8,7 @@
  * the practical attack window.
  */
 
+import { EMA_JTI_MIN_TTL_SECONDS } from './constants';
 import { err, ok } from './result';
 import type { EmaJtiStore } from './types';
 import { sha256Hex } from './util';
@@ -19,7 +20,9 @@ const EMA_JTI_KV_PREFIX = 'enterprise-jti:';
 export function createKvJtiStore(): EmaJtiStore {
   return {
     async markUsed({ issuer, jti, exp, now, env }) {
-      const ttl = Math.max(1, exp - now);
+      // KV rejects a sub-60s expirationTtl and an assertion in its last minute is
+      // still valid; a marker outliving its assertion only tightens replay detection.
+      const ttl = Math.max(EMA_JTI_MIN_TTL_SECONDS, exp - now);
       const jtiHash = await sha256Hex(`${issuer}\n${jti}`);
       const key = `${EMA_JTI_KV_PREFIX}${jtiHash}`;
       const existing = await env.OAUTH_KV.get(key);


### PR DESCRIPTION
## Problem

`createKvJtiStore` derives the replay marker's KV TTL from the assertion's remaining lifetime (`Math.max(1, exp - now)`). An ID-JAG with under 60 seconds left passes claim validation, then the marker write is rejected and the exception escapes `fetch()`:

```text
KV PUT failed: 400 Invalid expiration_ttl of 30. Expiration TTL's must be at least 60 seconds.
```

Same class as #233. #234 reached the EMA path through the access-token TTL, which a near-expiry assertion does not shrink; the marker write derives its own.

## Change

Floor the marker's TTL at 60s (`EMA_JTI_MIN_TTL_SECONDS`) rather than rejecting the assertion, mirroring the `saveGrantWithTTL` clamp. A marker outliving its assertion only tightens replay detection.

## Testing

New case in the EMA suite: an assertion 30 seconds from expiry now exchanges instead of throwing.

Mutation-checked: reverting only `src/ema/jti.ts` makes it fail. `npm run check`: tsc clean, 853/853 tests. `npm run prettier` clean.
